### PR TITLE
Fix background job worker imports

### DIFF
--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -5,7 +5,8 @@ import { notFound } from 'next/navigation'
 export const dynamic = 'force-dynamic'
 
 export default async function CasePage({ params }: { params: { id: string } }) {
-  const c = getCase(params.id)
+  const { id } = await params
+  const c = getCase(id)
   if (!c) return notFound()
   return (
     <div className="p-8 flex flex-col gap-4">

--- a/src/jobs/analyzeCase.ts
+++ b/src/jobs/analyzeCase.ts
@@ -1,4 +1,4 @@
-import { analyzeCase } from '../lib/caseAnalysis'
+import { analyzeCase } from '../lib/caseAnalysis.ts'
 import { parentPort, workerData } from 'worker_threads'
 
 (async () => {

--- a/src/jobs/fetchCaseLocation.ts
+++ b/src/jobs/fetchCaseLocation.ts
@@ -1,4 +1,4 @@
-import { fetchCaseLocation } from '../lib/caseLocation'
+import { fetchCaseLocation } from '../lib/caseLocation.ts'
 import { parentPort, workerData } from 'worker_threads'
 
 (async () => {

--- a/src/lib/jobScheduler.ts
+++ b/src/lib/jobScheduler.ts
@@ -1,21 +1,26 @@
-import Bree from 'bree'
+import { Worker } from 'worker_threads'
 import path from 'path'
 
-export const bree = new Bree({
-  root: path.join(process.cwd(), 'src', 'jobs'),
-  defaultExtension: 'ts',
-  workerOptions: {
-    execArgv: ['-r', 'ts-node/register']
-  }
-})
+const jobFiles: Record<string, string> = {
+  analyzeCase: path.join(process.cwd(), 'src', 'jobs', 'analyzeCase.ts'),
+  fetchCaseLocation: path.join(
+    process.cwd(),
+    'src',
+    'jobs',
+    'fetchCaseLocation.ts'
+  ),
+}
 
-export function runJob(name: string, data: unknown) {
-  bree.add({
-    name,
-    path: path.join(process.cwd(), 'src', 'jobs', `${name}.ts`),
-    worker: {
-      workerData: data
-    }
+export function runJob(name: string, data: unknown): void {
+  const file = jobFiles[name]
+  if (!file) throw new Error(`Job "${name}" does not exist`)
+
+  const worker = new Worker(file, {
+    workerData: data,
+    execArgv: ['--loader', 'ts-node/esm'],
+    type: 'module',
   })
-  void bree.run(name)
+  worker.on('error', (err) => {
+    console.error(`${name} worker failed`, err)
+  })
 }


### PR DESCRIPTION
## Summary
- reference TypeScript modules explicitly in workers
- execute worker threads using ts-node's ESM loader
- run workers in ESM mode

## Testing
- `npx vitest run`
- `npm run dev` *(fails: ENETUNREACH while downloading next.js swc binaries)*

------
https://chatgpt.com/codex/tasks/task_e_68482561261c832bbcfa9a46b9f25822