### PR TITLE
Fix override clear buttons

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -172,6 +172,12 @@ export default function ClientCasePage({
   const violationIdentified =
     caseData.analysisStatus === "complete" && hasViolation(caseData.analysis);
 
+  const vinOverridden = caseData.vinOverride !== null;
+  const plateNumberOverridden =
+    caseData.analysisOverrides?.vehicle?.licensePlateNumber !== undefined;
+  const plateStateOverridden =
+    caseData.analysisOverrides?.vehicle?.licensePlateState !== undefined;
+
   return (
     <CaseLayout
       header={
@@ -300,7 +306,7 @@ export default function ClientCasePage({
             <EditableText
               value={vin}
               onSubmit={updateVinFn}
-              onClear={clearVin}
+              onClear={vinOverridden ? clearVin : undefined}
               placeholder="VIN"
             />
           </p>
@@ -313,8 +319,8 @@ export default function ClientCasePage({
             analysis={caseData.analysis}
             onPlateChange={updatePlateNumber}
             onStateChange={updatePlateStateFn}
-            onClearPlate={clearPlateNumber}
-            onClearState={clearPlateState}
+            onClearPlate={plateNumberOverridden ? clearPlateNumber : undefined}
+            onClearState={plateStateOverridden ? clearPlateState : undefined}
           />
           {caseData.analysisStatus === "pending" ? (
             <p className="text-sm text-gray-500">Updating analysis...</p>


### PR DESCRIPTION
## Summary
- show VIN and plate clear buttons only when overrides exist

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684abdc9fd44832b9977cee464afb4e0