### PR TITLE
feat: track photo times and use in reports

### DIFF
--- a/src/app/api/cases/[id]/report/route.ts
+++ b/src/app/api/cases/[id]/report/route.ts
@@ -1,0 +1,15 @@
+import { draftEmail } from "@/lib/caseReport";
+import { getCase } from "@/lib/caseStore";
+import { reportModules } from "@/lib/reportModules";
+import { NextResponse } from "next/server";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  const c = getCase(params.id);
+  if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const module = reportModules["oak-park"];
+  const email = await draftEmail(c, module);
+  return NextResponse.json({ email, attachments: c.photos, module });
+}

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -241,6 +241,12 @@ export default function ClientCasePage({
         </form>
       ) : null}
       <input type="file" accept="image/*" multiple onChange={handleUpload} />
+      <a
+        href={`/cases/${caseId}/draft`}
+        className="bg-green-600 text-white px-2 py-1 rounded w-max"
+      >
+        Draft Email
+      </a>
     </div>
   );
 }

--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -1,0 +1,65 @@
+"use client";
+import type { EmailDraft } from "@/lib/caseReport";
+import type { ReportModule } from "@/lib/reportModules";
+import Image from "next/image";
+import { useState } from "react";
+
+export default function DraftEditor({
+  initialDraft,
+  attachments,
+  module,
+}: {
+  initialDraft: EmailDraft;
+  attachments: string[];
+  module: ReportModule;
+}) {
+  const [subject, setSubject] = useState(initialDraft.subject);
+  const [body, setBody] = useState(initialDraft.body);
+
+  function sendEmail() {
+    const mailto = `mailto:${module.authorityEmail}?subject=${encodeURIComponent(
+      subject,
+    )}&body=${encodeURIComponent(body)}`;
+    window.location.href = mailto;
+  }
+
+  return (
+    <div className="p-8 flex flex-col gap-4">
+      <h1 className="text-xl font-semibold">Email Draft</h1>
+      <p>
+        To: {module.authorityName} ({module.authorityEmail}) - attach the photos
+        shown below before sending.
+      </p>
+      <label className="flex flex-col">
+        Subject
+        <input
+          type="text"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+          className="border p-1"
+        />
+      </label>
+      <label className="flex flex-col">
+        Body
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={10}
+          className="border p-1"
+        />
+      </label>
+      <div className="flex gap-2 flex-wrap">
+        {attachments.map((p) => (
+          <Image key={p} src={p} alt="" width={120} height={90} />
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={sendEmail}
+        className="bg-blue-500 text-white px-2 py-1 rounded"
+      >
+        Send Email
+      </button>
+    </div>
+  );
+}

--- a/src/app/cases/[id]/draft/page.tsx
+++ b/src/app/cases/[id]/draft/page.tsx
@@ -1,0 +1,18 @@
+import { draftEmail } from "@/lib/caseReport";
+import { getCase } from "@/lib/caseStore";
+import { reportModules } from "@/lib/reportModules";
+import DraftEditor from "./DraftEditor";
+
+export const dynamic = "force-dynamic";
+
+export default async function DraftPage({
+  params,
+}: { params: { id: string } }) {
+  const c = getCase(params.id);
+  if (!c) return <div className="p-8">Case not found</div>;
+  const module = reportModules["oak-park"];
+  const email = await draftEmail(c, module);
+  return (
+    <DraftEditor initialDraft={email} attachments={c.photos} module={module} />
+  );
+}

--- a/src/lib/caseAnalysis.ts
+++ b/src/lib/caseAnalysis.ts
@@ -27,7 +27,11 @@ export async function analyzeCase(caseData: Case): Promise<void> {
       };
     });
     const result = await analyzeViolation(images);
-    updateCase(caseData.id, { analysis: result, analysisStatus: "complete", analysisStatusCode: 200 });
+    updateCase(caseData.id, {
+      analysis: result,
+      analysisStatus: "complete",
+      analysisStatusCode: 200,
+    });
   } catch (err) {
     const status = err instanceof APIError ? err.status : 500;
     updateCase(caseData.id, { analysisStatusCode: status });

--- a/src/lib/caseReport.ts
+++ b/src/lib/caseReport.ts
@@ -1,0 +1,70 @@
+import path from "node:path";
+import { z } from "zod";
+import type { Case } from "./caseStore";
+import { openai } from "./openai";
+import type { ReportModule } from "./reportModules";
+
+export const emailDraftSchema = z.object({
+  subject: z.string(),
+  body: z.string(),
+});
+
+export type EmailDraft = z.infer<typeof emailDraftSchema>;
+
+export function getViolationTime(caseData: Case): string | null {
+  const analysis = caseData.analysis;
+  if (!analysis?.images) return null;
+  const best = Object.entries(analysis.images).sort(
+    (a, b) => b[1].representationScore - a[1].representationScore,
+  )[0];
+  if (!best) return null;
+  const file = caseData.photos.find((p) => path.basename(p) === best[0]);
+  if (!file) return null;
+  return caseData.photoTimes[file] ?? null;
+}
+
+export async function draftEmail(
+  caseData: Case,
+  mod: ReportModule,
+): Promise<EmailDraft> {
+  const analysis = caseData.analysis;
+  const vehicle = analysis?.vehicle ?? {};
+  const time = getViolationTime(caseData) ?? caseData.createdAt;
+  const location =
+    caseData.streetAddress ||
+    caseData.intersection ||
+    (caseData.gps
+      ? `${caseData.gps.lat}, ${caseData.gps.lon}`
+      : "unknown location");
+  const schema = {
+    type: "object",
+    properties: { subject: { type: "string" }, body: { type: "string" } },
+  };
+  const prompt = `Draft a short, professional email to ${mod.authorityName} reporting a vehicle violation.
+Include these details if available:
+- Violation: ${analysis?.violationType || ""}
+- Description: ${analysis?.details || ""}
+- Location: ${location}
+- License Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}
+ - Time: ${new Date(time).toLocaleString()}
+Mention that photos are attached. Respond with JSON matching this schema: ${JSON.stringify(
+    schema,
+  )}`;
+
+  const res = await openai.chat.completions.create({
+    model: "gpt-4o",
+    messages: [
+      {
+        role: "system",
+        content: "You create email drafts for municipal authorities.",
+      },
+      { role: "user", content: prompt },
+    ],
+    max_tokens: 300,
+    response_format: { type: "json_object" },
+  });
+
+  const text = res.choices[0]?.message?.content ?? "{}";
+  const parsed = JSON.parse(text);
+  return emailDraftSchema.parse(parsed);
+}

--- a/src/lib/exif.ts
+++ b/src/lib/exif.ts
@@ -18,3 +18,19 @@ export function extractGps(buffer: Buffer): Gps | null {
   }
   return null;
 }
