### PR TITLE
Add loading feedback when sending email

### DIFF
--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -23,6 +23,7 @@ export default function DraftEditor({
 }) {
   const [subject, setSubject] = useState(initialDraft?.subject || "");
   const [body, setBody] = useState(initialDraft?.body || "");
+  const [sending, setSending] = useState(false);
 
   useEffect(() => {
     if (initialDraft) {
@@ -32,20 +33,25 @@ export default function DraftEditor({
   }, [initialDraft]);
 
   async function sendEmail() {
-    const res = await fetch(`/api/cases/${caseId}/${action}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        subject,
-        body,
-        attachments,
-        ...(replyTo ? { replyTo } : {}),
-      }),
-    });
-    if (res.ok) {
-      alert("Email sent");
-    } else {
-      alert("Failed to send email");
+    setSending(true);
+    try {
+      const res = await fetch(`/api/cases/${caseId}/${action}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          subject,
+          body,
+          attachments,
+          ...(replyTo ? { replyTo } : {}),
+        }),
+      });
+      if (res.ok) {
+        alert("Email sent");
+      } else {
+        alert("Failed to send email");
+      }
+    } finally {
+      setSending(false);
     }
   }
 
@@ -95,9 +101,10 @@ export default function DraftEditor({
       <button
         type="button"
         onClick={sendEmail}
-        className="bg-blue-500 text-white px-2 py-1 rounded"
+        disabled={sending}
+        className="bg-blue-500 text-white px-2 py-1 rounded disabled:opacity-50"
       >
-        Send Email
+        {sending ? "Sending..." : "Send Email"}
       </button>
     </div>
   );

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
@@ -16,6 +16,7 @@ export default function NotifyOwnerEditor({
 }) {
   const [subject, setSubject] = useState(initialDraft?.subject || "");
   const [body, setBody] = useState(initialDraft?.body || "");
+  const [sending, setSending] = useState(false);
 
   useEffect(() => {
     if (initialDraft) {
@@ -25,15 +26,20 @@ export default function NotifyOwnerEditor({
   }, [initialDraft]);
 
   async function sendEmail() {
-    const res = await fetch(`/api/cases/${caseId}/notify-owner`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ subject, body, attachments }),
-    });
-    if (res.ok) {
-      alert("Email sent");
-    } else {
-      alert("Failed to send email");
+    setSending(true);
+    try {
+      const res = await fetch(`/api/cases/${caseId}/notify-owner`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ subject, body, attachments }),
+      });
+      if (res.ok) {
+        alert("Email sent");
+      } else {
+        alert("Failed to send email");
+      }
+    } finally {
+      setSending(false);
     }
   }
 
@@ -82,9 +88,10 @@ export default function NotifyOwnerEditor({
       <button
         type="button"
         onClick={sendEmail}
-        className="bg-blue-500 text-white px-2 py-1 rounded"
+        disabled={sending}
+        className="bg-blue-500 text-white px-2 py-1 rounded disabled:opacity-50"
       >
-        Send Email
+        {sending ? "Sending..." : "Send Email"}
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- show `Sending...` feedback in DraftEditor
- show `Sending...` feedback in NotifyOwnerEditor

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b03346bec832bafa75f227078d022