### PR TITLE
Add analysis status updates

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -1,9 +1,9 @@
 "use client";
-import { getRepresentativePhoto } from "@/lib/caseUtils";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import type { Case } from "../../lib/caseStore";
+import { getRepresentativePhoto } from "../../lib/caseUtils";
 import AnalysisInfo from "../components/AnalysisInfo";
 import MapPreview from "../components/MapPreview";
 
@@ -58,9 +58,16 @@ export default function ClientCasesPage({
               <div className="flex flex-col text-sm gap-1">
                 <span className="font-semibold">Case {c.id}</span>
                 {c.analysis ? (
-                  <AnalysisInfo analysis={c.analysis} />
+                  <>
+                    <AnalysisInfo analysis={c.analysis} />
+                    {c.analysisStatus === "pending" ? (
+                      <span className="text-gray-500">
+                        Updating analysis...
+                      </span>
+                    ) : null}
+                  </>
                 ) : (
-                  <span className="text-gray-500">Processing...</span>
+                  <span className="text-gray-500">Analyzing photo...</span>
                 )}
               </div>
             </Link>

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -1,9 +1,9 @@
 "use client";
-import { getRepresentativePhoto } from "@/lib/caseUtils";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import type { Case } from "../../../lib/caseStore";
+import { getRepresentativePhoto } from "../../../lib/caseUtils";
 import AnalysisInfo from "../../components/AnalysisInfo";
 import MapPreview from "../../components/MapPreview";
 
@@ -166,8 +166,11 @@ export default function ClientCasePage({
         </p>
       ) : null}
       {caseData.analysis ? (
-        <div className="bg-gray-100 p-4 rounded">
+        <div className="bg-gray-100 p-4 rounded flex flex-col gap-2">
           <AnalysisInfo analysis={caseData.analysis} />
+          {caseData.analysisStatus === "pending" ? (
+            <p className="text-sm text-gray-500">Updating analysis...</p>
+          ) : null}
         </div>
       ) : (
         <p className="text-sm text-gray-500">Analyzing photo...</p>

--- a/src/lib/caseAnalysis.ts
+++ b/src/lib/caseAnalysis.ts
@@ -26,7 +26,7 @@ export async function analyzeCase(caseData: Case): Promise<void> {
       };
     });
     const result = await analyzeViolation(images);
-    updateCase(caseData.id, { analysis: result });
+    updateCase(caseData.id, { analysis: result, analysisStatus: "complete" });
   } catch (err) {
     console.error("Failed to analyze case", caseData.id, err);
   }

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -16,6 +16,7 @@ export interface Case {
   intersection?: string | null;
   analysis?: ViolationReport | null;
   analysisOverrides?: Partial<ViolationReport> | null;
+  analysisStatus: "pending" | "complete";
 }
 
 const dataFile = process.env.CASE_STORE_FILE
@@ -33,6 +34,7 @@ function loadCases(): Case[] {
     return raw.map((c) => ({
       ...c,
       photos: c.photos ?? (c.photo ? [c.photo] : []),
+      analysisStatus: c.analysisStatus ?? (c.analysis ? "complete" : "pending"),
     }));
   } catch {
     return [];
@@ -85,6 +87,7 @@ export function createCase(
     intersection: null,
     analysis: null,
     analysisOverrides: null,
+    analysisStatus: "pending",
   };
   cases.push(newCase);
   saveCases(cases);
@@ -110,6 +113,7 @@ export function addCasePhoto(id: string, photo: string): Case | undefined {
   const idx = cases.findIndex((c) => c.id === id);
   if (idx === -1) return undefined;
   cases[idx].photos.push(photo);
+  cases[idx].analysisStatus = "pending";
   saveCases(cases);
   caseEvents.emit("update", cases[idx]);
   return cases[idx];


### PR DESCRIPTION
## Summary
- track analysis status on cases
- re-run case analysis after uploads
- show when analysis data is being updated in the UI

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68489d6a9088832b872be4d9922af9f8