### PR TITLE
Fix async params typing in route handlers

### DIFF
--- a/src/app/api/cases/[id]/override/route.ts
+++ b/src/app/api/cases/[id]/override/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from "next/server";
 
 export async function PUT(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
   const overrides = (await req.json()) as Record<string, unknown>;
@@ -18,7 +18,7 @@ export async function PUT(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
   const updated = setCaseAnalysisOverrides(id, null);

--- a/src/app/api/cases/[id]/ownership-request/route.ts
+++ b/src/app/api/cases/[id]/ownership-request/route.ts
@@ -3,9 +3,9 @@ import { NextResponse } from "next/server";
 
 export async function POST(
   req: Request,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = params;
+  const { id } = await params;
   const { moduleId, checkNumber } = (await req.json()) as {
     moduleId: string;
     checkNumber?: string | null;

--- a/src/app/api/cases/[id]/photos/route.ts
+++ b/src/app/api/cases/[id]/photos/route.ts
@@ -5,7 +5,7 @@ import { NextResponse } from "next/server";
 
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
   const { photo } = (await req.json()) as { photo: string };

--- a/src/app/api/cases/[id]/report/route.ts
+++ b/src/app/api/cases/[id]/report/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from "next/server";
 
 export async function GET(
   _req: Request,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
   const c = getCase(id);
@@ -22,9 +22,9 @@ export async function GET(
 
 export async function POST(
   req: Request,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = params;
+  const { id } = await params;
   const { subject, body, attachments } = (await req.json()) as {
     subject: string;
     body: string;

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 
 export async function GET(
   req: Request,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
   const c = getCase(id);
@@ -15,7 +15,7 @@ export async function GET(
 
 export async function DELETE(
   req: Request,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
   const ok = deleteCase(id);

--- a/src/app/api/cases/[id]/vin/route.ts
+++ b/src/app/api/cases/[id]/vin/route.ts
@@ -3,9 +3,9 @@ import { NextResponse } from "next/server";
 
 export async function PUT(
   req: Request,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = params;
+  const { id } = await params;
   const { vin } = (await req.json()) as { vin: string | null };
   const updated = setCaseVinOverride(id, vin);
   if (!updated) {
@@ -17,9 +17,9 @@ export async function PUT(
 
 export async function DELETE(
   _req: Request,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = params;
+  const { id } = await params;
   const updated = setCaseVinOverride(id, null);
   if (!updated) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/src/app/api/cases/stream/route.ts
+++ b/src/app/api/cases/stream/route.ts
@@ -36,7 +36,10 @@ export async function GET(req: Request) {
         controller.close();
       });
 
-      controller.oncancel = cleanup;
+      const ctrl = controller as ReadableStreamDefaultController<Uint8Array> & {
+        oncancel?: () => void;
+      };
+      ctrl.oncancel = cleanup;
     },
   });
 

--- a/src/app/api/vin-sources/[id]/route.ts
+++ b/src/app/api/vin-sources/[id]/route.ts
@@ -3,9 +3,9 @@ import { NextResponse } from "next/server";
 
 export async function PUT(
   req: Request,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = params;
+  const { id } = await params;
   const { enabled } = (await req.json()) as { enabled: boolean };
   const result = setVinSourceEnabled(id, enabled);
   if (!result) {

--- a/src/app/cases/[id]/draft/page.tsx
+++ b/src/app/cases/[id]/draft/page.tsx
@@ -7,7 +7,7 @@ export const dynamic = "force-dynamic";
 
 export default async function DraftPage({
   params,
-}: { params: { id: string } }) {
+}: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const c = getCase(id);
   if (!c) return <div className="p-8">Case not found</div>;

--- a/src/app/cases/[id]/ownership/page.tsx
+++ b/src/app/cases/[id]/ownership/page.tsx
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 
 export default async function OwnershipPage({
   params,
-}: { params: { id: string } }) {
+}: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const c = getCase(id);
   if (!c) return <div className="p-8">Case not found</div>;

--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -3,7 +3,9 @@ import ClientCasePage from "./ClientCasePage";
 
 export const dynamic = "force-dynamic";
 
-export default async function CasePage({ params }: { params: { id: string } }) {
+export default async function CasePage({
+  params,
+}: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const c = getCase(id);
   return <ClientCasePage caseId={id} initialCase={c ?? null} />;


### PR DESCRIPTION
## Summary
- update route handlers to accept asynchronous `params`
- adjust pages that use `params`
- fix stream handler typing for controller cancel

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849f6b9511c832baadc505654e874bb