### PR TITLE
Add map previews to case pages

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "maps.googleapis.com",
+      },
+      {
+        protocol: "https",
+        hostname: "staticmap.openstreetmap.de",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -2,6 +2,7 @@
 import type { Case } from "@/lib/caseStore";
 import Image from "next/image";
 import { useEffect, useState } from "react";
+import MapPreview from "../../components/MapPreview";
 
 export default function ClientCasePage({
   initialCase,
@@ -51,9 +52,17 @@ export default function ClientCasePage({
         Created {new Date(caseData.createdAt).toLocaleString()}
       </p>
       {caseData.gps ? (
-        <p className="text-sm text-gray-500">
-          GPS: {caseData.gps.lat}, {caseData.gps.lon}
-        </p>
+        <>
+          <p className="text-sm text-gray-500">
+            GPS: {caseData.gps.lat}, {caseData.gps.lon}
+          </p>
+          <MapPreview
+            lat={caseData.gps.lat}
+            lon={caseData.gps.lon}
+            width={600}
+            height={300}
+          />
+        </>
       ) : null}
       {caseData.streetAddress ? (
         <p className="text-sm text-gray-500">

--- a/src/app/cases/page.tsx
+++ b/src/app/cases/page.tsx
@@ -1,6 +1,7 @@
 import { getCases } from "@/lib/caseStore";
 import Image from "next/image";
 import Link from "next/link";
+import MapPreview from "../components/MapPreview";
 
 export const dynamic = "force-dynamic";
 
@@ -14,6 +15,14 @@ export default function CasesPage() {
           <li key={c.id} className="border p-2">
             <Link href={`/cases/${c.id}`} className="flex items-center gap-4">
               <Image src={c.photo} alt="" width={80} height={60} />
+              {c.gps ? (
+                <MapPreview
+                  lat={c.gps.lat}
+                  lon={c.gps.lon}
+                  width={80}
+                  height={60}
+                />
+              ) : null}
               <span>
                 Case {c.id}
                 {c.analysis ? "" : " (processing...)"}

--- a/src/app/components/MapPreview.tsx
+++ b/src/app/components/MapPreview.tsx
@@ -1,0 +1,19 @@
+import Image from "next/image";
+
+export default function MapPreview({
+  lat,
+  lon,
+  width,
+  height,
+}: {
+  lat: number;
+  lon: number;
+  width: number;
+  height: number;
+}) {
+  const key = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+  const url = key
+    ? `https://maps.googleapis.com/maps/api/staticmap?center=${lat},${lon}&zoom=16&size=${width}x${height}&markers=color:red|${lat},${lon}&key=${key}`
+    : `https://staticmap.openstreetmap.de/staticmap.php?center=${lat},${lon}&zoom=16&size=${width}x${height}&markers=${lat},${lon},red`;
+  return <Image src={url} alt="map preview" width={width} height={height} />;
+}


### PR DESCRIPTION
## Summary
- show map previews in case list and case detail views
- allow loading static maps from Google Maps or OpenStreetMap

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684842b165c4832b9131ff159998d705