### PR TITLE
Fix Docker build dependency installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # Install dependencies only, no dev dependencies after build
 FROM node:20-bookworm AS deps
 WORKDIR /app
-COPY package.json package-lock.json ./
-RUN npm ci
+COPY package.json ./
+RUN npm install
 
 # Build the application
 FROM node:20-bookworm AS builder


### PR DESCRIPTION
## Summary
- install dependencies without package-lock during Docker build

## Testing
- `npm run format` *(fails: biome not found)*
- `npm install --no-audit --no-fund --progress=false` *(fails due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_6849c727fea4832bacf6c42707189ab7