### PR TITLE
Fix searchParams null access

### DIFF
--- a/src/app/cases/layout.tsx
+++ b/src/app/cases/layout.tsx
@@ -7,11 +7,11 @@ export const dynamic = "force-dynamic";
 export default function CasesLayout({
   children,
   params,
-  searchParams,
+  searchParams = {},
 }: {
   children: ReactNode;
   params: { id?: string };
-  searchParams: { ids?: string };
+  searchParams?: { ids?: string };
 }) {
   const cases = getCases();
   const selectedIds = searchParams.ids


### PR DESCRIPTION
## Summary
- prevent undefined errors on `/cases` pages by defaulting `searchParams`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849f763ed24832ba62e123180699384