### PR TITLE
Implement image upload dialog directly from header

### DIFF
--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -1,15 +1,33 @@
+"use client";
+
 import Link from "next/link";
+import { useRef } from "react";
+import useNewCaseFromFiles from "../useNewCaseFromFiles";
 
 export default function NavBar() {
+  const uploadCase = useNewCaseFromFiles();
+  const inputRef = useRef<HTMLInputElement>(null);
   return (
     <nav className="bg-gray-900 text-white py-4 px-8 flex items-center justify-between">
       <Link href="/" className="text-lg font-semibold hover:text-gray-300">
         Photo To Citation
       </Link>
+      <input
+        type="file"
+        accept="image/*"
+        multiple
+        hidden
+        ref={inputRef}
+        onChange={(e) => uploadCase(e.target.files)}
+      />
       <div className="flex gap-6 text-sm">
-        <Link href="/upload" className="hover:text-gray-300">
+        <button
+          type="button"
+          className="hover:text-gray-300"
+          onClick={() => inputRef.current?.click()}
+        >
           New Case from Image
-        </Link>
+        </button>
         <Link href="/cases" className="hover:text-gray-300">
           Cases
         </Link>

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,33 +1,17 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import useNewCaseFromFiles from "../useNewCaseFromFiles";
 
 export default function UploadPage() {
-  const router = useRouter();
-
-  async function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const files = e.target.files;
-    if (!files || files.length === 0) return;
-    const id = Date.now().toString();
-    const preview = URL.createObjectURL(files[0]);
-    sessionStorage.setItem(`preview-${id}`, preview);
-    Array.from(files).forEach((file, idx) => {
-      const formData = new FormData();
-      formData.append("photo", file);
-      formData.append("caseId", id);
-      const upload = fetch("/api/upload", { method: "POST", body: formData });
-      if (idx === 0) {
-        upload.then(() => {
-          sessionStorage.removeItem(`preview-${id}`);
-        });
-      }
-    });
-    router.push(`/cases/${id}`);
-  }
-
+  const uploadCase = useNewCaseFromFiles();
   return (
     <div className="p-8">
-      <input type="file" accept="image/*" multiple onChange={handleChange} />
+      <input
+        type="file"
+        accept="image/*"
+        multiple
+        onChange={(e) => uploadCase(e.target.files)}
+      />
     </div>
   );
 }

--- a/src/app/useNewCaseFromFiles.ts
+++ b/src/app/useNewCaseFromFiles.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function useNewCaseFromFiles() {
+  const router = useRouter();
+  return async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const id = Date.now().toString();
+    const preview = URL.createObjectURL(files[0]);
+    sessionStorage.setItem(`preview-${id}`, preview);
+    await Promise.all(
+      Array.from(files).map((file, idx) => {
+        const formData = new FormData();
+        formData.append("photo", file);
+        formData.append("caseId", id);
+        const upload = fetch("/api/upload", { method: "POST", body: formData });
+        if (idx === 0) {
+          upload.then(() => {
+            sessionStorage.removeItem(`preview-${id}`);
+          });
+        }
+        return upload;
+      }),
+    );
+    router.push(`/cases/${id}`);
+  };
+}


### PR DESCRIPTION
## Summary
- create shared upload hook to handle creating a case from selected files
- update upload page to use the hook
- trigger hidden file input from NavBar instead of navigating

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849854ed5f0832b94c247b16c198411