### PR TITLE
Add logging for followup feature

### DIFF
--- a/src/app/api/cases/[id]/followup/route.ts
+++ b/src/app/api/cases/[id]/followup/route.ts
@@ -26,12 +26,22 @@ export async function GET(
   const { id } = await params;
   const url = new URL(req.url);
   const replyTo = url.searchParams.get("replyTo");
+  console.log(`followup GET case=${id} replyTo=${replyTo ?? "none"}`);
   const c = getCase(id);
   if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
   const reportModule = reportModules["oak-park"];
   const thread = getThread(c, replyTo);
+  console.log(
+    `thread chain: ${thread
+      .map((m) => `${m.sentAt}->${m.replyTo ?? "null"}`)
+      .join(", ")}`,
+  );
   const recipient = thread.at(-1)?.to || reportModule.authorityName;
+  console.log(
+    `drafting followup for ${recipient} with ${thread.length} emails`,
+  );
   const email = await draftFollowUp(c, recipient, thread);
+  console.log(`drafted email subject: ${email.subject}`);
   return NextResponse.json({
     email,
     attachments: c.photos,
@@ -60,6 +70,9 @@ export async function POST(
   const target =
     c.sentEmails?.find((e) => e.sentAt === replyTo)?.to ||
     reportModule.authorityEmail;
+  console.log(
+    `followup POST case=${id} to=${target} replyTo=${replyTo ?? "none"}`,
+  );
   try {
     await sendEmail({
       to: target,

--- a/src/lib/caseReport.ts
+++ b/src/lib/caseReport.ts
@@ -111,6 +111,11 @@ export async function draftFollowUp(
   recipient: string,
   historyEmails: SentEmail[] = caseData.sentEmails ?? [],
 ): Promise<EmailDraft> {
+  console.log(
+    `draftFollowUp recipient=${recipient} history=${historyEmails
+      .map((m) => `${m.sentAt}:${m.subject}`)
+      .join("|")}`,
+  );
   const history = historyEmails.map((m) => ({
     role: "assistant",
     content: `Subject: ${m.subject}\n\n${m.body}`,
@@ -144,6 +149,8 @@ Mention that photos are attached again. Respond with JSON matching this schema: 
     ...history,
     { role: "user", content: prompt },
   ];
+
+  console.log(`draftFollowUp prompt: ${prompt.replace(/\n/g, " ")}`);
 
   const messages = [...baseMessages];
   for (let attempt = 0; attempt < 3; attempt++) {


### PR DESCRIPTION
## Summary
- add console logging in the followup API to report thread info and email details
- log recipient, history, and prompt when drafting follow-up emails

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aff1c5d08832ba3789847ddb9913d