### PR TITLE
Implement schema validation retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ OPENAI_API_KEY=your-key
 
 The helper in `src/lib/openai.ts` uses this key to analyze uploaded violation
 photos with OpenAI's vision model. It sends the image to the model and requests
-a JSON response describing the violation. The JSON follows a schema that
-includes the violation type, location clues, and vehicle details such as make,
-model, color and license plate information.
+a JSON response describing the violation. The response is validated with Zod to
+ensure it matches the expected schema. If validation fails, the helper retries
+the request, providing the previous response and error to guide the model. The
+JSON schema includes the violation type, location clues, and vehicle details
+such as make, model, color and license plate information.
 
 When a user uploads a photo, the API stores the case immediately and then
 triggers OpenAI analysis in the background. These asynchronous tasks are

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^4.12.0",
-        "ts-node": "^10.9.2"
+        "ts-node": "^10.9.2",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -8949,6 +8950,15 @@
         "tiny-case": "^1.0.3",
         "toposort": "^2.0.2",
         "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.57",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.57.tgz",
+      "integrity": "sha512-6tgzLuwVST5oLUxXTmBqoinKMd3JeesgbgseXeFasKKj8Q1FCZrHnbqJOyiEvr4cVAlbug+CgIsmJ8cl/pU5FA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-dom": "^19.0.0",
     "react-icons": "^4.12.0",
     "bree": "^9.2.4",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,5 +1,6 @@
 import dotenv from "dotenv";
 import OpenAI from "openai";
+import { z } from "zod";
 
 dotenv.config();
 
@@ -8,19 +9,23 @@ export const openai = new OpenAI({
   dangerouslyAllowBrowser: true,
 });
 
-export interface ViolationReport {
-  violationType: string;
-  details: string;
-  location?: string;
-  vehicle: {
-    make?: string;
-    model?: string;
-    type?: string;
-    color?: string;
-    licensePlateState?: string;
-    licensePlateNumber?: string;
-  };
-}
+export const violationReportSchema = z.object({
+  violationType: z.string(),
+  details: z.string(),
+  location: z.string().optional(),
+  vehicle: z
+    .object({
+      make: z.string().optional(),
+      model: z.string().optional(),
+      type: z.string().optional(),
+      color: z.string().optional(),
+      licensePlateState: z.string().optional(),
+      licensePlateNumber: z.string().optional(),
+    })
+    .default({}),
+});
+
+export type ViolationReport = z.infer<typeof violationReportSchema>;
 
 export async function analyzeViolation(
   imageUrls: string | string[],
@@ -46,31 +51,46 @@ export async function analyzeViolation(
   };
 
   const urls = Array.isArray(imageUrls) ? imageUrls : [imageUrls];
+  const baseMessages = [
+    {
+      role: "system",
+      content:
+        "You identify vehicle violations and reply in JSON strictly following the provided schema.",
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: `Analyze the photo${urls.length > 1 ? "s" : ""} and respond with JSON matching this schema: ${JSON.stringify(
+            schema,
+          )}`,
+        },
+        ...urls.map((u) => ({ type: "image_url", image_url: { url: u } })),
+      ],
+    },
+  ];
 
-  const response = await openai.chat.completions.create({
-    model: "gpt-4o",
-    messages: [
-      {
-        role: "system",
-        content:
-          "You identify vehicle violations and reply in JSON strictly following the provided schema.",
-      },
-      {
+  const messages = [...baseMessages];
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const response = await openai.chat.completions.create({
+      model: "gpt-4o",
+      messages,
+      max_tokens: 300,
+      response_format: { type: "json_object" },
+    });
+    const text = response.choices[0]?.message?.content ?? "{}";
+    try {
+      const parsed = JSON.parse(text);
+      return violationReportSchema.parse(parsed);
+    } catch (err) {
+      if (attempt === 2) throw err;
+      messages.push({ role: "assistant", content: text });
+      messages.push({
         role: "user",
-        content: [
-          {
-            type: "text",
-            text: `Analyze the photo${urls.length > 1 ? "s" : ""} and respond with JSON matching this schema: ${JSON.stringify(
-              schema,
-            )}`,
-          },
-          ...urls.map((u) => ({ type: "image_url", image_url: { url: u } })),
-        ],
-      },
-    ],
-    max_tokens: 300,
-    response_format: { type: "json_object" },
-  });
-  const text = response.choices[0]?.message?.content ?? "{}";
-  return JSON.parse(text);
+        content: `The previous JSON did not match the schema: ${err}. Please reply with corrected JSON only.`,
+      });
+    }
+  }
+  throw new Error("Failed to analyze violation");
 }


### PR DESCRIPTION
## Summary
- validate OpenAI results with a Zod schema
- retry violation analysis when the result is invalid
- document validation and retry behavior
- add zod dependency

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684876ed48a4832baee74a25ebe2e888