### PR TITLE
Add full-screen toggle and image fix for draft modal

### DIFF
--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -77,6 +77,7 @@ export default function DraftEditor({
             alt="email attachment"
             width={120}
             height={90}
+            className="object-contain"
           />
         ))}
       </div>

--- a/src/app/cases/[id]/draft/DraftModal.tsx
+++ b/src/app/cases/[id]/draft/DraftModal.tsx
@@ -18,6 +18,7 @@ export default function DraftModal({
   onClose: () => void;
 }) {
   const [data, setData] = useState<DraftData | null>(null);
+  const [fullScreen, setFullScreen] = useState(false);
 
   useEffect(() => {
     let canceled = false;
@@ -32,8 +33,12 @@ export default function DraftModal({
   }, [caseId]);
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-      <div className="bg-white rounded shadow max-w-xl w-full">
+    <div
+      className={`fixed inset-0 bg-black/50 flex p-4 z-50 ${fullScreen ? "items-stretch justify-stretch" : "items-center justify-center"}`}
+    >
+      <div
+        className={`bg-white rounded shadow w-full ${fullScreen ? "h-full max-w-none" : "max-w-xl"}`}
+      >
         {data ? (
           <DraftEditor
             caseId={caseId}
@@ -44,7 +49,14 @@ export default function DraftModal({
         ) : (
           <div className="p-8">Drafting email based on case information...</div>
         )}
-        <div className="flex justify-end p-4">
+        <div className="flex justify-between p-4">
+          <button
+            type="button"
+            onClick={() => setFullScreen(!fullScreen)}
+            className="bg-gray-200 px-2 py-1 rounded"
+          >
+            {fullScreen ? "Exit Full Screen" : "Full Screen"}
+          </button>
           <button
             type="button"
             onClick={onClose}

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -29,12 +29,6 @@ export default function CaseToolbar({
             Draft Email to Authorities
           </Link>
           <Link
-            href={`/cases/${caseId}/draft`}
-            className="block px-4 py-2 hover:bg-gray-100"
-          >
-            Open Full Screen Draft
-          </Link>
-          <Link
             href={`/cases/${caseId}/followup`}
             className="block px-4 py-2 hover:bg-gray-100"
           >


### PR DESCRIPTION
## Summary
- remove full-screen draft link from case toolbar
- add a toggleable full-screen mode inside the draft email modal
- preserve attachment image aspect ratio in draft editor

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ad0a04054832ba6723032d9c09644