### PR TITLE
Add no violation state to progress graph

### DIFF
--- a/src/app/components/CaseProgressGraph.tsx
+++ b/src/app/components/CaseProgressGraph.tsx
@@ -8,6 +8,7 @@ const Mermaid = dynamic(() => import("react-mermaid2"), { ssr: false });
 const steps = [
   { id: "uploaded", label: "Photographs Uploaded" },
   { id: "analysis", label: "Analysis Complete" },
+  { id: "noviol", label: "No Violation Identified" },
   { id: "violation", label: "Violation Identified" },
   { id: "plate", label: "License Plate Identified" },
   { id: "vin", label: "VIN Verified" },
@@ -23,9 +24,11 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
   const status = useMemo(() => {
     const analysisDone = caseData.analysisStatus === "complete";
     const violation = analysisDone && Boolean(caseData.analysis?.violationType);
+    const noViolation = analysisDone && !caseData.analysis?.violationType;
     return {
       uploaded: true,
       analysis: analysisDone,
+      noviol: noViolation,
       violation,
       plate: Boolean(caseData.analysis?.vehicle?.licensePlateNumber),
       vin: Boolean(caseData.vin),
@@ -38,27 +41,53 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
     } as Record<string, boolean>;
   }, [caseData]);
 
-  const firstPending = steps.findIndex((s) => !status[s.id]);
+  const visibleSteps = useMemo(() => {
+    if (status.violation) {
+      return steps.filter((s) => s.id !== "noviol");
+    }
+    const hidden = [
+      "violation",
+      "plate",
+      "vin",
+      "ownreq",
+      "own",
+      "notify",
+      "confirm",
+      "sent",
+      "received",
+    ];
+    return steps.filter((s) => !hidden.includes(s.id));
+  }, [status]);
+
+  const firstPending = visibleSteps.findIndex((s) => !status[s.id]);
 
   const chart = useMemo(() => {
-    const nodes = steps.map((s) => `${s.id}["${s.label}"]`).join("\n");
-    const edgesList: Array<[string, string, boolean]> = [
-      ["uploaded", "analysis", true],
-      ["analysis", "violation", true],
-      ["violation", "plate", true],
-      ["plate", "vin", true],
-      ["plate", "ownreq", true],
-      ["vin", "ownreq", false],
-      ["ownreq", "own", true],
-      ["violation", "notify", true],
-      ["notify", "confirm", true],
-      ["confirm", "sent", true],
-      ["sent", "received", true],
-    ];
+    const nodes = visibleSteps.map((s) => `${s.id}["${s.label}"]`).join("\n");
+    let edgesList: Array<[string, string, boolean]> = [];
+    if (status.violation) {
+      edgesList = [
+        ["uploaded", "analysis", true],
+        ["analysis", "violation", true],
+        ["violation", "plate", true],
+        ["plate", "vin", true],
+        ["plate", "ownreq", true],
+        ["vin", "ownreq", false],
+        ["ownreq", "own", true],
+        ["violation", "notify", true],
+        ["notify", "confirm", true],
+        ["confirm", "sent", true],
+        ["sent", "received", true],
+      ];
+    } else {
+      edgesList = [
+        ["uploaded", "analysis", true],
+        ["analysis", "noviol", true],
+      ];
+    }
     const edges = edgesList
       .map(([a, b, hard]) => `${a}${hard ? "-->" : "-.->"}${b}`)
       .join("\n");
-    const classAssignments = steps
+    const classAssignments = visibleSteps
       .map((s, i) => {
         const cls = status[s.id]
           ? "completed"
@@ -69,7 +98,7 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
       })
       .join("\n");
     return `graph TD\n${nodes}\n${edges}\nclassDef completed fill:#D1FAE5,stroke:#047857;\nclassDef current fill:#FEF3C7,stroke:#92400E;\nclassDef pending fill:#F3F4F6,stroke:#6B7280;\n${classAssignments}`;
-  }, [status, firstPending]);
+  }, [status, firstPending, visibleSteps]);
 
   return (
     <div className="max-w-full overflow-x-auto">


### PR DESCRIPTION
## Summary
- show a "No Violation Identified" step in the case progress graph
- hide all steps after "Violation Identified" when no violation was found

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6849b698e784832badff4524b2b3ee99