### PR TITLE
Add case deletion

### DIFF
--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -1,4 +1,4 @@
-import { getCase } from "@/lib/caseStore";
+import { deleteCase, getCase } from "@/lib/caseStore";
 import { NextResponse } from "next/server";
 
 export async function GET(
@@ -11,4 +11,16 @@ export async function GET(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
   return NextResponse.json(c);
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  const { id } = await params;
+  const ok = deleteCase(id);
+  if (!ok) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true });
 }

--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -19,8 +19,11 @@ export default function ClientCasesPage({
   useEffect(() => {
     const es = new EventSource("/api/cases/stream");
     es.onmessage = (e) => {
-      const data = JSON.parse(e.data) as Case;
+      const data = JSON.parse(e.data) as Case & { deleted?: boolean };
       setCases((prev) => {
+        if (data.deleted) {
+          return prev.filter((c) => c.id !== data.id);
+        }
         const idx = prev.findIndex((c) => c.id === data.id);
         if (idx === -1) return [...prev, data];
         const copy = [...prev];

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -34,6 +34,22 @@ export default function CaseToolbar({
           >
             Request Ownership Info
           </Link>
+          <button
+            type="button"
+            onClick={async () => {
+              const code = Math.random().toString(36).slice(2, 6);
+              const input = prompt(
+                `Type '${code}' to confirm deleting this case.`,
+              );
+              if (input === code) {
+                await fetch(`/api/cases/${caseId}`, { method: "DELETE" });
+                window.location.href = "/cases";
+              }
+            }}
+            className="block px-4 py-2 hover:bg-gray-100 w-full text-left"
+          >
+            Delete Case
+          </button>
         </div>
       </details>
     </div>

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -226,3 +226,13 @@ export function addOwnershipRequest(
   caseEvents.emit("update", cases[idx]);
   return cases[idx];
 }
+
+export function deleteCase(id: string): boolean {
+  const cases = loadCases();
+  const idx = cases.findIndex((c) => c.id === id);
+  if (idx === -1) return false;
+  const [removed] = cases.splice(idx, 1);
+  saveCases(cases);
+  caseEvents.emit("update", { id: removed.id, deleted: true });
+  return true;
+}

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -106,4 +106,18 @@ describe("caseStore", () => {
     const stored = getCase(c.id);
     expect(stored?.photos).toEqual(["/bar.jpg"]);
   });
+
+  it("deletes a case", () => {
+    const { createCase, deleteCase, getCase, getCases } = caseStore;
+    const c = createCase(
+      "/foo.jpg",
+      null,
+      undefined,
+      "2020-01-09T00:00:00.000Z",
+    );
+    const ok = deleteCase(c.id);
+    expect(ok).toBe(true);
+    expect(getCase(c.id)).toBeUndefined();
+    expect(getCases()).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary
- implement `deleteCase` in caseStore and expose via API
- support delete events in ClientCasesPage
- allow user to delete cases from CaseToolbar with a confirmation code
- cover deleting cases with a new test

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849e2623d58832b98a2e371832cee6c