### PR TITLE
Add paperwork handling to LLM

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -14,8 +14,9 @@ describe("Home page", () => {
       FakeEventSource as unknown as typeof EventSource;
   });
 
-  it("shows the cases list", () => {
-    render(<Home />);
+  it("shows the cases list", async () => {
+    const ui = await Home({ searchParams: Promise.resolve({}) });
+    render(ui);
     expect(screen.getByText("Cases")).toBeInTheDocument();
   });
 });

--- a/src/lib/caseReport.ts
+++ b/src/lib/caseReport.ts
@@ -54,6 +54,12 @@ export async function draftEmail(
     type: "object",
     properties: { subject: { type: "string" }, body: { type: "string" } },
   };
+  const paperworkTexts = analysis?.images
+    ? Object.values(analysis.images)
+        .filter((i) => i.paperwork && i.paperworkText)
+        .map((i) => i.paperworkText)
+        .join("\n\n")
+    : "";
   const prompt = `Draft a short, professional email to ${mod.authorityName} reporting a vehicle violation.
 Include these details if available:
 - Violation: ${analysis?.violationType || ""}
@@ -61,6 +67,7 @@ Include these details if available:
 - Location: ${location}
 - License Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}
  - Time: ${new Date(time).toLocaleString()}
+${paperworkTexts ? `Attached paperwork:\n${paperworkTexts}` : ""}
 Mention that photos are attached. Respond with JSON matching this schema: ${JSON.stringify(
     schema,
   )}`;

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -46,6 +46,8 @@ export const violationReportSchema = z.object({
         representationScore: z.number().min(0).max(1),
         highlights: z.string().optional(),
         violation: z.boolean().optional(),
+        paperwork: z.boolean().optional(),
+        paperworkText: z.string().optional(),
       }),
     )
     .default({}),
@@ -81,6 +83,8 @@ export async function analyzeViolation(
             representationScore: { type: "number" },
             highlights: { type: "string" },
             violation: { type: "boolean" },
+            paperwork: { type: "boolean" },
+            paperworkText: { type: "string" },
           },
         },
       },
@@ -100,7 +104,7 @@ export async function analyzeViolation(
       content: [
         {
           type: "text",
-          text: `Analyze the photo${urls.length > 1 ? "s" : ""} and score each image from 0 to 1 for how well it represents the case. Indicate with a boolean if each photo depicts a violation. Also provide a short description of the evidence each image adds. Use these filenames as keys: ${names.join(", ")}. Respond with JSON matching this schema: ${JSON.stringify(
+          text: `Analyze the photo${urls.length > 1 ? "s" : ""} and score each image from 0 to 1 for how well it represents the case. Indicate with a boolean if each photo depicts a violation. If an image is paperwork such as a letter or form, set a paperwork flag and transcribe all text from it. Also provide a short description of the evidence each image adds. Use these filenames as keys: ${names.join(", ")}. Respond with JSON matching this schema: ${JSON.stringify(
             schema,
           )}`,
         },


### PR DESCRIPTION
## Summary
- classify uploaded images as violation evidence or paperwork
- OCR paperwork images and include text in case analysis
- include paperwork text when drafting email
- adjust Home page test for async component

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a35bb0770832ba58aa7cfa1be9b0b