### PR TITLE
Add owner notification feature

### DIFF
--- a/src/app/api/cases/[id]/notify-owner/route.ts
+++ b/src/app/api/cases/[id]/notify-owner/route.ts
@@ -1,0 +1,67 @@
+import { draftOwnerNotification } from "@/lib/caseReport";
+import { addCaseEmail, getCase } from "@/lib/caseStore";
+import { getCaseOwnerContact } from "@/lib/caseUtils";
+import { sendEmail } from "@/lib/email";
+import { reportModules } from "@/lib/reportModules";
+import { NextResponse } from "next/server";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const c = getCase(id);
+  if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const contact = getCaseOwnerContact(c);
+  if (!contact) {
+    return NextResponse.json({ error: "No owner contact" }, { status: 400 });
+  }
+  const authorities = [reportModules["oak-park"].authorityName];
+  const email = await draftOwnerNotification(c, authorities);
+  return NextResponse.json({
+    email,
+    attachments: c.photos,
+    contact,
+  });
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const { subject, body, attachments } = (await req.json()) as {
+    subject: string;
+    body: string;
+    attachments: string[];
+  };
+  const c = getCase(id);
+  if (!c) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const contact = getCaseOwnerContact(c);
+  if (!contact) {
+    return NextResponse.json({ error: "No owner contact" }, { status: 400 });
+  }
+  try {
+    await sendEmail({
+      to: contact,
+      subject,
+      body,
+      attachments,
+    });
+  } catch (err) {
+    console.error("Failed to send email", err);
+    return NextResponse.json(
+      { error: "Failed to send email" },
+      { status: 500 },
+    );
+  }
+  const updated = addCaseEmail(id, {
+    subject,
+    body,
+    attachments,
+    sentAt: new Date().toISOString(),
+  });
+  return NextResponse.json(updated);
+}

