### PR TITLE
Add Storybook stories for pages

### DIFF
--- a/src/app/cases/ClientCasesPage.stories.tsx
+++ b/src/app/cases/ClientCasesPage.stories.tsx
@@ -1,0 +1,56 @@
+import type { Case } from "@/lib/caseStore";
+import type { Meta, StoryObj } from "@storybook/react";
+import ClientCasesPage from "./ClientCasesPage";
+
+const meta: Meta<typeof ClientCasesPage> = {
+  component: ClientCasesPage,
+  title: "Pages/ClientCasesPage",
+};
+export default meta;
+
+type Story = StoryObj<typeof ClientCasesPage>;
+
+const caseBase: Omit<Case, "id"> = {
+  photos: ["https://placehold.co/600x400?text=photo"],
+  photoTimes: {},
+  createdAt: new Date().toISOString(),
+  gps: { lat: 41.88, lon: -87.78 },
+  streetAddress: null,
+  intersection: null,
+  vin: null,
+  vinOverride: null,
+  analysis: null,
+  analysisOverrides: null,
+  analysisStatus: "pending",
+  analysisStatusCode: null,
+  sentEmails: [],
+  ownershipRequests: [],
+};
+
+export const MultipleCases: Story = {
+  render: () => {
+    const cases: Case[] = [
+      {
+        id: "1",
+        ...caseBase,
+        analysis: {
+          violationType: "parking",
+          details: "Blocking sidewalk",
+          vehicle: { licensePlateNumber: "ABC123" },
+          location: "Oak Park",
+          images: {},
+        },
+        analysisStatus: "complete",
+      },
+      {
+        id: "2",
+        ...caseBase,
+        photos: [
+          "https://placehold.co/600x400?text=photo2",
+          "https://placehold.co/601x400?text=photo3",
+        ],
+      },
+    ];
+    return <ClientCasesPage initialCases={cases} />;
+  },
+};

--- a/src/app/cases/[id]/ClientCasePage.stories.tsx
+++ b/src/app/cases/[id]/ClientCasePage.stories.tsx
@@ -1,0 +1,59 @@
+import type { Case } from "@/lib/caseStore";
+import type { Meta, StoryObj } from "@storybook/react";
+import ClientCasePage from "./ClientCasePage";
+
+const meta: Meta<typeof ClientCasePage> = {
+  component: ClientCasePage,
+  title: "Pages/ClientCasePage",
+};
+export default meta;
+
+type Story = StoryObj<typeof ClientCasePage>;
+
+const base: Case = {
+  id: "123",
+  photos: [
+    "https://placehold.co/600x400?text=main",
+    "https://placehold.co/601x400?text=alt",
+  ],
+  photoTimes: {},
+  createdAt: new Date().toISOString(),
+  gps: { lat: 41.88, lon: -87.78 },
+  streetAddress: "123 Main St",
+  intersection: "Main & 1st",
+  vin: "1HGCM82633A004352",
+  vinOverride: null,
+  analysis: {
+    violationType: "parking",
+    details: "Blocking sidewalk",
+    location: "Oak Park",
+    vehicle: {
+      licensePlateNumber: "ABC123",
+      model: "Civic",
+    },
+    images: {},
+  },
+  analysisOverrides: null,
+  analysisStatus: "complete",
+  analysisStatusCode: 200,
+  sentEmails: [],
+  ownershipRequests: [],
+};
+
+export const Completed: Story = {
+  render: () => <ClientCasePage caseId={base.id} initialCase={base} />,
+};
+
+export const PendingAnalysis: Story = {
+  render: () => (
+    <ClientCasePage
+      caseId="124"
+      initialCase={{
+        ...base,
+        id: "124",
+        analysis: null,
+        analysisStatus: "pending",
+      }}
+    />
+  ),
+};

--- a/src/app/settings/SettingsPage.stories.tsx
+++ b/src/app/settings/SettingsPage.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import SettingsPage from "./page";
+
+const meta: Meta<typeof SettingsPage> = {
+  component: SettingsPage,
+  title: "Pages/SettingsPage",
+};
+export default meta;
+
+type Story = StoryObj<typeof SettingsPage>;
+
+function mockFetch() {
+  const statuses = [
+    { id: "carfax", enabled: true, failureCount: 0 },
+    { id: "dmv", enabled: false, failureCount: 2 },
+  ];
+  // biome-ignore lint/suspicious/noExplicitAny: mock fetch
+  (global as any).fetch = async (url: string, options?: any) => {
+    if (options && options.method === "PUT") return new Response(null);
+    return new Response(JSON.stringify(statuses));
+  };
+}
+
+export const Default: Story = {
+  render: () => {
+    mockFetch();
+    return <SettingsPage />;
+  },
+};


### PR DESCRIPTION
## Summary
- add example stories for case list
- add example stories for individual case page
- add mock-based story for settings page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849bc052b70832bbc428d94946ecc9e