### PR TITLE
Implement modal email drafting

### DIFF
--- a/src/app/cases/[id]/ComposeWrapper.stories.tsx
+++ b/src/app/cases/[id]/ComposeWrapper.stories.tsx
@@ -1,0 +1,64 @@
+import type { Case } from "@/lib/caseStore";
+import { reportModules } from "@/lib/reportModules";
+import type { Meta, StoryObj } from "@storybook/react";
+import ComposeWrapper from "./ComposeWrapper";
+
+const meta: Meta<typeof ComposeWrapper> = {
+  component: ComposeWrapper,
+  title: "Pages/ComposeWrapper",
+};
+export default meta;
+
+type Story = StoryObj<typeof ComposeWrapper>;
+
+const base: Case = {
+  id: "123",
+  photos: [
+    "https://placehold.co/600x400?text=main",
+    "https://placehold.co/601x400?text=alt",
+  ],
+  photoTimes: {},
+  createdAt: new Date().toISOString(),
+  gps: { lat: 41.88, lon: -87.78 },
+  streetAddress: "123 Main St",
+  intersection: "Main & 1st",
+  vin: "1HGCM82633A004352",
+  vinOverride: null,
+  analysis: {
+    violationType: "parking",
+    details: "Blocking sidewalk",
+    location: "Oak Park",
+    vehicle: {
+      licensePlateNumber: "ABC123",
+      model: "Civic",
+    },
+    images: {},
+  },
+  analysisOverrides: null,
+  analysisStatus: "complete",
+  analysisStatusCode: 200,
+  sentEmails: [],
+  ownershipRequests: [],
+};
+
+function mockFetch() {
+  (global as Record<string, unknown>).fetch = async (url: string) => {
+    if (url.includes(`/cases/${base.id}/report`)) {
+      return new Response(
+        JSON.stringify({
+          email: { subject: "Violation Report", body: "Report body" },
+          attachments: base.photos,
+          module: reportModules["oak-park"],
+        }),
+      );
+    }
+    return new Response(JSON.stringify(base));
+  };
+}
+
+export const Default: Story = {
+  render: () => {
+    mockFetch();
+    return <ComposeWrapper caseData={base} caseId={base.id} />;
+  },
+};

--- a/src/app/cases/[id]/ComposeWrapper.tsx
+++ b/src/app/cases/[id]/ComposeWrapper.tsx
@@ -1,0 +1,24 @@
+"use client";
+import type { Case } from "@/lib/caseStore";
+import { useRouter } from "next/navigation";
+import ClientCasePage from "./ClientCasePage";
+import DraftModal from "./draft/DraftModal";
+
+export default function ComposeWrapper({
+  caseData,
+  caseId,
+}: {
+  caseData: Case | null;
+  caseId: string;
+}) {
+  const router = useRouter();
+  return (
+    <>
+      <ClientCasePage initialCase={caseData} caseId={caseId} />
+      <DraftModal
+        caseId={caseId}
+        onClose={() => router.push(`/cases/${caseId}`)}
+      />
+    </>
+  );
+}

--- a/src/app/cases/[id]/compose/page.tsx
+++ b/src/app/cases/[id]/compose/page.tsx
@@ -1,0 +1,14 @@
+import { getCase } from "@/lib/caseStore";
+import ComposeWrapper from "../ComposeWrapper";
+
+export const dynamic = "force-dynamic";
+
+export default async function ComposePage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const { id } = params;
+  const c = getCase(id);
+  return <ComposeWrapper caseData={c ?? null} caseId={id} />;
+}

