### PR TITLE
Add site-wide navigation bar

### DIFF
--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function NavBar() {
+  return (
+    <nav className="bg-gray-900 text-white py-4 px-8 flex items-center justify-between">
+      <Link href="/" className="text-lg font-semibold hover:text-gray-300">Photo To Citation</Link>
+      <div className="flex gap-6 text-sm">
+        <Link href="/upload" className="hover:text-gray-300">Upload</Link>
+        <Link href="/cases" className="hover:text-gray-300">Cases</Link>
+      </div>
+    </nav>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import NavBar from "./components/NavBar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <NavBar />
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- create a `NavBar` component with links to home, upload and cases
- include the navigation in the root layout so it's visible on every page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68482899df00832bb06ac11a88ec8124