### PR TITLE
Implement photo upload workflow

### DIFF
--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createCase } from '@/lib/caseStore'
+import fs from 'fs'
+import path from 'path'
+
+export async function POST(req: NextRequest) {
+  const form = await req.formData()
+  const file = form.get('photo') as File | null
+  if (!file) {
+    return NextResponse.json({ error: 'No file' }, { status: 400 })
+  }
+  const bytes = await file.arrayBuffer()
+  const buffer = Buffer.from(bytes)
+  const uploadDir = path.join(process.cwd(), 'public', 'uploads')
+  fs.mkdirSync(uploadDir, { recursive: true })
+  const ext = path.extname(file.name || 'jpg') || '.jpg'
+  const filename = `${crypto.randomUUID()}${ext}`
+  fs.writeFileSync(path.join(uploadDir, filename), buffer)
+  const newCase = createCase(`/uploads/${filename}`)
+  return NextResponse.json({ caseId: newCase.id })
+}

--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -1,0 +1,17 @@
+import Image from 'next/image'
+import { getCase } from '@/lib/caseStore'
+import { notFound } from 'next/navigation'
+
+export const dynamic = 'force-dynamic'
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function CasePage({ params }: any) {
+  const c = getCase(params.id)
+  if (!c) return notFound()
+  return (
+    <div className="p-8 flex flex-col gap-4">
+      <h1 className="text-xl font-semibold">Case {c.id}</h1>
+      <Image src={c.photo} alt="uploaded" width={600} height={400} />
+      <p className="text-sm text-gray-500">Created {new Date(c.createdAt).toLocaleString()}</p>
+    </div>
+  )
+}

--- a/src/app/cases/page.tsx
+++ b/src/app/cases/page.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+import Image from 'next/image'
+import { getCases } from '@/lib/caseStore'
+
+export const dynamic = 'force-dynamic'
+
+export default function CasesPage() {
+  const cases = getCases()
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">Cases</h1>
+      <ul className="grid gap-4">
+        {cases.map((c) => (
+          <li key={c.id} className="border p-2">
+            <Link href={`/cases/${c.id}`} className="flex items-center gap-4">
+              <Image src={c.photo} alt="" width={80} height={60} />
+              <span>Case {c.id}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,11 @@
-import Image from "next/image";
+import Link from 'next/link'
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
-  );
+    <main className="p-8 flex flex-col gap-4">
+      <h1 className="text-2xl font-bold mb-4">Photo To Citation</h1>
+      <Link href="/upload" className="text-blue-600 underline">Upload a Photo</Link>
+      <Link href="/cases" className="text-blue-600 underline">View Cases</Link>
+    </main>
+  )
 }

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function UploadPage() {
+  const [file, setFile] = useState<File | null>(null)
+  const router = useRouter()
+
+  return (
+    <form
+      className="flex flex-col gap-4 p-8"
+      onSubmit={async (e) => {
+        e.preventDefault()
+        if (!file) return
+        const formData = new FormData()
+        formData.append('photo', file)
+        const res = await fetch('/api/upload', {
+          method: 'POST',
+          body: formData,
+        })
+        if (res.ok) {
+          const data = await res.json()
+          router.push(`/cases/${data.caseId}`)
+        }
+      }}
+    >
+      <input
+        type="file"
+        accept="image/*"
+        onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+      />
+      <button
+        type="submit"
+        className="rounded border bg-black text-white px-4 py-2"
+      >
+        Upload Photo
+      </button>
+    </form>
+  )
+}

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -1,0 +1,46 @@
+import fs from 'fs'
+import path from 'path'
+
+export interface Case {
+  id: string
+  photo: string
+  createdAt: string
+}
+
+const dataFile = path.join(process.cwd(), 'data', 'cases.json')
+
+function loadCases(): Case[] {
+  if (!fs.existsSync(dataFile)) {
+    return []
+  }
+  try {
+    return JSON.parse(fs.readFileSync(dataFile, 'utf8')) as Case[]
+  } catch {
+    return []
+  }
+}
+
+function saveCases(cases: Case[]) {
+  fs.mkdirSync(path.dirname(dataFile), { recursive: true })
+  fs.writeFileSync(dataFile, JSON.stringify(cases, null, 2))
+}
+
+export function getCases(): Case[] {
+  return loadCases()
+}
+
+export function getCase(id: string): Case | undefined {
+  return loadCases().find((c) => c.id === id)
+}
+
+export function createCase(photo: string): Case {
+  const cases = loadCases()
+  const newCase: Case = {
+    id: Date.now().toString(),
+    photo,
+    createdAt: new Date().toISOString(),
+  }
+  cases.push(newCase)
+  saveCases(cases)
+  return newCase
+}


### PR DESCRIPTION
## Summary
- add case data store
- add API route to upload photos and create cases
- add upload page with client-side form
- add pages to view all cases and individual case
- simplify home page to link to upload and cases

## Testing
- `npm run lint`
- `npm run build` *(fails after build traces or truncated, but compiled)*

------
https://chatgpt.com/codex/tasks/task_e_68477732050c832b9d8e47e25e9d6bc7