### PR TITLE
Fix independent scrolling for case layout

### DIFF
--- a/src/app/cases/layout.tsx
+++ b/src/app/cases/layout.tsx
@@ -13,7 +13,7 @@ export default function CasesLayout({
 }) {
   const cases = getCases();
   return (
-    <div className="grid grid-cols-[20%_80%] h-full">
+    <div className="grid grid-cols-[20%_80%] h-[calc(100vh-4rem)]">
       <div className="border-r overflow-y-auto">
         <ClientCasesPage initialCases={cases} selectedId={params.id} />
       </div>


### PR DESCRIPTION
## Summary
- maintain full-height layout for case overview page

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849d047d6f0832ba9cf6366ca711a58