### PR TITLE
Enable multi-case selection with summary view

### DIFF
--- a/src/app/cases/ClientCasesPage.stories.tsx
+++ b/src/app/cases/ClientCasesPage.stories.tsx
@@ -51,6 +51,6 @@ export const MultipleCases: Story = {
         ],
       },
     ];
-    return <ClientCasesPage initialCases={cases} />;
+    return <ClientCasesPage initialCases={cases} selectedIds={[]} />;
   },
 };

--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Image from "next/image";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import type { Case } from "../../lib/caseStore";
 import { getRepresentativePhoto } from "../../lib/caseUtils";
@@ -9,12 +9,13 @@ import MapPreview from "../components/MapPreview";
 
 export default function ClientCasesPage({
   initialCases,
-  selectedId,
+  selectedIds,
 }: {
   initialCases: Case[];
-  selectedId?: string;
+  selectedIds: string[];
 }) {
   const [cases, setCases] = useState(initialCases);
+  const router = useRouter();
 
   useEffect(() => {
     const es = new EventSource("/api/cases/stream");
@@ -41,9 +42,20 @@ export default function ClientCasesPage({
         {cases.map((c) => (
           <li
             key={c.id}
-            className={`border p-2 ${selectedId === c.id ? "bg-gray-100" : ""}`}
+            className={`border p-2 ${selectedIds.includes(c.id) ? "bg-gray-100" : ""}`}
           >
-            <Link href={`/cases/${c.id}`} className="flex items-start gap-4">
+            <button
+              type="button"
+              onClick={(e) => {
+                if (e.shiftKey) {
+                  const ids = Array.from(new Set([...selectedIds, c.id]));
+                  router.push(`/cases?ids=${ids.join(",")}`);
+                } else {
+                  router.push(`/cases/${c.id}`);
+                }
+              }}
+              className="flex items-start gap-4 w-full text-left"
+            >
               <div className="relative">
                 <Image
                   src={getRepresentativePhoto(c)}
@@ -79,7 +91,7 @@ export default function ClientCasesPage({
                   <span className="text-gray-500">Analyzing photo...</span>
                 )}
               </div>
-            </Link>
+            </button>
           </li>
         ))}
       </ul>

--- a/src/app/cases/layout.tsx
+++ b/src/app/cases/layout.tsx
@@ -7,15 +7,22 @@ export const dynamic = "force-dynamic";
 export default function CasesLayout({
   children,
   params,
+  searchParams,
 }: {
   children: ReactNode;
   params: { id?: string };
+  searchParams: { ids?: string };
 }) {
   const cases = getCases();
+  const selectedIds = searchParams.ids
+    ? searchParams.ids.split(",").filter(Boolean)
+    : params.id
+      ? [params.id]
+      : [];
   return (
     <div className="grid grid-cols-[20%_80%] h-[calc(100vh-4rem)]">
       <div className="border-r overflow-y-auto">
-        <ClientCasesPage initialCases={cases} selectedId={params.id} />
+        <ClientCasesPage initialCases={cases} selectedIds={selectedIds} />
       </div>
       <div className="overflow-y-auto">{children}</div>
     </div>

--- a/src/app/cases/page.tsx
+++ b/src/app/cases/page.tsx
@@ -1,6 +1,21 @@
 export const dynamic = "force-dynamic";
 
-export default function CasesPage() {
+import type { Case } from "../../lib/caseStore";
+import { getCase } from "../../lib/caseStore";
+import CaseSummary from "../components/CaseSummary";
+
+export default function CasesPage({
+  searchParams = {},
+}: {
+  searchParams?: { ids?: string };
+}) {
+  const ids = searchParams.ids
+    ? searchParams.ids.split(",").filter(Boolean)
+    : [];
+  if (ids.length > 1) {
+    const cases = ids.map((id) => getCase(id)).filter(Boolean) as Case[];
+    return <CaseSummary cases={cases} />;
+  }
   return (
     <div className="p-8">
       <h1 className="text-xl font-bold mb-4">Cases</h1>

--- a/src/app/components/CaseSummary.tsx
+++ b/src/app/components/CaseSummary.tsx
@@ -1,0 +1,29 @@
+import type { Case } from "@/lib/caseStore";
+
+export default function CaseSummary({ cases }: { cases: Case[] }) {
+  if (cases.length === 0) return null;
+  const first = cases[0];
+  function allEqual<T>(getter: (c: Case) => T): T | undefined {
+    const value = getter(first);
+    return cases.every((c) => getter(c) === value) ? value : undefined;
+  }
+  const violation = allEqual((c) => c.analysis?.violationType);
+  const plateNum = allEqual((c) => c.analysis?.vehicle?.licensePlateNumber);
+  const plateState = allEqual((c) => c.analysis?.vehicle?.licensePlateState);
+  const vin = allEqual((c) => c.vin);
+
+  return (
+    <div className="p-8 flex flex-col gap-2">
+      <h1 className="text-xl font-semibold">Case Summary</h1>
+      <p className="text-sm text-gray-500">{cases.length} cases selected.</p>
+      {violation ? <p>Violation: {violation}</p> : null}
+      {plateNum || plateState ? (
+        <p>
+          Plate: {plateState ? `${plateState} ` : ""}
+          {plateNum}
+        </p>
+      ) : null}
+      {vin ? <p>VIN: {vin}</p> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- support multiple case selection by tracking `ids` query param
- show selected cases on list
- add `CaseSummary` component for multi-case view
- update stories

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849f43bdfb4832b9226b5e39531b5db