### PR TITLE
Implement image removal and re-analysis

### DIFF
--- a/src/app/api/cases/[id]/photos/route.ts
+++ b/src/app/api/cases/[id]/photos/route.ts
@@ -1,0 +1,19 @@
+import { analyzeCaseInBackground } from "@/lib/caseAnalysis";
+import { getCase, removeCasePhoto } from "@/lib/caseStore";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const { id } = params;
+  const { photo } = (await req.json()) as { photo: string };
+  const updated = removeCasePhoto(id, photo);
+  if (!updated) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  analyzeCaseInBackground(updated);
+  const layered = getCase(id);
+  return NextResponse.json(layered);
+}

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -104,6 +104,20 @@ export default function ClientCasePage({
     }
   }
 
+  async function removePhoto(photo: string) {
+    await fetch(`/api/cases/${caseId}/photos`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ photo }),
+    });
+    const res = await fetch(`/api/cases/${caseId}`);
+    if (res.ok) {
+      const data = (await res.json()) as Case;
+      setCaseData(data);
+    }
+    router.refresh();
+  }
+
   if (!caseData) {
     return (
       <div className="p-8 flex flex-col gap-4">
@@ -125,18 +139,26 @@ export default function ClientCasePage({
       ) : null}
       <div className="flex gap-2 flex-wrap">
         {caseData.photos.map((p) => (
-          <button
-            key={p}
-            type="button"
-            onClick={() => setSelectedPhoto(p)}
-            className={
-              selectedPhoto === p
-                ? "ring-2 ring-blue-500"
-                : "ring-1 ring-transparent"
-            }
-          >
-            <Image src={p} alt="" width={80} height={60} />
-          </button>
+          <div key={p} className="relative">
+            <button
+              type="button"
+              onClick={() => setSelectedPhoto(p)}
+              className={
+                selectedPhoto === p
+                  ? "ring-2 ring-blue-500"
+                  : "ring-1 ring-transparent"
+              }
+            >
+              <Image src={p} alt="" width={80} height={60} />
+            </button>
+            <button
+              type="button"
+              onClick={() => removePhoto(p)}
+              className="absolute -top-1 -right-1 bg-red-600 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"
+            >
+              ×
+            </button>
+          </div>
         ))}
       </div>
       <p className="text-sm text-gray-500">

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -119,6 +119,19 @@ export function addCasePhoto(id: string, photo: string): Case | undefined {
   return cases[idx];
 }
 
+export function removeCasePhoto(id: string, photo: string): Case | undefined {
+  const cases = loadCases();
+  const idx = cases.findIndex((c) => c.id === id);
+  if (idx === -1) return undefined;
+  const photoIdx = cases[idx].photos.indexOf(photo);
+  if (photoIdx === -1) return undefined;
+  cases[idx].photos.splice(photoIdx, 1);
+  cases[idx].analysisStatus = "pending";
+  saveCases(cases);
+  caseEvents.emit("update", cases[idx]);
+  return cases[idx];
+}
+
 export function setCaseAnalysisOverrides(
   id: string,
   overrides: Partial<ViolationReport> | null,

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -75,4 +75,15 @@ describe("caseStore", () => {
     const rep = getRepresentativePhoto(updated as NonNullable<typeof updated>);
     expect(rep).toBe("/a.jpg");
   });
+
+  it("removes a photo and marks analysis pending", () => {
+    const { createCase, addCasePhoto, removeCasePhoto, getCase } = caseStore;
+    const c = createCase("/foo.jpg");
+    addCasePhoto(c.id, "/bar.jpg");
+    const updated = removeCasePhoto(c.id, "/foo.jpg");
+    expect(updated?.photos).toEqual(["/bar.jpg"]);
+    expect(updated?.analysisStatus).toBe("pending");
+    const stored = getCase(c.id);
+    expect(stored?.photos).toEqual(["/bar.jpg"]);
+  });
 });


### PR DESCRIPTION
## Summary
- add `removeCasePhoto` in `caseStore`
- expose DELETE `/api/cases/[id]/photos` route
- allow removing photos in the case page UI
- test photo removal behavior

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848a7ef0b24832bb59010aa095341d3