### PR TITLE
Fix dynamic params usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@ This repository is a Next.js TypeScript project using Vitest and Biome.
 - Terminate statements with semicolons.
 - Import Node.js builtin modules using the `node:` protocol (e.g. `import fs from "node:fs";`).
 
+## Next.js Dynamic APIs
+- Type `params` and `searchParams` as `Promise` objects and `await` them before using their properties.
+
 ## Commit Messages
 - Use short commit summaries starting with a type such as `feat:`, `fix:`, or `chore:` followed by a concise description.
 

--- a/src/app/cases/[id]/compose/page.tsx
+++ b/src/app/cases/[id]/compose/page.tsx
@@ -6,9 +6,9 @@ export const dynamic = "force-dynamic";
 export default async function ComposePage({
   params,
 }: {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }) {
-  const { id } = params;
+  const { id } = await params;
   const c = getCase(id);
   return <ComposeWrapper caseData={c ?? null} caseId={id} />;
 }

--- a/src/app/cases/page.tsx
+++ b/src/app/cases/page.tsx
@@ -4,16 +4,15 @@ import type { Case } from "../../lib/caseStore";
 import { getCase } from "../../lib/caseStore";
 import CaseSummary from "../components/CaseSummary";
 
-export default function CasesPage({
-  searchParams = {},
+export default async function CasesPage({
+  searchParams,
 }: {
-  searchParams?: { ids?: string };
+  searchParams?: Promise<{ ids?: string }>;
 }) {
-  const ids = searchParams.ids
-    ? searchParams.ids.split(",").filter(Boolean)
-    : [];
-  if (ids.length > 1) {
-    const cases = ids.map((id) => getCase(id)).filter(Boolean) as Case[];
+  const { ids } = (await searchParams) ?? {};
+  const parsed = ids ? ids.split(",").filter(Boolean) : [];
+  if (parsed.length > 1) {
+    const cases = parsed.map((id) => getCase(id)).filter(Boolean) as Case[];
     return <CaseSummary cases={cases} />;
   }
   return (


### PR DESCRIPTION
## Summary
- await `params` and `searchParams` in Next.js pages
- document using `await` for dynamic params

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Unable to find an element with the text: Cases. e2e basic test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_684a22114498832bb8af4268055e9608