### PR TITLE
Fix Docker build architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 RUN npm run build && npm prune --production
 
 # Runtime image
-FROM node:20-bookworm-slim AS runner
+FROM node:20-bookworm AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000

--- a/README.md
+++ b/README.md
@@ -152,4 +152,7 @@ To run the app in containers, install Docker and Docker Compose then build the s
 docker compose up -d
 ```
 
+The compose file sets `platform: \"linux/amd64\"` so builds use an architecture
+with prebuilt Node.js binaries.
+
 Traefik will serve the application at `https://730op.synology.me/photo-citation` using the labels defined in `docker-compose.yml`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.8"
 
 services:
   app:
+    platform: "linux/amd64"
     build: .
     env_file:
       - .env


### PR DESCRIPTION
## Summary
- use full Node image for runtime stage
- build amd64 images via docker-compose
- document architecture requirement in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849bba43edc832bac05b7a681e785ee