### PR TITLE
Improve VIN extraction prompt

### DIFF
--- a/src/lib/__tests__/openai.test.ts
+++ b/src/lib/__tests__/openai.test.ts
@@ -1,6 +1,6 @@
 import type { ChatCompletion } from "openai/resources/chat/completions";
 import { describe, expect, it, vi } from "vitest";
-import { ocrPaperwork, openai } from "../openai";
+import { extractPaperworkInfo, ocrPaperwork, openai } from "../openai";
 
 describe("openai client", () => {
   it("exports a client instance", () => {

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -40,7 +40,10 @@ export const paperworkInfoSchema = z.object({
   contact: z.string().optional(),
   vehicle: z
     .object({
-      vin: z.string().optional(),
+      vin: z
+        .string()
+        .regex(/^[A-HJ-NPR-Z0-9]{17}$/)
+        .optional(),
       registrationStatus: z.string().optional(),
       licensePlateState: licensePlateStateSchema.optional(),
       licensePlateNumber: licensePlateNumberSchema.optional(),
@@ -210,7 +213,7 @@ export async function extractPaperworkInfo(
       vehicle: {
         type: "object",
         properties: {
-          vin: { type: "string" },
+          vin: { type: "string", pattern: "^[A-HJ-NPR-Z0-9]{17}$" },
           registrationStatus: { type: "string" },
           licensePlateState: { type: "string" },
           licensePlateNumber: { type: "string" },
@@ -224,11 +227,11 @@ export async function extractPaperworkInfo(
     {
       role: "system",
       content:
-        "You extract structured vehicle information from text and reply in JSON strictly following the provided schema.",
+        "You extract structured vehicle information from text and reply in JSON strictly following the provided schema. A VIN is a 17-character string of digits and capital letters except I, O, and Q.",
     },
     {
       role: "user",
-      content: `Analyze the following text and extract the registered owner contact information, VIN, vehicle registration status, license plate details and any calls to action. Respond with JSON matching this schema: ${JSON.stringify(
+      content: `Analyze the following text and extract the registered owner contact information, the VIN, vehicle registration status, license plate details and any calls to action. Omit the VIN field if none is present. Respond with JSON matching this schema: ${JSON.stringify(
         schema,
       )}`,
     },


### PR DESCRIPTION
## Summary
- enforce VIN pattern in the paperwork schema
- remove regex fallback and clarify prompts
- update unit tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b0d91509c832bbc79ed5ceb5b4e92