### PR TITLE
Hide ownership request when owner known

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -221,7 +221,11 @@ export default function ClientCasePage({
       header={
         <div className="flex items-center justify-between">
           <h1 className="text-xl font-semibold">Case {caseData.id}</h1>
-          <CaseToolbar caseId={caseId} disabled={!violationIdentified} />
+          <CaseToolbar
+            caseId={caseId}
+            disabled={!violationIdentified}
+            hasOwner={Boolean(ownerContact)}
+          />
         </div>
       }
       left={<CaseProgressGraph caseData={caseData} />}

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -4,9 +4,11 @@ import Link from "next/link";
 export default function CaseToolbar({
   caseId,
   disabled = false,
+  hasOwner = false,
 }: {
   caseId: string;
   disabled?: boolean;
+  hasOwner?: boolean;
 }) {
   if (disabled) {
     return (
@@ -28,12 +30,14 @@ export default function CaseToolbar({
           >
             Draft Email to Authorities
           </Link>
-          <Link
-            href={`/cases/${caseId}/ownership`}
-            className="block px-4 py-2 hover:bg-gray-100"
-          >
-            Request Ownership Info
-          </Link>
+          {hasOwner ? null : (
+            <Link
+              href={`/cases/${caseId}/ownership`}
+              className="block px-4 py-2 hover:bg-gray-100"
+            >
+              Request Ownership Info
+            </Link>
+          )}
           <Link
             href={`/cases/${caseId}/notify-owner`}
             className="block px-4 py-2 hover:bg-gray-100"


### PR DESCRIPTION
## Summary
- pass `hasOwner` info into `CaseToolbar`
- hide ownership request link when the case already has ownership data

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b0038b8c0832ba73462246a34d66a