### PR TITLE
Fix thread wrapper import path

### DIFF
--- a/src/app/cases/[id]/thread/[sent]/page.tsx
+++ b/src/app/cases/[id]/thread/[sent]/page.tsx
@@ -1,5 +1,5 @@
 import { getCase } from "@/lib/caseStore";
-import ThreadWrapper from "../ThreadWrapper";
+import ThreadWrapper from "../../ThreadWrapper";
 
 export const dynamic = "force-dynamic";
 


### PR DESCRIPTION
## Summary
- fix incorrect relative import path to ThreadWrapper

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684afc7a5b24832bb051b5d8ebf6048c