### PR TITLE
Add case toolbar and email logging

### DIFF
--- a/src/app/api/cases/[id]/report/route.ts
+++ b/src/app/api/cases/[id]/report/route.ts
@@ -1,5 +1,5 @@
 import { draftEmail } from "@/lib/caseReport";
-import { getCase } from "@/lib/caseStore";
+import { addCaseEmail, getCase } from "@/lib/caseStore";
 import { reportModules } from "@/lib/reportModules";
 import { NextResponse } from "next/server";
 
@@ -13,4 +13,26 @@ export async function GET(
   const module = reportModules["oak-park"];
   const email = await draftEmail(c, module);
   return NextResponse.json({ email, attachments: c.photos, module });
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  const { id } = params;
+  const { subject, body, attachments } = (await req.json()) as {
+    subject: string;
+    body: string;
+    attachments: string[];
+  };
+  const updated = addCaseEmail(id, {
+    subject,
+    body,
+    attachments,
+    sentAt: new Date().toISOString(),
+  });
+  if (!updated) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(updated);
 }

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import type { Case } from "../../../lib/caseStore";
 import { getRepresentativePhoto } from "../../../lib/caseUtils";
 import AnalysisInfo from "../../components/AnalysisInfo";
+import CaseToolbar from "../../components/CaseToolbar";
 import ImageHighlights from "../../components/ImageHighlights";
 import MapPreview from "../../components/MapPreview";
 
@@ -145,6 +146,7 @@ export default function ClientCasePage({
   return (
     <div className="p-8 flex flex-col gap-4">
       <h1 className="text-xl font-semibold">Case {caseData.id}</h1>
+      <CaseToolbar caseId={caseId} />
       {selectedPhoto ? (
         <>
           <Image src={selectedPhoto} alt="uploaded" width={600} height={400} />
@@ -298,12 +300,6 @@ export default function ClientCasePage({
           </div>
         </form>
       ) : null}
-      <a
-        href={`/cases/${caseId}/draft`}
-        className="bg-green-600 text-white px-2 py-1 rounded w-max"
-      >
-        Draft Email
-      </a>
     </div>
   );
 }

--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -8,18 +8,25 @@ export default function DraftEditor({
   initialDraft,
   attachments,
   module,
+  caseId,
 }: {
   initialDraft: EmailDraft;
   attachments: string[];
   module: ReportModule;
+  caseId: string;
 }) {
   const [subject, setSubject] = useState(initialDraft.subject);
   const [body, setBody] = useState(initialDraft.body);
 
-  function sendEmail() {
+  async function sendEmail() {
     const mailto = `mailto:${module.authorityEmail}?subject=${encodeURIComponent(
       subject,
     )}&body=${encodeURIComponent(body)}`;
+    await fetch(`/api/cases/${caseId}/report`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ subject, body, attachments }),
+    });
     window.location.href = mailto;
   }
 

--- a/src/app/cases/[id]/draft/page.tsx
+++ b/src/app/cases/[id]/draft/page.tsx
@@ -14,6 +14,11 @@ export default async function DraftPage({
   const module = reportModules["oak-park"];
   const email = await draftEmail(c, module);
   return (
-    <DraftEditor initialDraft={email} attachments={c.photos} module={module} />
+    <DraftEditor
+      caseId={id}
+      initialDraft={email}
+      attachments={c.photos}
+      module={module}
+    />
   );
 }

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -1,0 +1,22 @@
+"use client";
+import Link from "next/link";
+
+export default function CaseToolbar({ caseId }: { caseId: string }) {
+  return (
+    <div className="bg-gray-100 px-8 py-2 flex justify-end">
+      <details className="relative">
+        <summary className="cursor-pointer select-none bg-gray-300 px-2 py-1 rounded">
+          Actions
+        </summary>
+        <div className="absolute right-0 mt-1 bg-white border rounded shadow">
+          <Link
+            href={`/cases/${caseId}/draft`}
+            className="block px-4 py-2 hover:bg-gray-100"
+          >
+            Draft Email to Authorities
+          </Link>
+        </div>
+      </details>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a toolbar for case actions under the main header
- move the draft email action into a dropdown and rename it
- record sent email drafts in the case file via a new API endpoint

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68498a95fb58832ba9afcf26a059d40d