### PR TITLE
Add reverse geocoding background task

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ blocked waiting for OpenAI.
 If the uploaded image contains GPS EXIF data, the latitude and longitude are
 extracted and saved with the case information.
 
+If a `GOOGLE_MAPS_API_KEY` is provided in `.env`, the app also performs a
+reverse geocode lookup for each case in the background. The resulting street
+address and closest intersection are stored with the case once the lookup
+completes.
+
 ## Folder Structure
 
 ```text

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createCase } from '@/lib/caseStore'
 import { analyzeCaseInBackground } from '@/lib/caseAnalysis'
+import { fetchCaseLocationInBackground } from '@/lib/caseLocation'
 import fs from 'fs'
 import path from 'path'
 import crypto from 'crypto'
@@ -38,5 +39,6 @@ export async function POST(req: NextRequest) {
   fs.writeFileSync(path.join(uploadDir, filename), buffer)
   const newCase = createCase(`/uploads/${filename}`, gps)
   analyzeCaseInBackground(newCase)
+  fetchCaseLocationInBackground(newCase)
   return NextResponse.json({ caseId: newCase.id })
 }

--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -15,6 +15,12 @@ export default function CasePage({ params }: any) {
       {c.gps ? (
         <p className="text-sm text-gray-500">GPS: {c.gps.lat}, {c.gps.lon}</p>
       ) : null}
+      {c.streetAddress ? (
+        <p className="text-sm text-gray-500">Address: {c.streetAddress}</p>
+      ) : null}
+      {c.intersection ? (
+        <p className="text-sm text-gray-500">Intersection: {c.intersection}</p>
+      ) : null}
       {c.analysis ? (
         <pre className="bg-gray-100 p-4 rounded text-sm overflow-auto">
           {JSON.stringify(c.analysis, null, 2)}

--- a/src/lib/caseLocation.ts
+++ b/src/lib/caseLocation.ts
@@ -1,0 +1,19 @@
+import { Case, updateCase } from './caseStore'
+import { reverseGeocode, intersectionLookup } from './geocode'
+
+export async function fetchCaseLocation(caseData: Case): Promise<void> {
+  if (!caseData.gps) return
+  try {
+    const [address, intersection] = await Promise.all([
+      reverseGeocode(caseData.gps),
+      intersectionLookup(caseData.gps),
+    ])
+    updateCase(caseData.id, { streetAddress: address, intersection })
+  } catch (err) {
+    console.error('Failed to fetch location data', err)
+  }
+}
+
+export function fetchCaseLocationInBackground(caseData: Case): void {
+  fetchCaseLocation(caseData).catch((err) => console.error(err))
+}

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -11,6 +11,8 @@ export interface Case {
     lat: number
     lon: number
   } | null
+  streetAddress?: string | null
+  intersection?: string | null
   analysis?: ViolationReport | null
 }
 
@@ -49,6 +51,8 @@ export function createCase(photo: string, gps: Case['gps'] = null): Case {
     photo,
     createdAt: new Date().toISOString(),
     gps,
+    streetAddress: null,
+    intersection: null,
     analysis: null,
   }
   cases.push(newCase)

--- a/src/lib/geocode.ts
+++ b/src/lib/geocode.ts
@@ -1,0 +1,25 @@
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+export interface Coordinates {
+  lat: number
+  lon: number
+}
+
+async function fetchGeocode(params: Record<string, string>): Promise<any> {
+  const query = new URLSearchParams({ key: process.env.GOOGLE_MAPS_API_KEY || '', ...params })
+  const res = await fetch(`https://maps.googleapis.com/maps/api/geocode/json?${query}`)
+  if (!res.ok) throw new Error(`Geocode request failed: ${res.status}`)
+  return res.json()
+}
+
+export async function reverseGeocode({ lat, lon }: Coordinates): Promise<string | null> {
+  const data = await fetchGeocode({ latlng: `${lat},${lon}`, result_type: 'street_address' })
+  return data.results?.[0]?.formatted_address ?? null
+}
+
+export async function intersectionLookup({ lat, lon }: Coordinates): Promise<string | null> {
+  const data = await fetchGeocode({ latlng: `${lat},${lon}`, result_type: 'intersection' })
+  return data.results?.[0]?.formatted_address ?? null
+}

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -25,6 +25,8 @@ describe('caseStore', () => {
     const c = createCase('/foo.jpg', { lat: 10, lon: 20 })
     expect(c.photo).toBe('/foo.jpg')
     expect(c.gps).toEqual({ lat: 10, lon: 20 })
+    expect(c.streetAddress).toBeNull()
+    expect(c.intersection).toBeNull()
     expect(getCase(c.id)).toEqual(c)
     expect(getCases()).toHaveLength(1)
     const updated = updateCase(c.id, { analysis: { violationType: 'foo', details: 'bar', vehicle: {} } })


### PR DESCRIPTION
## Summary
- extend Case model with street address and intersection fields
- create Google Maps geocoding helpers
- update API route to fire location lookup in the background
- display address and intersection on the case page
- document Google Maps API usage in README

## Testing
- `npm test`
- `npm run lint` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_684796f476bc832b98cd6556074f2770