### PR TITLE
Fix truncated OpenAI responses

### DIFF
--- a/src/lib/caseReport.ts
+++ b/src/lib/caseReport.ts
@@ -86,7 +86,7 @@ Mention that photos are attached. Respond with JSON matching this schema: ${JSON
     const res = await openai.chat.completions.create({
       model: "gpt-4o",
       messages,
-      max_tokens: 300,
+      max_tokens: 800,
       response_format: { type: "json_object" },
     });
     const text = res.choices[0]?.message?.content ?? "{}";
@@ -149,7 +149,7 @@ Mention that photos are attached again. Respond with JSON matching this schema: 
     const res = await openai.chat.completions.create({
       model: "gpt-4o",
       messages,
-      max_tokens: 300,
+      max_tokens: 800,
       response_format: { type: "json_object" },
     });
     const text = res.choices[0]?.message?.content ?? "{}";

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -119,7 +119,7 @@ export async function analyzeViolation(
     const response = await openai.chat.completions.create({
       model: "gpt-4o",
       messages,
-      max_tokens: 300,
+      max_tokens: 800,
       response_format: { type: "json_object" },
     });
     const text = response.choices[0]?.message?.content ?? "{}";


### PR DESCRIPTION
## Summary
- increase `max_tokens` for OpenAI calls so responses aren't truncated

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684abceb0ce8832baaf3fc2b4807a4fe