### PR TITLE
Add Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Multi-stage build for Photo To Citation Next.js app
+
+# Install dependencies only, no dev dependencies after build
+FROM node:20-bookworm AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Build the application
+FROM node:20-bookworm AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build && npm prune --production
+
+# Runtime image
+FROM node:20-bookworm-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3000
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -143,3 +143,13 @@ manually enabling or disabling modules.
    status entry for the new module.
 3. Visit `/settings` to verify the module appears and enable or disable it as
    desired.
+
+## Docker
+
+To run the app in containers, install Docker and Docker Compose then build the stack:
+
+```bash
+docker compose up -d
+```
+
+Traefik will serve the application at `https://730op.synology.me/photo-citation` using the labels defined in `docker-compose.yml`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.8"
+
+services:
+  app:
+    build: .
+    env_file:
+      - .env
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.photo-citation.rule=Host(`730op.synology.me`) && PathPrefix(`/photo-citation`)"
+      - "traefik.http.routers.photo-citation.entrypoints=https"
+      - "traefik.http.routers.photo-citation.tls=true"
+      - "traefik.http.routers.photo-citation.tls.certresolver=myresolver"
+      - "traefik.http.services.photo-citation.loadbalancer.server.port=3000"
+      - "traefik.http.middlewares.photo-citation-stripprefix.stripprefix.prefixes=/photo-citation"
+      - "traefik.http.routers.photo-citation.middlewares=photo-citation-stripprefix"
+    networks:
+      - web
+
+  traefik:
+    image: traefik:v3.0
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.http.address=:80
+      - --entrypoints.https.address=:443
+      - --certificatesresolvers.myresolver.acme.tlschallenge=true
+      - --certificatesresolvers.myresolver.acme.email=you@example.com
+      - --certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./letsencrypt:/letsencrypt
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - web
+    restart: unless-stopped
+
+networks:
+  web:
+    external: false


### PR DESCRIPTION
## Summary
- containerize Next.js app with Dockerfile
- define a `docker-compose.yml` that runs Traefik as a reverse proxy
- document container usage in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849a11f3184832b933d6313ea88c87b