### PR TITLE
Add auto-upload with preview support

### DIFF
--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import { getCase } from '@/lib/caseStore'
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const c = getCase(params.id)
+  if (!c) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  return NextResponse.json(c)
+}

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -10,6 +10,7 @@ import ExifParser from 'exif-parser'
 export async function POST(req: NextRequest) {
   const form = await req.formData()
   const file = form.get('photo') as File | null
+  const clientId = form.get('caseId') as string | null
   if (!file) {
     return NextResponse.json({ error: 'No file' }, { status: 400 })
   }
@@ -37,7 +38,7 @@ export async function POST(req: NextRequest) {
   const ext = path.extname(file.name || 'jpg') || '.jpg'
   const filename = `${crypto.randomUUID()}${ext}`
   fs.writeFileSync(path.join(uploadDir, filename), buffer)
-  const newCase = createCase(`/uploads/${filename}`, gps)
+  const newCase = createCase(`/uploads/${filename}`, gps, clientId || undefined)
   analyzeCaseInBackground(newCase)
   fetchCaseLocationInBackground(newCase)
   return NextResponse.json({ caseId: newCase.id })

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -1,0 +1,71 @@
+'use client'
+import Image from 'next/image'
+import { useEffect, useState } from 'react'
+import type { Case } from '@/lib/caseStore'
+
+export default function ClientCasePage({
+  initialCase,
+  caseId,
+}: {
+  initialCase: Case | null
+  caseId: string
+}) {
+  const [caseData, setCaseData] = useState<Case | null>(initialCase)
+  const [preview, setPreview] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!caseData) {
+      const stored = sessionStorage.getItem(`preview-${caseId}`)
+      if (stored) setPreview(stored)
+      const interval = setInterval(async () => {
+        const res = await fetch(`/api/cases/${caseId}`)
+        if (res.ok) {
+          const data = (await res.json()) as Case
+          setCaseData(data)
+          sessionStorage.removeItem(`preview-${caseId}`)
+          clearInterval(interval)
+        }
+      }, 1000)
+      return () => clearInterval(interval)
+    }
+  }, [caseData, caseId])
+
+  if (!caseData) {
+    return (
+      <div className="p-8 flex flex-col gap-4">
+        <h1 className="text-xl font-semibold">Uploading...</h1>
+        {preview ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={preview} alt="preview" className="max-w-full" />
+        ) : null}
+        <p className="text-sm text-gray-500">Uploading photo...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-8 flex flex-col gap-4">
+      <h1 className="text-xl font-semibold">Case {caseData.id}</h1>
+      <Image src={caseData.photo} alt="uploaded" width={600} height={400} />
+      <p className="text-sm text-gray-500">
+        Created {new Date(caseData.createdAt).toLocaleString()}
+      </p>
+      {caseData.gps ? (
+        <p className="text-sm text-gray-500">GPS: {caseData.gps.lat}, {caseData.gps.lon}</p>
+      ) : null}
+      {caseData.streetAddress ? (
+        <p className="text-sm text-gray-500">Address: {caseData.streetAddress}</p>
+      ) : null}
+      {caseData.intersection ? (
+        <p className="text-sm text-gray-500">Intersection: {caseData.intersection}</p>
+      ) : null}
+      {caseData.analysis ? (
+        <pre className="bg-gray-100 p-4 rounded text-sm overflow-auto">
+          {JSON.stringify(caseData.analysis, null, 2)}
+        </pre>
+      ) : (
+        <p className="text-sm text-gray-500">Analyzing photo...</p>
+      )}
+    </div>
+  )
+}

--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -1,34 +1,10 @@
-import Image from 'next/image'
 import { getCase } from '@/lib/caseStore'
