### PR TITLE
Handle empty image analysis request

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -206,7 +206,9 @@ export default function ClientCasePage({
         ? "Analysis failed because the AI response was cut off. Please try again."
         : caseData.analysisError === "parse"
           ? "Analysis failed due to invalid JSON from the AI. Please try again."
-          : "Analysis failed because the AI response did not match the expected format. Please retry."}
+          : caseData.analysisError === "images"
+            ? "Analysis failed because no images were provided."
+            : "Analysis failed because the AI response did not match the expected format. Please retry."}
     </p>
   ) : caseData.analysisStatusCode && caseData.analysisStatusCode >= 400 ? (
     <p className="text-sm text-red-600">

--- a/src/generated/zod/caseStore.ts
+++ b/src/generated/zod/caseStore.ts
@@ -2,16 +2,27 @@
 import { z } from "zod";
 
 export const sentEmailSchema = z.object({
+  to: z.string(),
   subject: z.string(),
   body: z.string(),
   attachments: z.array(z.string()),
   sentAt: z.string(),
+  replyTo: z.string().optional().nullable(),
 });
 
 export const ownershipRequestSchema = z.object({
   moduleId: z.string(),
   requestedAt: z.string(),
   checkNumber: z.string().optional().nullable(),
+});
+
+export const threadImageSchema = z.object({
+  id: z.string(),
+  threadParent: z.string().optional().nullable(),
+  url: z.string(),
+  uploadedAt: z.string(),
+  ocrText: z.string().optional().nullable(),
+  ocrInfo: z.any().optional().nullable(),
 });
 
 const violationReportSchema = z.any();
@@ -37,9 +48,15 @@ export const caseSchema = z.object({
   analysisStatus: z.union([z.literal("pending"), z.literal("complete")]),
   analysisStatusCode: z.number().optional().nullable(),
   analysisError: z
-    .union([z.literal("truncated"), z.literal("parse"), z.literal("schema")])
+    .union([
+      z.literal("truncated"),
+      z.literal("parse"),
+      z.literal("schema"),
+      z.literal("images"),
+    ])
     .optional()
     .nullable(),
   sentEmails: z.array(sentEmailSchema).optional(),
   ownershipRequests: z.array(ownershipRequestSchema).optional(),
+  threadImages: z.array(threadImageSchema).optional(),
 });

--- a/src/lib/__tests__/analyzeViolation.test.ts
+++ b/src/lib/__tests__/analyzeViolation.test.ts
@@ -9,6 +9,11 @@ afterEach(() => {
 });
 
 describe("analyzeViolation", () => {
+  it("rejects when no images are provided", async () => {
+    await expect(analyzeViolation([])).rejects.toMatchObject({
+      kind: "images",
+    });
+  });
   it("classifies cut off responses", async () => {
     vi.spyOn(openai.chat.completions, "create").mockResolvedValue({
       choices: [{ message: { content: "{" }, finish_reason: "length" }],

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -24,7 +24,7 @@ export interface Case {
   /** @zod.enum(["pending", "complete"]) */
   analysisStatus: "pending" | "complete";
   analysisStatusCode?: number | null;
-  analysisError?: "truncated" | "parse" | "schema" | null;
+  analysisError?: "truncated" | "parse" | "schema" | "images" | null;
   sentEmails?: SentEmail[];
   ownershipRequests?: OwnershipRequest[];
   threadImages?: ThreadImage[];

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -6,8 +6,8 @@ import "./zod-setup";
 dotenv.config();
 
 export class AnalysisError extends Error {
-  kind: "truncated" | "parse" | "schema";
-  constructor(kind: "truncated" | "parse" | "schema") {
+  kind: "truncated" | "parse" | "schema" | "images";
+  constructor(kind: "truncated" | "parse" | "schema" | "images") {
     super(kind);
     this.kind = kind;
   }
@@ -92,6 +92,9 @@ export type ViolationReport = z.infer<typeof violationReportSchema>;
 export async function analyzeViolation(
   images: Array<{ url: string; filename: string }>,
 ): Promise<ViolationReport> {
+  if (images.length === 0) {
+    throw new AnalysisError("images");
+  }
   const schema = {
     type: "object",
     properties: {


### PR DESCRIPTION
## Summary
- add new `images` error type for analysis failures
- surface error when no violation photos are provided
- update front-end error messages
- regenerate Zod schemas
- test empty images case

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b0c4f2190832b92f8f92defd1cfa2