### PR TITLE
Fix Next.js params handling in case route

### DIFF
--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -5,7 +5,8 @@ export async function GET(
   req: Request,
   { params }: { params: { id: string } }
 ) {
-  const c = getCase(params.id)
+  const { id } = await params
+  const c = getCase(id)
   if (!c) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }


### PR DESCRIPTION
## Summary
- await `params` before using `id` in `GET` handler for `/api/cases/[id]`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68482e8d82f4832ba3ca673c83b72d00