### PR TITLE
fix: retry drafting email

### DIFF
--- a/src/lib/__tests__/caseReport.test.ts
+++ b/src/lib/__tests__/caseReport.test.ts
@@ -1,0 +1,68 @@
+import type { ChatCompletion } from "openai/resources/chat/completions";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { draftEmail } from "../caseReport";
+import type { Case } from "../caseStore";
+import { openai } from "../openai";
+import { reportModules } from "../reportModules";
+
+const baseCase: Case = {
+  id: "1",
+  photos: ["/foo.jpg"],
+  photoTimes: { "/foo.jpg": "2020-01-01T00:00:00.000Z" },
+  createdAt: "2020-01-01T00:00:00.000Z",
+  gps: null,
+  streetAddress: null,
+  intersection: null,
+  analysis: {
+    violationType: "test",
+    details: "details",
+    vehicle: {},
+    images: { "foo.jpg": { representationScore: 1 } },
+  },
+  analysisOverrides: null,
+  analysisStatus: "complete",
+  analysisStatusCode: 200,
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("draftEmail", () => {
+  it("returns parsed email when response is valid", async () => {
+    vi.spyOn(openai.chat.completions, "create").mockResolvedValueOnce({
+      choices: [
+        { message: { content: JSON.stringify({ subject: "s", body: "b" }) } },
+      ],
+    } as unknown as ChatCompletion);
+
+    const result = await draftEmail(baseCase, reportModules["oak-park"]);
+    expect(result).toEqual({ subject: "s", body: "b" });
+  });
+
+  it("retries when response is invalid", async () => {
+    vi.spyOn(openai.chat.completions, "create")
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: "{}" } }],
+      } as unknown as ChatCompletion)
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            message: { content: JSON.stringify({ subject: "s2", body: "b2" }) },
+          },
+        ],
+      } as unknown as ChatCompletion);
+
+    const result = await draftEmail(baseCase, reportModules["oak-park"]);
+    expect(result).toEqual({ subject: "s2", body: "b2" });
+  });
+
+  it("returns empty draft after repeated failures", async () => {
+    vi.spyOn(openai.chat.completions, "create").mockResolvedValue({
+      choices: [{ message: { content: "{}" } }],
+    } as unknown as ChatCompletion);
+
+    const result = await draftEmail(baseCase, reportModules["oak-park"]);
+    expect(result).toEqual({ subject: "", body: "" });
+  });
+});


### PR DESCRIPTION
## Summary
- improve `draftEmail` to retry parsing responses
- log malformed replies and return an empty draft if retries fail
- add tests for the new behaviour

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68497de55814832b87c46fc5076a01bf