### PR TITLE
Implement async OpenAI analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ a JSON response describing the violation. The JSON follows a schema that
 includes the violation type, location clues, and vehicle details such as make,
 model, color and license plate information.
 
+When a user uploads a photo, the API stores the case immediately and then
+triggers OpenAI analysis in the background. The resulting JSON is persisted
+alongside the case record once the analysis completes, so uploads are never
+blocked waiting for OpenAI.
+
 ## Folder Structure
 
 ```text

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createCase } from '@/lib/caseStore'
+import { analyzeCaseInBackground } from '@/lib/caseAnalysis'
 import fs from 'fs'
 import path from 'path'
+import crypto from 'crypto'
 
 export async function POST(req: NextRequest) {
   const form = await req.formData()
@@ -17,5 +19,6 @@ export async function POST(req: NextRequest) {
   const filename = `${crypto.randomUUID()}${ext}`
   fs.writeFileSync(path.join(uploadDir, filename), buffer)
   const newCase = createCase(`/uploads/${filename}`)
+  analyzeCaseInBackground(newCase)
   return NextResponse.json({ caseId: newCase.id })
 }

--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -12,6 +12,13 @@ export default function CasePage({ params }: any) {
       <h1 className="text-xl font-semibold">Case {c.id}</h1>
       <Image src={c.photo} alt="uploaded" width={600} height={400} />
       <p className="text-sm text-gray-500">Created {new Date(c.createdAt).toLocaleString()}</p>
+      {c.analysis ? (
+        <pre className="bg-gray-100 p-4 rounded text-sm overflow-auto">
+          {JSON.stringify(c.analysis, null, 2)}
+        </pre>
+      ) : (
+        <p className="text-sm text-gray-500">Analyzing photo...</p>
+      )}
     </div>
   )
 }

--- a/src/app/cases/page.tsx
+++ b/src/app/cases/page.tsx
@@ -14,7 +14,10 @@ export default function CasesPage() {
           <li key={c.id} className="border p-2">
             <Link href={`/cases/${c.id}`} className="flex items-center gap-4">
               <Image src={c.photo} alt="" width={80} height={60} />
-              <span>Case {c.id}</span>
+              <span>
+                Case {c.id}
+                {c.analysis ? '' : ' (processing...)'}
+              </span>
             </Link>
           </li>
         ))}

--- a/src/lib/caseAnalysis.ts
+++ b/src/lib/caseAnalysis.ts
@@ -1,0 +1,15 @@
+import { analyzeViolation } from './openai'
+import { Case, updateCase } from './caseStore'
+
+export async function analyzeCase(caseData: Case): Promise<void> {
+  try {
+    const result = await analyzeViolation(`${process.env.NEXT_PUBLIC_BASE_URL || ''}${caseData.photo}`)
+    updateCase(caseData.id, { analysis: result })
+  } catch (err) {
+    console.error('Failed to analyze case', caseData.id, err)
+  }
+}
+
+export function analyzeCaseInBackground(caseData: Case): void {
+  analyzeCase(caseData).catch((err) => console.error(err))
+}

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -1,10 +1,13 @@
 import fs from 'fs'
 import path from 'path'
 
+import { ViolationReport } from './openai'
+
 export interface Case {
   id: string
   photo: string
   createdAt: string
+  analysis?: ViolationReport | null
 }
 
 const dataFile = process.env.CASE_STORE_FILE
@@ -41,8 +44,18 @@ export function createCase(photo: string): Case {
     id: Date.now().toString(),
     photo,
     createdAt: new Date().toISOString(),
+    analysis: null,
   }
   cases.push(newCase)
   saveCases(cases)
   return newCase
+}
+
+export function updateCase(id: string, updates: Partial<Case>): Case | undefined {
+  const cases = loadCases()
+  const idx = cases.findIndex((c) => c.id === id)
+  if (idx === -1) return undefined
+  cases[idx] = { ...cases[idx], ...updates }
+  saveCases(cases)
+  return cases[idx]
 }

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -21,10 +21,12 @@ afterEach(() => {
 
 describe('caseStore', () => {
   it('creates and retrieves a case', () => {
-    const { createCase, getCase, getCases } = caseStore
+    const { createCase, getCase, getCases, updateCase } = caseStore
     const c = createCase('/foo.jpg')
     expect(c.photo).toBe('/foo.jpg')
     expect(getCase(c.id)).toEqual(c)
     expect(getCases()).toHaveLength(1)
+    const updated = updateCase(c.id, { analysis: { violationType: 'foo', details: 'bar', vehicle: {} } })
+    expect(updated?.analysis?.violationType).toBe('foo')
   })
 })


### PR DESCRIPTION
## Summary
- store violation analysis with each case
- analyze photos asynchronously on upload
- show case processing status in UI
- update tests for new case fields

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68478d4960ec832ba6868e4a1231d4ec