### PR TITLE
Add split layout for cases

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -9,8 +9,10 @@ import MapPreview from "../components/MapPreview";
 
 export default function ClientCasesPage({
   initialCases,
+  selectedId,
 }: {
   initialCases: Case[];
+  selectedId?: string;
 }) {
   const [cases, setCases] = useState(initialCases);
 
@@ -34,7 +36,10 @@ export default function ClientCasesPage({
       <h1 className="text-xl font-bold mb-4">Cases</h1>
       <ul className="grid gap-4">
         {cases.map((c) => (
-          <li key={c.id} className="border p-2">
+          <li
+            key={c.id}
+            className={`border p-2 ${selectedId === c.id ? "bg-gray-100" : ""}`}
+          >
             <Link href={`/cases/${c.id}`} className="flex items-start gap-4">
               <div className="relative">
                 <Image

--- a/src/app/cases/layout.tsx
+++ b/src/app/cases/layout.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+import { getCases } from "../../lib/caseStore";
+import ClientCasesPage from "./ClientCasesPage";
+
+export const dynamic = "force-dynamic";
+
+export default function CasesLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: { id?: string };
+}) {
+  const cases = getCases();
+  return (
+    <div className="grid grid-cols-[20%_80%] h-full">
+      <div className="border-r overflow-y-auto">
+        <ClientCasesPage initialCases={cases} selectedId={params.id} />
+      </div>
+      <div className="overflow-y-auto">{children}</div>
+    </div>
+  );
+}

--- a/src/app/cases/page.tsx
+++ b/src/app/cases/page.tsx
@@ -1,9 +1,8 @@
-import { getCases } from "../../lib/caseStore";
-import ClientCasesPage from "./ClientCasesPage";
-
-export const dynamic = "force-dynamic";
-
 export default function CasesPage() {
-  const cases = getCases();
-  return <ClientCasesPage initialCases={cases} />;
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">Cases</h1>
+      <p>Select a case to view details.</p>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- create `cases/layout.tsx` to show list left and case right
- update `ClientCasesPage` to highlight selected case
- show placeholder text on `/cases` page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849cc796a28832b88976c006d1092dd