### PR TITLE
Inline override editing

### DIFF
--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -1,8 +1,19 @@
 import type { ViolationReport } from "@/lib/openai";
+import EditableText from "./EditableText";
 
 export default function AnalysisInfo({
   analysis,
-}: { analysis: ViolationReport }) {
+  onPlateChange,
+  onStateChange,
+  onClearPlate,
+  onClearState,
+}: {
+  analysis: ViolationReport;
+  onPlateChange?: (v: string) => Promise<void> | void;
+  onStateChange?: (v: string) => Promise<void> | void;
+  onClearPlate?: () => Promise<void> | void;
+  onClearState?: () => Promise<void> | void;
+}) {
   const { violationType, details, location, vehicle = {} } = analysis;
   return (
     <div className="flex flex-col gap-1 text-sm">
@@ -20,7 +31,31 @@ export default function AnalysisInfo({
         {vehicle.model ? <span>Model: {vehicle.model}</span> : null}
         {vehicle.type ? <span>Type: {vehicle.type}</span> : null}
         {vehicle.color ? <span>Color: {vehicle.color}</span> : null}
-        {vehicle.licensePlateState || vehicle.licensePlateNumber ? (
+        {onPlateChange || onStateChange ? (
+          <span className="inline-flex items-center gap-1">
+            Plate:
+            {onStateChange ? (
+              <EditableText
+                value={vehicle.licensePlateState ?? ""}
+                onSubmit={onStateChange}
+                onClear={onClearState}
+                placeholder="state"
+              />
+            ) : vehicle.licensePlateState ? (
+              <span>{vehicle.licensePlateState}</span>
+            ) : null}
+            {onPlateChange ? (
+              <EditableText
+                value={vehicle.licensePlateNumber ?? ""}
+                onSubmit={onPlateChange}
+                onClear={onClearPlate}
+                placeholder="plate"
+              />
+            ) : vehicle.licensePlateNumber ? (
+              <span>{vehicle.licensePlateNumber}</span>
+            ) : null}
+          </span>
+        ) : vehicle.licensePlateState || vehicle.licensePlateNumber ? (
           <span>
             Plate:{" "}
             {vehicle.licensePlateState ? `${vehicle.licensePlateState} ` : ""}

--- a/src/app/components/EditableText.tsx
+++ b/src/app/components/EditableText.tsx
@@ -1,0 +1,70 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+export default function EditableText({
+  value,
+  onSubmit,
+  onClear,
+  placeholder,
+}: {
+  value: string;
+  onSubmit: (v: string) => Promise<void> | void;
+  onClear?: () => Promise<void> | void;
+  placeholder?: string;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [text, setText] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setText(value);
+  }, [value]);
+
+  function start() {
+    setEditing(true);
+    setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 0);
+  }
+
+  async function finish() {
+    setEditing(false);
+    if (text !== value) {
+      await onSubmit(text);
+    }
+  }
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        type="text"
+        value={text}
+        placeholder={placeholder}
+        onChange={(e) => setText(e.target.value)}
+        onBlur={finish}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.currentTarget.blur();
+          }
+        }}
+        className="border p-1 text-sm"
+      />
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span>{value || placeholder}</span>
+      <button type="button" onClick={start} className="text-gray-500">
+        ✎
+      </button>
+      {onClear && value ? (
+        <button type="button" onClick={onClear} className="text-gray-500">
+          ×
+        </button>
+      ) : null}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- add `EditableText` component for inline editing
- update `AnalysisInfo` to show inline editable plate/state fields
- refactor `ClientCasePage` to use inline editing for VIN, license plate, and state

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849beb1e848832bad22062df1d7e832