### PR TITLE
Fix ts-node worker resolution

### DIFF
--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -1,12 +1,12 @@
-import { NextResponse } from "next/server";
 import { getCase } from "@/lib/caseStore";
+import { NextResponse } from "next/server";
 
 export async function GET(
   req: Request,
   { params }: { params: { id: string } },
 ) {
-  const { id } = await params
-  const c = getCase(id)
+  const { id } = await params;
+  const c = getCase(id);
   if (!c) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -1,7 +1,7 @@
 "use client";
+import type { Case } from "@/lib/caseStore";
 import Image from "next/image";
 import { useEffect, useState } from "react";
-import type { Case } from "@/lib/caseStore";
 
 export default function ClientCasePage({
   initialCase,

--- a/src/jobs/analyzeCase.ts
+++ b/src/jobs/analyzeCase.ts
@@ -1,9 +1,10 @@
 import { parentPort, workerData } from "node:worker_threads";
 import { analyzeCase } from "../lib/caseAnalysis";
+import type { Case } from "../lib/caseStore";
 
 (async () => {
-  const { jobData } = workerData as { jobData: unknown };
-  await analyzeCase(jobData as any);
+  const { jobData } = workerData as { jobData: Case };
+  await analyzeCase(jobData);
   if (parentPort) parentPort.postMessage("done");
 })().catch((err) => {
   console.error("analyzeCase job failed", err);

--- a/src/jobs/fetchCaseLocation.ts
+++ b/src/jobs/fetchCaseLocation.ts
@@ -1,9 +1,10 @@
 import { parentPort, workerData } from "node:worker_threads";
 import { fetchCaseLocation } from "../lib/caseLocation";
+import type { Case } from "../lib/caseStore";
 
 (async () => {
-  const { jobData } = workerData as { jobData: unknown };
-  await fetchCaseLocation(jobData as any);
+  const { jobData } = workerData as { jobData: Case };
+  await fetchCaseLocation(jobData);
   if (parentPort) parentPort.postMessage("done");
 })().catch((err) => {
   console.error("fetchCaseLocation job failed", err);

--- a/src/jobs/workerWrapper.js
+++ b/src/jobs/workerWrapper.js
@@ -1,3 +1,6 @@
-const { workerData, parentPort } = require("worker_threads");
-require("ts-node/register");
+const { workerData, parentPort } = require("node:worker_threads");
+require("ts-node").register({
+  transpileOnly: true,
+  compilerOptions: { module: "commonjs" },
+});
 require(workerData.path);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "allowImportingTsExtensions": true,
     "plugins": [
       {
         "name": "next"
@@ -20,6 +21,12 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
+    }
+  },
+  "ts-node": {
+    "compilerOptions": {
+      "module": "CommonJS",
+      "moduleResolution": "node"
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- allow ts-node to load .ts paths by configuring ts-node compiler options
- register ts-node with custom options in worker wrapper
- tighten imports in API route and client page
- type worker job data

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684830207840832bb69f0518c76cdb25