### PR TITLE
Add representation score output from OpenAI

### DIFF
--- a/src/lib/caseAnalysis.ts
+++ b/src/lib/caseAnalysis.ts
@@ -6,7 +6,7 @@ import { analyzeViolation } from "./openai";
 
 export async function analyzeCase(caseData: Case): Promise<void> {
   try {
-    const dataUrls = caseData.photos.map((p) => {
+    const images = caseData.photos.map((p) => {
       const filePath = path.join(
         process.cwd(),
         "public",
@@ -20,9 +20,12 @@ export async function analyzeCase(caseData: Case): Promise<void> {
           : ext === ".webp"
             ? "image/webp"
             : "image/jpeg";
-      return `data:${mime};base64,${buffer.toString("base64")}`;
+      return {
+        filename: path.basename(p),
+        url: `data:${mime};base64,${buffer.toString("base64")}`,
+      };
     });
-    const result = await analyzeViolation(dataUrls);
+    const result = await analyzeViolation(images);
     updateCase(caseData.id, { analysis: result });
   } catch (err) {
     console.error("Failed to analyze case", caseData.id, err);

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -32,7 +32,15 @@ describe("caseStore", () => {
     expect(getCases()).toHaveLength(1);
     addCasePhoto(c.id, "/bar.jpg");
     const updated = updateCase(c.id, {
-      analysis: { violationType: "foo", details: "bar", vehicle: {} },
+      analysis: {
+        violationType: "foo",
+        details: "bar",
+        vehicle: {},
+        images: {
+          "foo.jpg": { representationScore: 0.6 },
+          "bar.jpg": { representationScore: 0.5 },
+        },
+      },
     });
     expect(updated?.photos).toEqual(["/foo.jpg", "/bar.jpg"]);
     expect(updated?.analysis?.violationType).toBe("foo");


### PR DESCRIPTION
## Summary
- extend violation report schema with `images` map keyed by filename
- update OpenAI prompt and analyze function to return per-image representation scores
- adjust `caseStore` tests and case analysis logic for new structure

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68488ecbc368832bb3d071c14e2844de