### PR TITLE
feat: add representative image support

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 import type { Case } from "@/lib/caseStore";
-import { getRepresentativePhoto } from "@/lib/caseStore";
+import { getRepresentativePhoto } from "@/lib/caseUtils";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -1,6 +1,6 @@
 "use client";
 import type { Case } from "@/lib/caseStore";
-import { getRepresentativePhoto } from "@/lib/caseStore";
+import { getRepresentativePhoto } from "@/lib/caseUtils";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -18,10 +18,6 @@ export interface Case {
   analysisOverrides?: Partial<ViolationReport> | null;
 }
 
-export function getRepresentativePhoto(caseData: Pick<Case, "photos">): string {
-  return [...caseData.photos].sort()[0];
-}
-
 const dataFile = process.env.CASE_STORE_FILE
   ? path.resolve(process.env.CASE_STORE_FILE)
   : path.join(process.cwd(), "data", "cases.json");

--- a/src/lib/caseUtils.ts
+++ b/src/lib/caseUtils.ts
@@ -1,0 +1,5 @@
+import type { Case } from "./caseStore";
+
+export function getRepresentativePhoto(caseData: Pick<Case, "photos">): string {
+  return [...caseData.photos].sort()[0];
+}

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getRepresentativePhoto } from "../src/lib/caseUtils";
 
 let dataDir: string;
 let caseStore: typeof import("../src/lib/caseStore");
@@ -58,8 +59,7 @@ describe("caseStore", () => {
   });
 
   it("computes the representative photo", () => {
-    const { createCase, addCasePhoto, getCase, getRepresentativePhoto } =
-      caseStore;
+    const { createCase, addCasePhoto, getCase } = caseStore;
     const c = createCase("/b.jpg");
     addCasePhoto(c.id, "/a.jpg");
     const updated = getCase(c.id);


### PR DESCRIPTION
## Summary
- compute representative image per case
- show case image count and representative photo on case listing
- display representative photo as main image on case page and allow browsing
- test representative photo logic

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68488ed45a8c832bb79ccf9b6705e08e