### PR TITLE
Responsive layout improvements

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -44,7 +44,7 @@ export default function ClientCasesPage({
               <div className="relative">
                 <Image
                   src={getRepresentativePhoto(c)}
-                  alt=""
+                  alt="case thumbnail"
                   width={80}
                   height={60}
                 />
@@ -58,6 +58,7 @@ export default function ClientCasesPage({
                   lon={c.gps.lon}
                   width={80}
                   height={60}
+                  className="w-20 aspect-[4/3]"
                 />
               ) : null}
               <div className="flex flex-col text-sm gap-1">

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -188,7 +188,7 @@ export default function ClientCasePage({
         <>
           {selectedPhoto ? (
             <>
-              <div className="w-[600px] h-[400px] relative">
+              <div className="relative w-full aspect-[3/2] md:max-w-2xl">
                 <Image
                   src={selectedPhoto}
                   alt="uploaded"
@@ -233,8 +233,13 @@ export default function ClientCasePage({
                       : "ring-1 ring-transparent"
                   }
                 >
-                  <div className="relative w-[80px] h-[60px]">
-                    <Image src={p} alt="" fill className="object-cover" />
+                  <div className="relative w-20 aspect-[4/3]">
+                    <Image
+                      src={p}
+                      alt="case photo"
+                      fill
+                      className="object-cover"
+                    />
                   </div>
                   {(() => {
                     const t = caseData.photoTimes[p];
@@ -254,7 +259,7 @@ export default function ClientCasePage({
                 </button>
               </div>
             ))}
-            <label className="flex items-center justify-center border rounded w-[80px] h-[60px] text-sm text-gray-500 cursor-pointer">
+            <label className="flex items-center justify-center border rounded w-20 aspect-[4/3] text-sm text-gray-500 cursor-pointer">
               + add image
               <input
                 ref={fileInputRef}
@@ -279,6 +284,7 @@ export default function ClientCasePage({
                 lon={caseData.gps.lon}
                 width={600}
                 height={300}
+                className="w-full aspect-[2/1] md:max-w-xl"
               />
             </>
           ) : null}

--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -58,7 +58,13 @@ export default function DraftEditor({
       </label>
       <div className="flex gap-2 flex-wrap">
         {attachments.map((p) => (
-          <Image key={p} src={p} alt="" width={120} height={90} />
+          <Image
+            key={p}
+            src={p}
+            alt="email attachment"
+            width={120}
+            height={90}
+          />
         ))}
       </div>
       <button

--- a/src/app/components/CaseLayout.tsx
+++ b/src/app/components/CaseLayout.tsx
@@ -14,7 +14,7 @@ export default function CaseLayout({
   return (
     <div className="p-8 flex flex-col gap-4">
       <div className="sticky top-0 bg-white z-10">{header}</div>
-      <div className="grid grid-cols-1 md:grid-cols-[30%_70%] gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-[35%_65%] lg:grid-cols-[30%_70%] gap-4 md:gap-6">
         <div>{left}</div>
         <div className="flex flex-col gap-4">{right}</div>
       </div>

--- a/src/app/components/MapPreview.tsx
+++ b/src/app/components/MapPreview.tsx
@@ -5,15 +5,30 @@ export default function MapPreview({
   lon,
   width,
   height,
+  className,
 }: {
   lat: number;
   lon: number;
   width: number;
   height: number;
+  className?: string;
 }) {
   const key = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
   const url = key
     ? `https://maps.googleapis.com/maps/api/staticmap?center=${lat},${lon}&zoom=16&size=${width}x${height}&markers=color:red|${lat},${lon}&key=${key}`
     : `https://staticmap.openstreetmap.de/staticmap.php?center=${lat},${lon}&zoom=16&size=${width}x${height}&markers=${lat},${lon},red`;
-  return <Image src={url} alt="map preview" width={width} height={height} />;
+  return (
+    <div
+      className={`relative ${className ?? ""}`}
+      style={{ aspectRatio: `${width} / ${height}` }}
+    >
+      <Image
+        src={url}
+        alt={`Map preview at ${lat}, ${lon}`}
+        fill
+        className="object-cover"
+        sizes="100vw"
+      />
+    </div>
+  );
 }

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -20,7 +20,7 @@ export default function NavBar() {
         ref={inputRef}
         onChange={(e) => uploadCase(e.target.files)}
       />
-      <div className="flex gap-6 text-sm">
+      <div className="flex gap-4 sm:gap-6 md:gap-8 text-sm">
         <button
           type="button"
           className="hover:text-gray-300"


### PR DESCRIPTION
## Summary
- make case layout grid responsive
- improve map preview for responsive sizes
- tweak nav bar spacing
- add alt text for all images

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849d1118f2c832ba258426f44f7f637