### PR TITLE
Handle analysis failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ npm run reanalyze
 This command scans stored cases and reprocesses any that meet the retry
 criteria.
 
+If analysis fails, the case page shows a red error message explaining why.
+Common issues include the AI response being cut off, invalid JSON, or not
+matching the expected schema. In most cases you can simply retry the analysis.
+If the problem persists, contact the project maintainers for help.
+
 If the uploaded image contains GPS EXIF data, the latitude and longitude are
 extracted and saved with the case information.
 

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -320,6 +320,18 @@ export default function ClientCasePage({
             <p className="text-sm text-gray-500">Updating analysis...</p>
           ) : null}
         </div>
+      ) : caseData.analysisError ? (
+        <p className="text-sm text-red-600">
+          {caseData.analysisError === "truncated"
+            ? "Analysis failed because the AI response was cut off. Please try again."
+            : caseData.analysisError === "parse"
+              ? "Analysis failed due to invalid JSON from the AI. Please try again."
+              : "Analysis failed because the AI response did not match the expected format. Please retry."}
+        </p>
+      ) : caseData.analysisStatusCode && caseData.analysisStatusCode >= 400 ? (
+        <p className="text-sm text-red-600">
+          Analysis failed. Please try again later.
+        </p>
       ) : (
         <p className="text-sm text-gray-500">Analyzing photo...</p>
       )}

--- a/src/generated/zod/caseStore.ts
+++ b/src/generated/zod/caseStore.ts
@@ -36,6 +36,10 @@ export const caseSchema = z.object({
   analysisOverrides: violationReportSchema.partial().optional().nullable(),
   analysisStatus: z.union([z.literal("pending"), z.literal("complete")]),
   analysisStatusCode: z.number().optional().nullable(),
+  analysisError: z
+    .union([z.literal("truncated"), z.literal("parse"), z.literal("schema")])
+    .optional()
+    .nullable(),
   sentEmails: z.array(sentEmailSchema).optional(),
   ownershipRequests: z.array(ownershipRequestSchema).optional(),
 });

--- a/src/lib/__tests__/analyzeViolation.test.ts
+++ b/src/lib/__tests__/analyzeViolation.test.ts
@@ -1,0 +1,41 @@
+import type { ChatCompletion } from "openai/resources/chat/completions";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AnalysisError, analyzeViolation, openai } from "../openai";
+
+const imgs = [{ url: "data:image/png;base64,AA", filename: "foo.png" }];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("analyzeViolation", () => {
+  it("classifies cut off responses", async () => {
+    vi.spyOn(openai.chat.completions, "create").mockResolvedValue({
+      choices: [{ message: { content: "{" }, finish_reason: "length" }],
+    } as unknown as ChatCompletion);
+
+    await expect(analyzeViolation(imgs)).rejects.toMatchObject({
+      kind: "truncated",
+    });
+  });
+
+  it("classifies parse failures", async () => {
+    vi.spyOn(openai.chat.completions, "create").mockResolvedValue({
+      choices: [{ message: { content: "oops" }, finish_reason: "stop" }],
+    } as unknown as ChatCompletion);
+
+    await expect(analyzeViolation(imgs)).rejects.toMatchObject({
+      kind: "parse",
+    });
+  });
+
+  it("classifies schema mismatches", async () => {
+    vi.spyOn(openai.chat.completions, "create").mockResolvedValue({
+      choices: [{ message: { content: "{}" }, finish_reason: "stop" }],
+    } as unknown as ChatCompletion);
+
+    await expect(analyzeViolation(imgs)).rejects.toMatchObject({
+      kind: "schema",
+    });
+  });
+});

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -24,6 +24,7 @@ export interface Case {
   /** @zod.enum(["pending", "complete"]) */
   analysisStatus: "pending" | "complete";
   analysisStatusCode?: number | null;
+  analysisError?: "truncated" | "parse" | "schema" | null;
   sentEmails?: SentEmail[];
   ownershipRequests?: OwnershipRequest[];
 }
@@ -124,6 +125,7 @@ export function createCase(
     analysisOverrides: null,
     analysisStatus: "pending",
     analysisStatusCode: null,
+    analysisError: null,
     sentEmails: [],
     ownershipRequests: [],
   };


### PR DESCRIPTION
## Summary
- communicate to users when analysis fails
- differentiate cut off JSON, parse errors and schema mismatch

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684abf196550832bb820ba269b6ab954