### PR TITLE
Implement ownership request tracking

### DIFF
--- a/src/app/api/cases/[id]/ownership-request/route.ts
+++ b/src/app/api/cases/[id]/ownership-request/route.ts
@@ -1,0 +1,22 @@
+import { addOwnershipRequest } from "@/lib/caseStore";
+import { NextResponse } from "next/server";
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  const { id } = params;
+  const { moduleId, checkNumber } = (await req.json()) as {
+    moduleId: string;
+    checkNumber?: string | null;
+  };
+  const updated = addOwnershipRequest(id, {
+    moduleId,
+    checkNumber: checkNumber ?? null,
+    requestedAt: new Date().toISOString(),
+  });
+  if (!updated) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(updated);
+}

--- a/src/app/cases/[id]/ownership/OwnershipEditor.tsx
+++ b/src/app/cases/[id]/ownership/OwnershipEditor.tsx
@@ -1,0 +1,49 @@
+"use client";
+import type { OwnershipModule } from "@/lib/ownershipModules";
+import { useState } from "react";
+
+export default function OwnershipEditor({
+  caseId,
+  module,
+}: {
+  caseId: string;
+  module: OwnershipModule;
+}) {
+  const [checkNumber, setCheckNumber] = useState("");
+
+  async function record() {
+    await fetch(`/api/cases/${caseId}/ownership-request`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ moduleId: module.id, checkNumber }),
+    });
+    alert("Request recorded");
+  }
+
+  return (
+    <div className="p-8 flex flex-col gap-4">
+      <h1 className="text-xl font-semibold">Ownership Request</h1>
+      <p>State: {module.state}</p>
+      <p>Send a check for ${module.fee} to:</p>
+      <pre className="bg-gray-100 p-2 whitespace-pre-wrap">
+        {module.address}
+      </pre>
+      <label className="flex flex-col">
+        Check Number
+        <input
+          type="text"
+          value={checkNumber}
+          onChange={(e) => setCheckNumber(e.target.value)}
+          className="border p-1"
+        />
+      </label>
+      <button
+        type="button"
+        onClick={record}
+        className="bg-blue-500 text-white px-2 py-1 rounded"
+      >
+        Mark as Requested
+      </button>
+    </div>
+  );
+}

--- a/src/app/cases/[id]/ownership/page.tsx
+++ b/src/app/cases/[id]/ownership/page.tsx
@@ -1,0 +1,17 @@
+import { getCase } from "@/lib/caseStore";
+import { ownershipModules } from "@/lib/ownershipModules";
+import OwnershipEditor from "./OwnershipEditor";
+
+export const dynamic = "force-dynamic";
+
+export default async function OwnershipPage({
+  params,
+}: { params: { id: string } }) {
+  const { id } = await params;
+  const c = getCase(id);
+  if (!c) return <div className="p-8">Case not found</div>;
+  const state = c.analysis?.vehicle?.licensePlateState?.toLowerCase();
+  const mod = state ? ownershipModules[state] : undefined;
+  if (!mod) return <div className="p-8">No module for this state</div>;
+  return <OwnershipEditor caseId={id} module={mod} />;
+}

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -15,6 +15,12 @@ export default function CaseToolbar({ caseId }: { caseId: string }) {
           >
             Draft Email to Authorities
           </Link>
+          <Link
+            href={`/cases/${caseId}/ownership`}
+            className="block px-4 py-2 hover:bg-gray-100"
+          >
+            Request Ownership Info
+          </Link>
         </div>
       </details>
     </div>

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -23,6 +23,7 @@ export interface Case {
   analysisStatus: "pending" | "complete";
   analysisStatusCode?: number | null;
   sentEmails?: SentEmail[];
+  ownershipRequests?: OwnershipRequest[];
 }
 
 export interface SentEmail {
@@ -30,6 +31,12 @@ export interface SentEmail {
   body: string;
   attachments: string[];
   sentAt: string;
+}
+
+export interface OwnershipRequest {
+  moduleId: string;
+  requestedAt: string;
+  checkNumber?: string | null;
 }
 
 const dataFile = process.env.CASE_STORE_FILE
@@ -50,6 +57,7 @@ function loadCases(): Case[] {
       photoTimes: c.photoTimes ?? {},
       analysisStatus: c.analysisStatus ?? (c.analysis ? "complete" : "pending"),
       sentEmails: c.sentEmails ?? [],
+      ownershipRequests: c.ownershipRequests ?? [],
     }));
   } catch {
     return [];
@@ -113,6 +121,7 @@ export function createCase(
     analysisStatus: "pending",
     analysisStatusCode: null,
     sentEmails: [],
+    ownershipRequests: [],
   };
   cases.push(newCase);
   saveCases(cases);
@@ -199,6 +208,20 @@ export function addCaseEmail(id: string, email: SentEmail): Case | undefined {
   if (idx === -1) return undefined;
   const list = cases[idx].sentEmails ?? [];
   cases[idx].sentEmails = [...list, email];
+  saveCases(cases);
+  caseEvents.emit("update", cases[idx]);
+  return cases[idx];
+}
+
+export function addOwnershipRequest(
+  id: string,
+  request: OwnershipRequest,
+): Case | undefined {
+  const cases = loadCases();
+  const idx = cases.findIndex((c) => c.id === id);
+  if (idx === -1) return undefined;
+  const list = cases[idx].ownershipRequests ?? [];
+  cases[idx].ownershipRequests = [...list, request];
   saveCases(cases);
   caseEvents.emit("update", cases[idx]);
   return cases[idx];

--- a/src/lib/ownershipModules.ts
+++ b/src/lib/ownershipModules.ts
@@ -1,0 +1,26 @@
+export interface OwnershipModule {
+  id: string;
+  state: string;
+  address: string;
+  fee: number;
+  requiresCheck: boolean;
+}
+
+export const ownershipModules: Record<string, OwnershipModule> = {
+  il: {
+    id: "il",
+    state: "Illinois",
+    address:
+      "Driver Records Unit\n2701 S. Dirksen Pkwy.\nSpringfield, IL 62723",
+    fee: 12,
+    requiresCheck: true,
+  },
+  ca: {
+    id: "ca",
+    state: "California",
+    address:
+      "DMV Vehicle History Section\nP.O. Box 944247\nSacramento, CA 94244-2470",
+    fee: 5,
+    requiresCheck: true,
+  },
+};


### PR DESCRIPTION
## Summary
- create `ownershipModules` listing state request info
- extend `Case` model with `ownershipRequests`
- track ownership requests in the case store
- expose POST `/api/cases/[id]/ownership-request` route
- add ownership request UI and menu link

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684994dd387c832b82aab56828594faf