### PR TITLE
Add citation status question to follow-up prompt

### DIFF
--- a/src/lib/caseReport.ts
+++ b/src/lib/caseReport.ts
@@ -133,7 +133,7 @@ Include these details if available:
 - Description: ${analysis?.details || ""}
 - Location: ${location}
 - License Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}
-Mention that photos are attached again. Respond with JSON matching this schema: ${JSON.stringify(
+Ask about the current citation status and mention that photos are attached again. Respond with JSON matching this schema: ${JSON.stringify(
     schema,
   )}`;
   const baseMessages = [


### PR DESCRIPTION
## Summary
- ask for current citation status when drafting follow-up emails

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b00f90b30832b8207caede7f7b933