### PR TITLE
Enable SMTP email sending with override option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ reverse geocode lookup for each case in the background. The resulting street
 address and closest intersection are stored with the case once the lookup
 completes.
 
+## Email Sending
+
+To enable sending reports directly from the app, configure SMTP credentials in
+your `.env` file:
+
+```bash
+SMTP_HOST=localhost
+SMTP_PORT=587
+SMTP_USER=username
+SMTP_PASS=password
+SMTP_FROM=from@example.com
+# Send all mail to this address instead of the real authority
+MOCK_EMAIL_TO=test@example.com
+```
+
+If `MOCK_EMAIL_TO` is set, all outgoing email will be directed there instead of
+the authority's address. Omit the variable in production to send to the real
+recipient.
+
 ## Folder Structure
 
 ```text

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "exif-parser": "^0.1.12",
         "lodash": "4.17.21",
         "next": "15.3.3",
+        "nodemailer": "^7.0.3",
         "openai": "^5.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -6409,6 +6410,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.3.tgz",
+      "integrity": "sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/numbered": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -12,19 +12,21 @@
     "reanalyze": "ts-node --transpile-only scripts/updateMissingAnalysis.ts"
   },
   "dependencies": {
+    "bree": "^9.2.4",
     "dotenv": "^16.5.0",
     "exif-parser": "^0.1.12",
     "lodash": "4.17.21",
     "next": "15.3.3",
+    "nodemailer": "^7.0.3",
     "openai": "^5.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^4.12.0",
-    "bree": "^9.2.4",
     "ts-node": "^10.9.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.6.3",
@@ -35,13 +37,12 @@
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4.5.1",
     "@vitest/coverage-v8": "^3.2.3",
-    "vite-tsconfig-paths": "^4.2.0",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
     "jsdom": "^26.1.0",
     "tailwindcss": "^4",
     "typescript": "^5",
-    "vitest": "^3.2.3",
-    "@biomejs/biome": "^1.9.4"
+    "vite-tsconfig-paths": "^4.2.0",
+    "vitest": "^3.2.3"
   }
 }

--- a/src/app/api/cases/[id]/report/route.ts
+++ b/src/app/api/cases/[id]/report/route.ts
@@ -1,5 +1,6 @@
 import { draftEmail } from "@/lib/caseReport";
 import { addCaseEmail, getCase } from "@/lib/caseStore";
+import { sendEmail } from "@/lib/email";
 import { reportModules } from "@/lib/reportModules";
 import { NextResponse } from "next/server";
 
@@ -25,14 +26,30 @@ export async function POST(
     body: string;
     attachments: string[];
   };
+  const c = getCase(id);
+  if (!c) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const module = reportModules["oak-park"];
+  try {
+    await sendEmail({
+      to: module.authorityEmail,
+      subject,
+      body,
+      attachments,
+    });
+  } catch (err) {
+    console.error("Failed to send email", err);
+    return NextResponse.json(
+      { error: "Failed to send email" },
+      { status: 500 },
+    );
+  }
   const updated = addCaseEmail(id, {
     subject,
     body,
     attachments,
     sentAt: new Date().toISOString(),
   });
-  if (!updated) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
   return NextResponse.json(updated);
 }

--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -19,23 +19,24 @@ export default function DraftEditor({
   const [body, setBody] = useState(initialDraft.body);
 
   async function sendEmail() {
-    const mailto = `mailto:${module.authorityEmail}?subject=${encodeURIComponent(
-      subject,
-    )}&body=${encodeURIComponent(body)}`;
-    await fetch(`/api/cases/${caseId}/report`, {
+    const res = await fetch(`/api/cases/${caseId}/report`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ subject, body, attachments }),
     });
-    window.location.href = mailto;
+    if (res.ok) {
+      alert("Email sent");
+    } else {
+      alert("Failed to send email");
+    }
   }
 
   return (
     <div className="p-8 flex flex-col gap-4">
       <h1 className="text-xl font-semibold">Email Draft</h1>
       <p>
-        To: {module.authorityName} ({module.authorityEmail}) - attach the photos
-        shown below before sending.
+        To: {module.authorityName} ({module.authorityEmail}) - the photos shown
+        below will be attached automatically.
       </p>
       <label className="flex flex-col">
         Subject

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,39 @@
+import path from "node:path";
+import dotenv from "dotenv";
+import nodemailer from "nodemailer";
+
+dotenv.config();
+
+export interface EmailOptions {
+  to: string;
+  subject: string;
+  body: string;
+  attachments?: string[];
+}
+
+export async function sendEmail({
+  to,
+  subject,
+  body,
+  attachments = [],
+}: EmailOptions): Promise<void> {
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: process.env.SMTP_PORT ? Number(process.env.SMTP_PORT) : 587,
+    secure: process.env.SMTP_SECURE === "true",
+    auth: process.env.SMTP_USER
+      ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS || "" }
+      : undefined,
+  });
+  const override = process.env.MOCK_EMAIL_TO;
+  await transporter.sendMail({
+    from: process.env.SMTP_FROM || process.env.SMTP_USER,
+    to: override || to,
+    subject,
+    text: body,
+    attachments: attachments.map((p) => ({
+      filename: path.basename(p),
+      path: path.join(process.cwd(), "public", p.replace(/^\//, "")),
+    })),
+  });
+}


### PR DESCRIPTION
## Summary
- add `nodemailer` dependency and implement `sendEmail` helper
- send email via SMTP in the report API route
- update draft editor to call the API instead of opening `mailto:`
- document SMTP setup and mock email override in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849936c865c832b8d5181e8fc82f28b