### PR TITLE
Add thread page e2e test

### DIFF
--- a/src/app/cases/[id]/thread/[sent]/page.tsx
+++ b/src/app/cases/[id]/thread/[sent]/page.tsx
@@ -1,5 +1,5 @@
 import { getCase } from "@/lib/caseStore";
-import ThreadWrapper from "../ThreadWrapper";
+import ThreadWrapper from "../../ThreadWrapper";
 
 export const dynamic = "force-dynamic";
 

--- a/test/e2e/thread.test.ts
+++ b/test/e2e/thread.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type TestServer, startServer } from "./startServer";
+
+let server: TestServer;
+let tmpDir: string;
+
+beforeAll(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
+  process.env.CASE_STORE_FILE = path.join(tmpDir, "cases.json");
+  server = await startServer(3006);
+}, 120000);
+
+afterAll(async () => {
+  await server.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  process.env.CASE_STORE_FILE = undefined;
+}, 120000);
+
+describe("thread page", () => {
+  async function createCase(): Promise<string> {
+    const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+    const form = new FormData();
+    form.append("photo", file);
+    const res = await fetch(`${server.url}/api/upload`, {
+      method: "POST",
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { caseId: string };
+    return data.caseId;
+  }
+
+  it("serves existing thread pages", async () => {
+    await fetch(`${server.url}/`);
+    const id = await createCase();
+    const res = await fetch(`${server.url}/cases/${id}/thread/start`);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("Thread");
+  }, 30000);
+});


### PR DESCRIPTION
## Summary
- add an end-to-end test for the thread page

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684afc7a5b24832bb051b5d8ebf6048c