### PR TITLE
Add Google map previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ reverse geocode lookup for each case in the background. The resulting street
 address and closest intersection are stored with the case once the lookup
 completes.
 
+To show map previews in the UI, set `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` to the
+same value so the Google Static Maps API can be used on the client.
+
 ## Folder Structure
 
 ```text

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "maps.googleapis.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -1,12 +1,12 @@
-import { NextResponse } from "next/server";
 import { getCase } from "@/lib/caseStore";
+import { NextResponse } from "next/server";
 
 export async function GET(
   req: Request,
   { params }: { params: { id: string } },
 ) {
-  const { id } = await params
-  const c = getCase(id)
+  const { id } = await params;
+  const c = getCase(id);
   if (!c) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -1,7 +1,8 @@
 "use client";
+import type { Case } from "@/lib/caseStore";
+import { getStaticMapUrl } from "@/lib/maps";
 import Image from "next/image";
 import { useEffect, useState } from "react";
-import type { Case } from "@/lib/caseStore";
 
 export default function ClientCasePage({
   initialCase,
@@ -47,6 +48,14 @@ export default function ClientCasePage({
     <div className="p-8 flex flex-col gap-4">
       <h1 className="text-xl font-semibold">Case {caseData.id}</h1>
       <Image src={caseData.photo} alt="uploaded" width={600} height={400} />
+      {caseData.gps ? (
+        <Image
+          src={getStaticMapUrl(caseData.gps, { width: 600, height: 400 })}
+          alt="map"
+          width={600}
+          height={400}
+        />
+      ) : null}
       <p className="text-sm text-gray-500">
         Created {new Date(caseData.createdAt).toLocaleString()}
       </p>

--- a/src/app/cases/page.tsx
+++ b/src/app/cases/page.tsx
@@ -1,4 +1,5 @@
 import { getCases } from "@/lib/caseStore";
+import { getStaticMapUrl } from "@/lib/maps";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -14,6 +15,14 @@ export default function CasesPage() {
           <li key={c.id} className="border p-2">
             <Link href={`/cases/${c.id}`} className="flex items-center gap-4">
               <Image src={c.photo} alt="" width={80} height={60} />
+              {c.gps ? (
+                <Image
+                  src={getStaticMapUrl(c.gps, { width: 80, height: 60 })}
+                  alt="map"
+                  width={80}
+                  height={60}
+                />
+              ) : null}
               <span>
                 Case {c.id}
                 {c.analysis ? "" : " (processing...)"}

--- a/src/jobs/analyzeCase.ts
+++ b/src/jobs/analyzeCase.ts
@@ -1,9 +1,10 @@
 import { parentPort, workerData } from "node:worker_threads";
 import { analyzeCase } from "../lib/caseAnalysis";
+import type { Case } from "../lib/caseStore";
 
 (async () => {
   const { jobData } = workerData as { jobData: unknown };
-  await analyzeCase(jobData as any);
+  await analyzeCase(jobData as Case);
   if (parentPort) parentPort.postMessage("done");
 })().catch((err) => {
   console.error("analyzeCase job failed", err);

--- a/src/jobs/fetchCaseLocation.ts
+++ b/src/jobs/fetchCaseLocation.ts
@@ -1,9 +1,10 @@
 import { parentPort, workerData } from "node:worker_threads";
 import { fetchCaseLocation } from "../lib/caseLocation";
+import type { Case } from "../lib/caseStore";
 
 (async () => {
   const { jobData } = workerData as { jobData: unknown };
-  await fetchCaseLocation(jobData as any);
+  await fetchCaseLocation(jobData as Case);
   if (parentPort) parentPort.postMessage("done");
 })().catch((err) => {
   console.error("fetchCaseLocation job failed", err);

--- a/src/jobs/workerWrapper.js
+++ b/src/jobs/workerWrapper.js
@@ -1,3 +1,3 @@
-const { workerData, parentPort } = require("worker_threads");
+const { workerData, parentPort } = require("node:worker_threads");
 require("ts-node/register");
 require(workerData.path);

--- a/src/lib/__tests__/maps.test.ts
+++ b/src/lib/__tests__/maps.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { getStaticMapUrl } from "../maps";
+
+describe("getStaticMapUrl", () => {
+  it("creates a google maps url", () => {
+    const url = getStaticMapUrl(
+      { lat: 1, lon: 2 },
+      { width: 100, height: 50, zoom: 10 },
+    );
+    expect(url).toContain("maps.googleapis.com");
+    expect(url).toContain("center=1%2C2");
+  });
+});

--- a/src/lib/maps.ts
+++ b/src/lib/maps.ts
@@ -1,0 +1,15 @@
+export function getStaticMapUrl(
+  coords: { lat: number; lon: number },
+  opts: { width?: number; height?: number; zoom?: number } = {},
+): string {
+  const { width = 300, height = 200, zoom = 15 } = opts;
+  const params = new URLSearchParams({
+    center: `${coords.lat},${coords.lon}`,
+    zoom: zoom.toString(),
+    size: `${width}x${height}`,
+    markers: `${coords.lat},${coords.lon}`,
+  });
+  const key = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+  if (key) params.set("key", key);
+  return `https://maps.googleapis.com/maps/api/staticmap?${params.toString()}`;
+}


### PR DESCRIPTION
## Summary
- generate map URLs via `getStaticMapUrl`
- preview map thumbnails in case list
- show large static map on case detail page
- allow maps.googleapis.com images
- document `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`
- test `getStaticMapUrl`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68483f592354832b85d49a432591af3d