### PR TITLE
Implement contextual follow ups

### DIFF
--- a/src/app/api/cases/[id]/notify-owner/route.ts
+++ b/src/app/api/cases/[id]/notify-owner/route.ts
@@ -43,9 +43,10 @@ export async function POST(
   if (!contact) {
     return NextResponse.json({ error: "No owner contact" }, { status: 400 });
   }
+  const to = contact;
   try {
     await sendEmail({
-      to: contact,
+      to,
       subject,
       body,
       attachments,
@@ -58,10 +59,12 @@ export async function POST(
     );
   }
   const updated = addCaseEmail(id, {
+    to,
     subject,
     body,
     attachments,
     sentAt: new Date().toISOString(),
+    replyTo: null,
   });
   return NextResponse.json(updated);
 }

--- a/src/app/api/cases/[id]/report/route.ts
+++ b/src/app/api/cases/[id]/report/route.ts
@@ -35,9 +35,10 @@ export async function POST(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
   const reportModule = reportModules["oak-park"];
+  const to = reportModule.authorityEmail;
   try {
     await sendEmail({
-      to: reportModule.authorityEmail,
+      to,
       subject,
       body,
       attachments,
@@ -50,10 +51,12 @@ export async function POST(
     );
   }
   const updated = addCaseEmail(id, {
+    to,
     subject,
     body,
     attachments,
     sentAt: new Date().toISOString(),
+    replyTo: null,
   });
   return NextResponse.json(updated);
 }

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -367,15 +367,22 @@ export default function ClientCasePage({
       {caseData.sentEmails && caseData.sentEmails.length > 0 ? (
         <div className="bg-gray-100 p-4 rounded flex flex-col gap-2">
           <h2 className="font-semibold">Email Log</h2>
-          <ul className="flex flex-col gap-1 text-sm">
+          <ul className="flex flex-col gap-2 text-sm">
             {caseData.sentEmails.map((mail) => (
-              <li key={mail.sentAt} className="flex flex-col">
+              <li key={mail.sentAt} className="flex flex-col gap-1">
                 <span>
                   {new Date(mail.sentAt).toLocaleString()} - {mail.subject}
                 </span>
+                <span className="text-gray-500">To: {mail.to}</span>
                 <span className="text-gray-500 whitespace-pre-wrap">
                   {mail.body}
                 </span>
+                <a
+                  href={`/cases/${caseId}/followup?replyTo=${encodeURIComponent(mail.sentAt)}`}
+                  className="self-start text-blue-500 underline"
+                >
+                  Follow Up
+                </a>
               </li>
             ))}
           </ul>

--- a/src/app/cases/[id]/FollowUpWrapper.tsx
+++ b/src/app/cases/[id]/FollowUpWrapper.tsx
@@ -1,6 +1,6 @@
 "use client";
 import type { Case } from "@/lib/caseStore";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import ClientCasePage from "./ClientCasePage";
 import FollowUpModal from "./followup/FollowUpModal";
 
@@ -12,11 +12,14 @@ export default function FollowUpWrapper({
   caseId: string;
 }) {
   const router = useRouter();
+  const params = useSearchParams();
+  const replyTo = params.get("replyTo") || undefined;
   return (
     <>
       <ClientCasePage initialCase={caseData} caseId={caseId} />
       <FollowUpModal
         caseId={caseId}
+        replyTo={replyTo || undefined}
         onClose={() => router.push(`/cases/${caseId}`)}
       />
     </>

--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -9,11 +9,17 @@ export default function DraftEditor({
   attachments,
   module,
   caseId,
+  action = "report",
+  replyTo,
+  to,
 }: {
   initialDraft?: EmailDraft;
   attachments: string[];
   module: ReportModule;
   caseId: string;
+  action?: "report" | "followup";
+  replyTo?: string;
+  to?: string;
 }) {
   const [subject, setSubject] = useState(initialDraft?.subject || "");
   const [body, setBody] = useState(initialDraft?.body || "");
@@ -26,10 +32,15 @@ export default function DraftEditor({
   }, [initialDraft]);
 
   async function sendEmail() {
-    const res = await fetch(`/api/cases/${caseId}/report`, {
+    const res = await fetch(`/api/cases/${caseId}/${action}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ subject, body, attachments }),
+      body: JSON.stringify({
+        subject,
+        body,
+        attachments,
+        ...(replyTo ? { replyTo } : {}),
+      }),
     });
     if (res.ok) {
       alert("Email sent");
@@ -48,8 +59,8 @@ export default function DraftEditor({
     <div className="p-8 flex flex-col gap-4">
       <h1 className="text-xl font-semibold">Email Draft</h1>
       <p>
-        To: {module.authorityName} ({module.authorityEmail}) - the photos shown
-        below will be attached automatically.
+        To: {to || `${module.authorityName} (${module.authorityEmail})`} - the
+        photos shown below will be attached automatically.
       </p>
       <label className="flex flex-col">
         Subject

--- a/src/app/cases/[id]/draft/DraftModal.tsx
+++ b/src/app/cases/[id]/draft/DraftModal.tsx
@@ -45,6 +45,7 @@ export default function DraftModal({
             initialDraft={data.email}
             attachments={data.attachments}
             module={data.module}
+            action="report"
           />
         ) : (
           <div className="p-8">Drafting email based on case information...</div>

--- a/src/app/cases/[id]/draft/page.tsx
+++ b/src/app/cases/[id]/draft/page.tsx
@@ -19,6 +19,7 @@ export default async function DraftPage({
       initialDraft={email}
       attachments={c.photos}
       module={reportModule}
+      action="report"
     />
   );
 }

--- a/src/app/cases/[id]/followup/FollowUpModal.tsx
+++ b/src/app/cases/[id]/followup/FollowUpModal.tsx
@@ -8,20 +8,24 @@ interface DraftData {
   email: EmailDraft;
   attachments: string[];
   module: ReportModule;
+  to: string;
 }
 
 export default function FollowUpModal({
   caseId,
+  replyTo,
   onClose,
 }: {
   caseId: string;
+  replyTo?: string;
   onClose: () => void;
 }) {
   const [data, setData] = useState<DraftData | null>(null);
 
   useEffect(() => {
     let canceled = false;
-    fetch(`/api/cases/${caseId}/followup`)
+    const url = `/api/cases/${caseId}/followup${replyTo ? `?replyTo=${encodeURIComponent(replyTo)}` : ""}`;
+    fetch(url)
       .then((res) => res.json())
       .then((d) => {
         if (!canceled) setData(d as DraftData);
@@ -29,7 +33,7 @@ export default function FollowUpModal({
     return () => {
       canceled = true;
     };
-  }, [caseId]);
+  }, [caseId, replyTo]);
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
@@ -40,6 +44,9 @@ export default function FollowUpModal({
             initialDraft={data.email}
             attachments={data.attachments}
             module={data.module}
+            action="followup"
+            replyTo={replyTo}
+            to={data.to}
           />
         ) : (
           <div className="p-8">Drafting email based on case information...</div>

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -29,12 +29,6 @@ export default function CaseToolbar({
             Draft Email to Authorities
           </Link>
           <Link
-            href={`/cases/${caseId}/followup`}
-            className="block px-4 py-2 hover:bg-gray-100"
-          >
-            Follow Up with Authorities
-          </Link>
-          <Link
             href={`/cases/${caseId}/ownership`}
             className="block px-4 py-2 hover:bg-gray-100"
           >

--- a/src/lib/caseReport.ts
+++ b/src/lib/caseReport.ts
@@ -108,7 +108,7 @@ Mention that photos are attached. Respond with JSON matching this schema: ${JSON
 
 export async function draftFollowUp(
   caseData: Case,
-  mod: ReportModule,
+  recipient: string,
 ): Promise<EmailDraft> {
   const history = (caseData.sentEmails ?? []).map((m) => ({
     role: "assistant",
@@ -126,7 +126,7 @@ export async function draftFollowUp(
     type: "object",
     properties: { subject: { type: "string" }, body: { type: "string" } },
   };
-  const prompt = `Write a brief follow-up email to ${mod.authorityName} about the previous report.
+  const prompt = `Write a brief follow-up email to ${recipient} about the previous report.
 Include these details if available:
 - Violation: ${analysis?.violationType || ""}
 - Description: ${analysis?.details || ""}

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -30,11 +30,13 @@ export interface Case {
 }
 
 export interface SentEmail {
+  to: string;
   subject: string;
   body: string;
   attachments: string[];
   /** @zod.date */
   sentAt: string;
+  replyTo?: string | null;
 }
 
 export interface OwnershipRequest {
@@ -61,7 +63,17 @@ function loadCases(): Case[] {
       photos: c.photos ?? (c.photo ? [c.photo] : []),
       photoTimes: c.photoTimes ?? {},
       analysisStatus: c.analysisStatus ?? (c.analysis ? "complete" : "pending"),
-      sentEmails: c.sentEmails ?? [],
+      sentEmails: (c.sentEmails ?? []).map((m: unknown) => {
+        const mail = m as Partial<SentEmail> & { [key: string]: unknown };
+        return {
+          to: mail.to ?? "",
+          subject: mail.subject as string,
+          body: mail.body as string,
+          attachments: mail.attachments ?? [],
+          sentAt: mail.sentAt as string,
+          replyTo: mail.replyTo ?? null,
+        };
+      }),
       ownershipRequests: c.ownershipRequests ?? [],
     }));
   } catch {


### PR DESCRIPTION
## Summary
- record recipient and thread info for sent emails
- generate follow ups for any prior email
- adjust pages to show "Follow Up" buttons in the email log
- remove global follow-up action from toolbar

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684add49b430832bb24c7222511eb803