--- a/src/app/cases/[id]/NotifyOwnerWrapper.tsx
+++ b/src/app/cases/[id]/NotifyOwnerWrapper.tsx
@@ -1,0 +1,24 @@
+"use client";
+import type { Case } from "@/lib/caseStore";
+import { useRouter } from "next/navigation";
+import ClientCasePage from "./ClientCasePage";
+import NotifyOwnerModal from "./notify-owner/NotifyOwnerModal";
+
+export default function NotifyOwnerWrapper({
+  caseData,
+  caseId,
+}: {
+  caseData: Case | null;
+  caseId: string;
+}) {
+  const router = useRouter();
+  return (
+    <>
+      <ClientCasePage initialCase={caseData} caseId={caseId} />
+      <NotifyOwnerModal
+        caseId={caseId}
+        onClose={() => router.push(`/cases/${caseId}`)}
+      />
+    </>
+  );
+}

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
@@ -1,0 +1,91 @@
+"use client";
+import type { EmailDraft } from "@/lib/caseReport";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+
+export default function NotifyOwnerEditor({
+  initialDraft,
+  attachments,
+  contact,
+  caseId,
+}: {
+  initialDraft?: EmailDraft;
+  attachments: string[];
+  contact: string;
+  caseId: string;
+}) {
+  const [subject, setSubject] = useState(initialDraft?.subject || "");
+  const [body, setBody] = useState(initialDraft?.body || "");
+
+  useEffect(() => {
+    if (initialDraft) {
+      setSubject(initialDraft.subject);
+      setBody(initialDraft.body);
+    }
+  }, [initialDraft]);
+
+  async function sendEmail() {
+    const res = await fetch(`/api/cases/${caseId}/notify-owner`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ subject, body, attachments }),
+    });
+    if (res.ok) {
+      alert("Email sent");
+    } else {
+      alert("Failed to send email");
+    }
+  }
+
+  if (!initialDraft) {
+    return (
+      <div className="p-8">Drafting email based on case information...</div>
+    );
+  }
+
+  return (
+    <div className="p-8 flex flex-col gap-4">
+      <h1 className="text-xl font-semibold">Owner Notification</h1>
+      <p>
+        To: {contact} - the photos shown below will be attached automatically.
+      </p>
+      <label className="flex flex-col">
+        Subject
+        <input
+          type="text"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+          className="border p-1"
+        />
+      </label>
+      <label className="flex flex-col">
+        Body
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={10}
+          className="border p-1"
+        />
+      </label>
+      <div className="flex gap-2 flex-wrap">
+        {attachments.map((p) => (
+          <Image
+            key={p}
+            src={p}
+            alt="email attachment"
+            width={120}
+            height={90}
+            className="object-contain"
+          />
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={sendEmail}
+        className="bg-blue-500 text-white px-2 py-1 rounded"
+      >
+        Send Email
+      </button>
+    </div>
+  );
+}

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerModal.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerModal.tsx
@@ -1,0 +1,58 @@
+"use client";
+import type { EmailDraft } from "@/lib/caseReport";
+import { useEffect, useState } from "react";
+import NotifyOwnerEditor from "./NotifyOwnerEditor";
+
+interface DraftData {
+  email: EmailDraft;
+  attachments: string[];
+  contact: string;
+}
+
+export default function NotifyOwnerModal({
+  caseId,
+  onClose,
+}: {
+  caseId: string;
+  onClose: () => void;
+}) {
+  const [data, setData] = useState<DraftData | null>(null);
+
+  useEffect(() => {
+    let canceled = false;
+    fetch(`/api/cases/${caseId}/notify-owner`)
+      .then((res) => res.json())
+      .then((d) => {
+        if (!canceled) setData(d as DraftData);
+      });
+    return () => {
+      canceled = true;
+    };
+  }, [caseId]);
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded shadow max-w-xl w-full">
+        {data ? (
+          <NotifyOwnerEditor
+            caseId={caseId}
+            initialDraft={data.email}
+            attachments={data.attachments}
+            contact={data.contact}
+          />
+        ) : (
+          <div className="p-8">Drafting email based on case information...</div>
+        )}
+        <div className="flex justify-end p-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="bg-gray-200 px-2 py-1 rounded"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/cases/[id]/notify-owner/page.tsx
+++ b/src/app/cases/[id]/notify-owner/page.tsx
@@ -1,0 +1,14 @@
+import { getCase } from "@/lib/caseStore";
+import NotifyOwnerWrapper from "../NotifyOwnerWrapper";
+
+export const dynamic = "force-dynamic";
+
+export default async function NotifyOwnerPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const c = getCase(id);
+  return <NotifyOwnerWrapper caseData={c ?? null} caseId={id} />;
+}

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -40,6 +40,12 @@ export default function CaseToolbar({
           >
             Request Ownership Info
           </Link>
+          <Link
+            href={`/cases/${caseId}/notify-owner`}
+            className="block px-4 py-2 hover:bg-gray-100"
+          >
+            Notify Registered Owner
+          </Link>
           <button
             type="button"
             onClick={async () => {

--- a/src/lib/__tests__/caseReport.test.ts
+++ b/src/lib/__tests__/caseReport.test.ts
@@ -1,6 +1,6 @@
 import type { ChatCompletion } from "openai/resources/chat/completions";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { draftEmail } from "../caseReport";
+import { draftEmail, draftOwnerNotification } from "../caseReport";
 import type { Case } from "../caseStore";
 import { openai } from "../openai";
 import { reportModules } from "../reportModules";
@@ -63,6 +63,51 @@ describe("draftEmail", () => {
     } as unknown as ChatCompletion);
 
     const result = await draftEmail(baseCase, reportModules["oak-park"]);
+    expect(result).toEqual({ subject: "", body: "" });
+  });
+});
+
+describe("draftOwnerNotification", () => {
+  it("returns parsed email when response is valid", async () => {
+    vi.spyOn(openai.chat.completions, "create").mockResolvedValueOnce({
+      choices: [
+        { message: { content: JSON.stringify({ subject: "s", body: "b" }) } },
+      ],
+    } as unknown as ChatCompletion);
+
+    const result = await draftOwnerNotification(baseCase, [
+      "Oak Park Police Department",
+    ]);
+    expect(result).toEqual({ subject: "s", body: "b" });
+  });
+
+  it("retries when response is invalid", async () => {
+    vi.spyOn(openai.chat.completions, "create")
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: "{}" } }],
+      } as unknown as ChatCompletion)
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            message: { content: JSON.stringify({ subject: "s2", body: "b2" }) },
+          },
+        ],
+      } as unknown as ChatCompletion);
+
+    const result = await draftOwnerNotification(baseCase, [
+      "Oak Park Police Department",
+    ]);
+    expect(result).toEqual({ subject: "s2", body: "b2" });
+  });
+
+  it("returns empty draft after repeated failures", async () => {
+    vi.spyOn(openai.chat.completions, "create").mockResolvedValue({
+      choices: [{ message: { content: "{}" } }],
+    } as unknown as ChatCompletion);
+
+    const result = await draftOwnerNotification(baseCase, [
+      "Oak Park Police Department",
+    ]);
     expect(result).toEqual({ subject: "", body: "" });
   });
 });


### PR DESCRIPTION
## Summary
- implement `draftOwnerNotification` for owner emails
- add `/notify-owner` API route and UI components
- link to notify owner from case toolbar
- extend tests for the new draft function

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ad71fea28832b8e3db8b4a7625319