### PR TITLE
Show cases list on home

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -1,12 +1,22 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import Home from "../page";
 
 describe("Home page", () => {
-  it("renders main navigation links", () => {
+  beforeAll(() => {
+    // jsdom does not implement EventSource
+    class FakeEventSource {
+      // biome-ignore lint/suspicious/noExplicitAny: test mock
+      onmessage: any;
+      close() {}
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    (global as any).EventSource = FakeEventSource;
+  });
+
+  it("shows the cases list", () => {
     render(<Home />);
-    expect(screen.getByText("Upload a Photo")).toBeInTheDocument();
-    expect(screen.getByText("View Cases")).toBeInTheDocument();
+    expect(screen.getByText("Cases")).toBeInTheDocument();
   });
 });

--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -1,8 +1,8 @@
 "use client";
-import type { Case } from "@/lib/caseStore";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import type { Case } from "../../lib/caseStore";
 import MapPreview from "../components/MapPreview";
 
 export default function ClientCasesPage({

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -1,8 +1,8 @@
 "use client";
-import type { Case } from "@/lib/caseStore";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import type { Case } from "../../../lib/caseStore";
 import MapPreview from "../../components/MapPreview";
 
 export default function ClientCasePage({

--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { getCase } from "@/lib/caseStore";
+import { getCase } from "../../../lib/caseStore";
 import ClientCasePage from "./ClientCasePage";
 
 export const dynamic = "force-dynamic";

--- a/src/app/cases/page.tsx
+++ b/src/app/cases/page.tsx
@@ -1,4 +1,4 @@
-import { getCases } from "@/lib/caseStore";
+import { getCases } from "../../lib/caseStore";
 import ClientCasesPage from "./ClientCasesPage";
 
 export const dynamic = "force-dynamic";

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -8,7 +8,7 @@ export default function NavBar() {
       </Link>
       <div className="flex gap-6 text-sm">
         <Link href="/upload" className="hover:text-gray-300">
-          Upload
+          New Case from Image
         </Link>
         <Link href="/cases" className="hover:text-gray-300">
           Cases

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,2 @@
-import Link from "next/link";
-import { LuAppWindow, LuFileText, LuGlobe } from "react-icons/lu";
-import { SiNextdotjs, SiVercel } from "react-icons/si";
-
-export default function Home() {
-  return (
-    <main className="p-8 flex flex-col gap-4">
-      <h1 className="text-2xl font-bold mb-4">Photo To Citation</h1>
-      <Link href="/upload" className="text-blue-600 underline">
-        Upload a Photo
-      </Link>
-      <Link href="/cases" className="text-blue-600 underline">
-        View Cases
-      </Link>
-    </main>
-  );
-}
+export { dynamic } from "./cases/page";
+export { default } from "./cases/page";


### PR DESCRIPTION
## Summary
- display the cases list on the home page
- update nav bar copy to "New Case from Image"
- fix imports after moving the cases component
- adjust home page test for new default view

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68488f80ce94832b87bda66e3d2e80af