### PR TITLE
Fix dynamic params async access

### DIFF
--- a/src/app/api/cases/[id]/photos/route.ts
+++ b/src/app/api/cases/[id]/photos/route.ts
@@ -7,7 +7,7 @@ export async function DELETE(
   req: NextRequest,
   { params }: { params: { id: string } },
 ) {
-  const { id } = params;
+  const { id } = await params;
   const { photo } = (await req.json()) as { photo: string };
   const updated = removeCasePhoto(id, photo);
   if (!updated) {

--- a/src/app/api/cases/[id]/report/route.ts
+++ b/src/app/api/cases/[id]/report/route.ts
@@ -7,7 +7,8 @@ export async function GET(
   _req: Request,
   { params }: { params: { id: string } },
 ) {
-  const c = getCase(params.id);
+  const { id } = await params;
+  const c = getCase(id);
   if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
   const module = reportModules["oak-park"];
   const email = await draftEmail(c, module);

--- a/src/app/cases/[id]/draft/page.tsx
+++ b/src/app/cases/[id]/draft/page.tsx
@@ -8,7 +8,8 @@ export const dynamic = "force-dynamic";
 export default async function DraftPage({
   params,
 }: { params: { id: string } }) {
-  const c = getCase(params.id);
+  const { id } = await params;
+  const c = getCase(id);
   if (!c) return <div className="p-8">Case not found</div>;
   const module = reportModules["oak-park"];
   const email = await draftEmail(c, module);


### PR DESCRIPTION
## Summary
- await dynamic params before accessing them in DraftPage and API routes

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684980d71934832ba8dd9986e79a9fa4