-import { notFound } from 'next/navigation'
+import ClientCasePage from './ClientCasePage'
 
 export const dynamic = 'force-dynamic'
 
 export default async function CasePage({ params }: { params: { id: string } }) {
-  const { id } = await params
+  const { id } = params
   const c = getCase(id)
-  if (!c) return notFound()
-  return (
-    <div className="p-8 flex flex-col gap-4">
-      <h1 className="text-xl font-semibold">Case {c.id}</h1>
-      <Image src={c.photo} alt="uploaded" width={600} height={400} />
-      <p className="text-sm text-gray-500">Created {new Date(c.createdAt).toLocaleString()}</p>
-      {c.gps ? (
-        <p className="text-sm text-gray-500">GPS: {c.gps.lat}, {c.gps.lon}</p>
-      ) : null}
-      {c.streetAddress ? (
-        <p className="text-sm text-gray-500">Address: {c.streetAddress}</p>
-      ) : null}
-      {c.intersection ? (
-        <p className="text-sm text-gray-500">Intersection: {c.intersection}</p>
-      ) : null}
-      {c.analysis ? (
-        <pre className="bg-gray-100 p-4 rounded text-sm overflow-auto">
-          {JSON.stringify(c.analysis, null, 2)}
-        </pre>
-      ) : (
-        <p className="text-sm text-gray-500">Analyzing photo...</p>
-      )}
-    </div>
-  )
+  return <ClientCasePage caseId={id} initialCase={c ?? null} />
 }

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,41 +1,28 @@
 'use client'
 
-import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 
 export default function UploadPage() {
-  const [file, setFile] = useState<File | null>(null)
   const router = useRouter()
 
+  async function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const id = Date.now().toString()
+    const preview = URL.createObjectURL(file)
+    sessionStorage.setItem(`preview-${id}`, preview)
+    const formData = new FormData()
+    formData.append('photo', file)
+    formData.append('caseId', id)
+    fetch('/api/upload', { method: 'POST', body: formData }).then(() => {
+      sessionStorage.removeItem(`preview-${id}`)
+    })
+    router.push(`/cases/${id}`)
+  }
+
   return (
-    <form
-      className="flex flex-col gap-4 p-8"
-      onSubmit={async (e) => {
-        e.preventDefault()
-        if (!file) return
-        const formData = new FormData()
-        formData.append('photo', file)
-        const res = await fetch('/api/upload', {
-          method: 'POST',
-          body: formData,
-        })
-        if (res.ok) {
-          const data = await res.json()
-          router.push(`/cases/${data.caseId}`)
-        }
-      }}
-    >
-      <input
-        type="file"
-        accept="image/*"
-        onChange={(e) => setFile(e.target.files?.[0] ?? null)}
-      />
-      <button
-        type="submit"
-        className="rounded border bg-black text-white px-4 py-2"
-      >
-        Upload Photo
-      </button>
-    </form>
+    <div className="p-8">
+      <input type="file" accept="image/*" onChange={handleChange} />
+    </div>
   )
 }

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -44,10 +44,14 @@ export function getCase(id: string): Case | undefined {
   return loadCases().find((c) => c.id === id)
 }
 
-export function createCase(photo: string, gps: Case['gps'] = null): Case {
+export function createCase(
+  photo: string,
+  gps: Case['gps'] = null,
+  id?: string
+): Case {
   const cases = loadCases()
   const newCase: Case = {
-    id: Date.now().toString(),
+    id: id ?? Date.now().toString(),
     photo,
     createdAt: new Date().toISOString(),
     gps,

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -32,4 +32,11 @@ describe('caseStore', () => {
     const updated = updateCase(c.id, { analysis: { violationType: 'foo', details: 'bar', vehicle: {} } })
     expect(updated?.analysis?.violationType).toBe('foo')
   })
+
+  it('allows providing a custom id', () => {
+    const { createCase, getCase } = caseStore
+    const c = createCase('/bar.jpg', null, 'custom-id')
+    expect(c.id).toBe('custom-id')
+    expect(getCase('custom-id')).toEqual(c)
+  })
 })


### PR DESCRIPTION
## Summary
- trigger upload immediately when photo is selected
- store preview locally and navigate to case page right away
- show preview while the backend finishes creating the case
- allow specifying a custom case id when creating a case
- expose case data via `/api/cases/[id]`
- add tests for new case id option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68482a7e8338832b8034991a5588f002