--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -2,7 +2,7 @@
 import type { EmailDraft } from "@/lib/caseReport";
 import type { ReportModule } from "@/lib/reportModules";
 import Image from "next/image";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function DraftEditor({
   initialDraft,
@@ -10,13 +10,20 @@ export default function DraftEditor({
   module,
   caseId,
 }: {
-  initialDraft: EmailDraft;
+  initialDraft?: EmailDraft;
   attachments: string[];
   module: ReportModule;
   caseId: string;
 }) {
-  const [subject, setSubject] = useState(initialDraft.subject);
-  const [body, setBody] = useState(initialDraft.body);
+  const [subject, setSubject] = useState(initialDraft?.subject || "");
+  const [body, setBody] = useState(initialDraft?.body || "");
+
+  useEffect(() => {
+    if (initialDraft) {
+      setSubject(initialDraft.subject);
+      setBody(initialDraft.body);
+    }
+  }, [initialDraft]);
 
   async function sendEmail() {
     const res = await fetch(`/api/cases/${caseId}/report`, {
@@ -29,6 +36,12 @@ export default function DraftEditor({
     } else {
       alert("Failed to send email");
     }
+  }
+
+  if (!initialDraft) {
+    return (
+      <div className="p-8">Drafting email based on case information...</div>
+    );
   }
 
   return (

--- a/src/app/cases/[id]/draft/DraftModal.stories.tsx
+++ b/src/app/cases/[id]/draft/DraftModal.stories.tsx
@@ -1,0 +1,64 @@
+import type { Case } from "@/lib/caseStore";
+import { reportModules } from "@/lib/reportModules";
+import type { Meta, StoryObj } from "@storybook/react";
+import DraftModal from "./DraftModal";
+
+const meta: Meta<typeof DraftModal> = {
+  component: DraftModal,
+  title: "Components/DraftModal",
+};
+export default meta;
+
+type Story = StoryObj<typeof DraftModal>;
+
+const base: Case = {
+  id: "123",
+  photos: [
+    "https://placehold.co/600x400?text=main",
+    "https://placehold.co/601x400?text=alt",
+  ],
+  photoTimes: {},
+  createdAt: new Date().toISOString(),
+  gps: { lat: 41.88, lon: -87.78 },
+  streetAddress: "123 Main St",
+  intersection: "Main & 1st",
+  vin: "1HGCM82633A004352",
+  vinOverride: null,
+  analysis: {
+    violationType: "parking",
+    details: "Blocking sidewalk",
+    location: "Oak Park",
+    vehicle: {
+      licensePlateNumber: "ABC123",
+      model: "Civic",
+    },
+    images: {},
+  },
+  analysisOverrides: null,
+  analysisStatus: "complete",
+  analysisStatusCode: 200,
+  sentEmails: [],
+  ownershipRequests: [],
+};
+
+function mockFetch() {
+  (global as Record<string, unknown>).fetch = async (url: string) => {
+    if (url.includes(`/cases/${base.id}/report`)) {
+      return new Response(
+        JSON.stringify({
+          email: { subject: "Violation Report", body: "Report body" },
+          attachments: base.photos,
+          module: reportModules["oak-park"],
+        }),
+      );
+    }
+    return new Response(JSON.stringify(base));
+  };
+}
+
+export const Default: Story = {
+  render: () => {
+    mockFetch();
+    return <DraftModal caseId={base.id} onClose={() => {}} />;
+  },
+};

--- a/src/app/cases/[id]/draft/DraftModal.tsx
+++ b/src/app/cases/[id]/draft/DraftModal.tsx
@@ -1,0 +1,59 @@
+"use client";
+import type { EmailDraft } from "@/lib/caseReport";
+import type { ReportModule } from "@/lib/reportModules";
+import { useEffect, useState } from "react";
+import DraftEditor from "./DraftEditor";
+
+interface DraftData {
+  email: EmailDraft;
+  attachments: string[];
+  module: ReportModule;
+}
+
+export default function DraftModal({
+  caseId,
+  onClose,
+}: {
+  caseId: string;
+  onClose: () => void;
+}) {
+  const [data, setData] = useState<DraftData | null>(null);
+
+  useEffect(() => {
+    let canceled = false;
+    fetch(`/api/cases/${caseId}/report`)
+      .then((res) => res.json())
+      .then((d) => {
+        if (!canceled) setData(d as DraftData);
+      });
+    return () => {
+      canceled = true;
+    };
+  }, [caseId]);
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded shadow max-w-xl w-full">
+        {data ? (
+          <DraftEditor
+            caseId={caseId}
+            initialDraft={data.email}
+            attachments={data.attachments}
+            module={data.module}
+          />
+        ) : (
+          <div className="p-8">Drafting email based on case information...</div>
+        )}
+        <div className="flex justify-end p-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="bg-gray-200 px-2 py-1 rounded"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -23,10 +23,16 @@ export default function CaseToolbar({
         </summary>
         <div className="absolute right-0 mt-1 bg-white border rounded shadow">
           <Link
-            href={`/cases/${caseId}/draft`}
+            href={`/cases/${caseId}/compose`}
             className="block px-4 py-2 hover:bg-gray-100"
           >
             Draft Email to Authorities
+          </Link>
+          <Link
+            href={`/cases/${caseId}/draft`}
+            className="block px-4 py-2 hover:bg-gray-100"
+          >
+            Open Full Screen Draft
           </Link>
           <Link
             href={`/cases/${caseId}/ownership`}


### PR DESCRIPTION
## Summary
- add ComposeWrapper and new `/compose` route with modal overlay
- create DraftModal client component
- update DraftEditor for loading state
- link to compose modal from case toolbar and full-screen draft option
- add stories for composing email view

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849fa4aac38832b8da8fa8f4088338e