### PR TITLE
Add per-image evidence display

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import type { Case } from "../../../lib/caseStore";
 import { getRepresentativePhoto } from "../../../lib/caseUtils";
 import AnalysisInfo from "../../components/AnalysisInfo";
+import ImageHighlights from "../../components/ImageHighlights";
 import MapPreview from "../../components/MapPreview";
 
 export default function ClientCasePage({
@@ -147,6 +148,12 @@ export default function ClientCasePage({
               </p>
             ) : null;
           })()}
+          {caseData.analysis ? (
+            <ImageHighlights
+              analysis={caseData.analysis}
+              photo={selectedPhoto}
+            />
+          ) : null}
         </>
       ) : null}
       <div className="flex gap-2 flex-wrap">

--- a/src/app/components/ImageHighlights.tsx
+++ b/src/app/components/ImageHighlights.tsx
@@ -1,0 +1,23 @@
+"use client";
+import type { ViolationReport } from "@/lib/openai";
+
+export default function ImageHighlights({
+  analysis,
+  photo,
+}: {
+  analysis: ViolationReport;
+  photo: string;
+}) {
+  const name = photo.split("/").pop() || photo;
+  const info = analysis.images?.[name];
+  if (!info) return null;
+  return (
+    <div className="bg-gray-50 p-2 rounded text-sm flex flex-col gap-1">
+      <span>
+        <span className="font-semibold">Image score:</span>{" "}
+        {info.representationScore.toFixed(2)}
+      </span>
+      {info.highlights ? <span>{info.highlights}</span> : null}
+    </div>
+  );
+}

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -41,6 +41,7 @@ export const violationReportSchema = z.object({
     .record(
       z.object({
         representationScore: z.number().min(0).max(1),
+        highlights: z.string().optional(),
       }),
     )
     .default({}),
@@ -74,6 +75,7 @@ export async function analyzeViolation(
           type: "object",
           properties: {
             representationScore: { type: "number" },
+            highlights: { type: "string" },
           },
         },
       },
@@ -93,7 +95,7 @@ export async function analyzeViolation(
       content: [
         {
           type: "text",
-          text: `Analyze the photo${urls.length > 1 ? "s" : ""} and score each image from 0 to 1 for how well it represents the case. Use these filenames as keys: ${names.join(", ")}. Respond with JSON matching this schema: ${JSON.stringify(
+          text: `Analyze the photo${urls.length > 1 ? "s" : ""} and score each image from 0 to 1 for how well it represents the case. Also provide a short description of the evidence each image adds. Use these filenames as keys: ${names.join(", ")}. Respond with JSON matching this schema: ${JSON.stringify(
             schema,
           )}`,
         },


### PR DESCRIPTION
## Summary
- allow OpenAI to return `highlights` for each analyzed image
- show each image's score and highlights on the case page

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849866945ec832b9eb3899d39142dc4