### PR TITLE
Fix dynamic route params and OpenAI image handling

### DIFF
--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -4,8 +4,10 @@ import { notFound } from 'next/navigation'
 
 export const dynamic = 'force-dynamic'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function CasePage({ params }: any) {
-  const c = getCase(params.id)
+export default async function CasePage({ params }: any) {
+  // Await params for compatibility with async dynamic routes
+  const { id } = await Promise.resolve(params)
+  const c = getCase(id)
   if (!c) return notFound()
   return (
     <div className="p-8 flex flex-col gap-4">

--- a/src/lib/caseAnalysis.ts
+++ b/src/lib/caseAnalysis.ts
@@ -1,9 +1,16 @@
 import { analyzeViolation } from './openai'
 import { Case, updateCase } from './caseStore'
+import fs from 'fs'
+import path from 'path'
 
 export async function analyzeCase(caseData: Case): Promise<void> {
   try {
-    const result = await analyzeViolation(`${process.env.NEXT_PUBLIC_BASE_URL || ''}${caseData.photo}`)
+    const filePath = path.join(process.cwd(), 'public', caseData.photo.replace(/^\/+/, ''))
+    const buffer = fs.readFileSync(filePath)
+    const ext = path.extname(filePath).toLowerCase()
+    const mime = ext === '.png' ? 'image/png' : ext === '.webp' ? 'image/webp' : 'image/jpeg'
+    const dataUrl = `data:${mime};base64,${buffer.toString('base64')}`
+    const result = await analyzeViolation(dataUrl)
     updateCase(caseData.id, { analysis: result })
   } catch (err) {
     console.error('Failed to analyze case', caseData.id, err)


### PR DESCRIPTION
## Summary
- handle async params in dynamic case page
- convert uploaded image to data URL for OpenAI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684821fab2c8832b8884fccc89d8183b