+
+export function extractTimestamp(buffer: Buffer): string | null {
+  try {
+    const result = ExifParser.create(buffer).parse();
+    const ts =
+      (result.tags.DateTimeOriginal as number | undefined) ||
+      (result.tags.CreateDate as number | undefined) ||
+      (result.tags.ModifyDate as number | undefined);
+    if (typeof ts === "number") {
+      return new Date(ts * 1000).toISOString();
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}

--- a/src/lib/reportModules.ts
+++ b/src/lib/reportModules.ts
@@ -1,0 +1,13 @@
+export interface ReportModule {
+  id: string;
+  authorityName: string;
+  authorityEmail: string;
+}
+
+export const reportModules: Record<string, ReportModule> = {
+  "oak-park": {
+    id: "oak-park",
+    authorityName: "Oak Park Police Department",
+    authorityEmail: "police@oak-park.us",
+  },
+};

--- a/test/caseReport.test.ts
+++ b/test/caseReport.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { getViolationTime } from "../src/lib/caseReport";
+import type { Case } from "../src/lib/caseStore";
+
+const baseCase: Case = {
+  id: "1",
+  photos: ["/a.jpg", "/b.jpg"],
+  photoTimes: {
+    "/a.jpg": "2020-01-01T00:00:00.000Z",
+    "/b.jpg": "2020-01-02T00:00:00.000Z",
+  },
+  createdAt: "2020-01-03T00:00:00.000Z",
+  gps: null,
+  streetAddress: null,
+  intersection: null,
+  analysis: null,
+  analysisOverrides: null,
+  analysisStatus: "complete",
+  analysisStatusCode: null,
+};
+
+describe("getViolationTime", () => {
+  it("returns time from highest scoring photo", () => {
+    const c: Case = {
+      ...baseCase,
+      analysis: {
+        violationType: "foo",
+        details: "bar",
+        location: "",
+        vehicle: {},
+        images: {
+          "a.jpg": { representationScore: 0.4 },
+          "b.jpg": { representationScore: 0.9 },
+        },
+      },
+    };
+    const t = getViolationTime(c);
+    expect(t).toBe("2020-01-02T00:00:00.000Z");
+  });
+
+  it("returns null when photo time missing", () => {
+    const c: Case = {
+      ...baseCase,
+      photoTimes: {},
+      analysis: {
+        violationType: "foo",
+        details: "bar",
+        location: "",
+        vehicle: {},
+        images: { "a.jpg": { representationScore: 0.5 } },
+      },
+    };
+    const t = getViolationTime(c);
+    expect(t).toBeNull();
+  });
+});

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -24,14 +24,19 @@ describe("caseStore", () => {
   it("creates and retrieves a case", () => {
     const { createCase, getCase, getCases, updateCase, addCasePhoto } =
       caseStore;
-    const c = createCase("/foo.jpg", { lat: 10, lon: 20 });
+    const c = createCase(
+      "/foo.jpg",
+      { lat: 10, lon: 20 },
+      undefined,
+      "2020-01-01T00:00:00.000Z",
+    );
     expect(c.photos).toEqual(["/foo.jpg"]);
     expect(c.gps).toEqual({ lat: 10, lon: 20 });
     expect(c.streetAddress).toBeNull();
     expect(c.intersection).toBeNull();
     expect(getCase(c.id)).toEqual(c);
     expect(getCases()).toHaveLength(1);
-    addCasePhoto(c.id, "/bar.jpg");
+    addCasePhoto(c.id, "/bar.jpg", "2020-01-02T00:00:00.000Z");
     const updated = updateCase(c.id, {
       analysis: {
         violationType: "foo",
@@ -49,7 +54,12 @@ describe("caseStore", () => {
 
   it("allows providing a custom id", () => {
     const { createCase, getCase } = caseStore;
-    const c = createCase("/bar.jpg", null, "custom-id");
+    const c = createCase(
+      "/bar.jpg",
+      null,
+      "custom-id",
+      "2020-01-03T00:00:00.000Z",
+    );
     expect(c.id).toBe("custom-id");
     expect(getCase("custom-id")).toEqual(c);
     expect(c.photos).toEqual(["/bar.jpg"]);
@@ -57,7 +67,12 @@ describe("caseStore", () => {
 
   it("applies analysis overrides", () => {
     const { createCase, setCaseAnalysisOverrides, getCase } = caseStore;
-    const c = createCase("/baz.jpg");
+    const c = createCase(
+      "/baz.jpg",
+      null,
+      undefined,
+      "2020-01-04T00:00:00.000Z",
+    );
     setCaseAnalysisOverrides(c.id, { vehicle: { model: "Tesla" } });
     const updated = getCase(c.id);
     expect(updated?.analysis?.vehicle?.model).toBe("Tesla");
@@ -68,8 +83,8 @@ describe("caseStore", () => {
 
   it("computes the representative photo", () => {
     const { createCase, addCasePhoto, getCase } = caseStore;
-    const c = createCase("/b.jpg");
-    addCasePhoto(c.id, "/a.jpg");
+    const c = createCase("/b.jpg", null, undefined, "2020-01-05T00:00:00.000Z");
+    addCasePhoto(c.id, "/a.jpg", "2020-01-06T00:00:00.000Z");
     const updated = getCase(c.id);
     expect(updated).toBeDefined();
     const rep = getRepresentativePhoto(updated as NonNullable<typeof updated>);
@@ -78,8 +93,13 @@ describe("caseStore", () => {
 
   it("removes a photo and marks analysis pending", () => {
     const { createCase, addCasePhoto, removeCasePhoto, getCase } = caseStore;
-    const c = createCase("/foo.jpg");
-    addCasePhoto(c.id, "/bar.jpg");
+    const c = createCase(
+      "/foo.jpg",
+      null,
+      undefined,
+      "2020-01-07T00:00:00.000Z",
+    );
+    addCasePhoto(c.id, "/bar.jpg", "2020-01-08T00:00:00.000Z");
     const updated = removeCasePhoto(c.id, "/foo.jpg");
     expect(updated?.photos).toEqual(["/bar.jpg"]);
     expect(updated?.analysisStatus).toBe("pending");

--- a/test/exif.test.ts
+++ b/test/exif.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import { describe, expect, it } from "vitest";
-import { extractGps } from "../src/lib/exif";
+import { extractGps, extractTimestamp } from "../src/lib/exif";
 
 const starfish = fs.readFileSync("node_modules/exif-parser/test/starfish.jpg");
 
@@ -15,5 +15,17 @@ describe("extractGps", () => {
   it("returns null when data has no exif", () => {
     const gps = extractGps(Buffer.from("no exif"));
     expect(gps).toBeNull();
+  });
+});
+
+describe("extractTimestamp", () => {
+  it("parses time from exif data", () => {
+    const ts = extractTimestamp(starfish);
+    expect(ts).toBe("2013-05-10T15:21:35.000Z");
+  });
+
+  it("returns null when no exif data", () => {
+    const ts = extractTimestamp(Buffer.from("no exif"));
+    expect(ts).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- record timestamp metadata from uploaded photos
- store photo times in case records
- include violation time in report drafts based on best photo
- update tests for new metadata helpers
- compute violation time from highest scoring image in email drafts
- test `getViolationTime` utility

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848b1f24d40832bbe6bec1f1940666c