### PR TITLE
Add multi-case actions toolbar

### DIFF
--- a/src/app/components/CaseSummary.tsx
+++ b/src/app/components/CaseSummary.tsx
@@ -6,6 +6,7 @@ import {
   getCaseVin,
   hasViolation,
 } from "@/lib/caseUtils";
+import MultiCaseToolbar from "./MultiCaseToolbar";
 
 export default function CaseSummary({ cases }: { cases: Case[] }) {
   if (cases.length === 0) return null;
@@ -22,19 +23,32 @@ export default function CaseSummary({ cases }: { cases: Case[] }) {
   const vin = allEqual((c) => getCaseVin(c));
   const contact = allEqual((c) => getCaseOwnerContact(c));
 
+  const actionsDisabled = !cases.every(
+    (c) => c.analysisStatus === "complete" && hasViolation(c.analysis),
+  );
+  const hasOwnerAll = cases.every((c) => Boolean(getCaseOwnerContact(c)));
+  const ids = cases.map((c) => c.id);
+
   return (
-    <div className="p-8 flex flex-col gap-2">
-      <h1 className="text-xl font-semibold">Case Summary</h1>
-      <p className="text-sm text-gray-500">{cases.length} cases selected.</p>
-      {violation ? <p>Violation: {violation}</p> : null}
-      {plateNum || plateState ? (
-        <p>
-          Plate: {plateState ? `${plateState} ` : ""}
-          {plateNum}
-        </p>
-      ) : null}
-      {vin ? <p>VIN: {vin}</p> : null}
-      {contact ? <p>Owner Contact: {contact}</p> : null}
+    <div className="flex flex-col">
+      <MultiCaseToolbar
+        caseIds={ids}
+        disabled={actionsDisabled}
+        hasOwner={hasOwnerAll}
+      />
+      <div className="p-8 flex flex-col gap-2">
+        <h1 className="text-xl font-semibold">Case Summary</h1>
+        <p className="text-sm text-gray-500">{cases.length} cases selected.</p>
+        {violation ? <p>Violation: {violation}</p> : null}
+        {plateNum || plateState ? (
+          <p>
+            Plate: {plateState ? `${plateState} ` : ""}
+            {plateNum}
+          </p>
+        ) : null}
+        {vin ? <p>VIN: {vin}</p> : null}
+        {contact ? <p>Owner Contact: {contact}</p> : null}
+      </div>
     </div>
   );
 }

--- a/src/app/components/MultiCaseToolbar.tsx
+++ b/src/app/components/MultiCaseToolbar.tsx
@@ -1,0 +1,73 @@
+"use client";
+import Link from "next/link";
+
+export default function MultiCaseToolbar({
+  caseIds,
+  disabled = false,
+  hasOwner = false,
+}: {
+  caseIds: string[];
+  disabled?: boolean;
+  hasOwner?: boolean;
+}) {
+  if (disabled) {
+    return (
+      <div className="bg-gray-100 px-8 py-2 flex justify-end text-gray-500">
+        No actions available
+      </div>
+    );
+  }
+  const idsParam = caseIds.join(",");
+  const first = caseIds[0];
+  return (
+    <div className="bg-gray-100 px-8 py-2 flex justify-end">
+      <details className="relative">
+        <summary className="cursor-pointer select-none bg-gray-300 px-2 py-1 rounded">
+          Actions
+        </summary>
+        <div className="absolute right-0 mt-1 bg-white border rounded shadow">
+          <Link
+            href={`/cases/${first}/compose?ids=${idsParam}`}
+            className="block px-4 py-2 hover:bg-gray-100"
+          >
+            Draft Email to Authorities
+          </Link>
+          {hasOwner ? null : (
+            <Link
+              href={`/cases/${first}/ownership?ids=${idsParam}`}
+              className="block px-4 py-2 hover:bg-gray-100"
+            >
+              Request Ownership Info
+            </Link>
+          )}
+          <Link
+            href={`/cases/${first}/notify-owner?ids=${idsParam}`}
+            className="block px-4 py-2 hover:bg-gray-100"
+          >
+            Notify Registered Owner
+          </Link>
+          <button
+            type="button"
+            onClick={async () => {
+              const code = Math.random().toString(36).slice(2, 6);
+              const input = prompt(
+                `Type '${code}' to confirm deleting these cases.`,
+              );
+              if (input === code) {
+                await Promise.all(
+                  caseIds.map((id) =>
+                    fetch(`/api/cases/${id}`, { method: "DELETE" }),
+                  ),
+                );
+                window.location.href = "/cases";
+              }
+            }}
+            className="block px-4 py-2 hover:bg-gray-100 w-full text-left"
+          >
+            Delete Cases
+          </button>
+        </div>
+      </details>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `MultiCaseToolbar` for applying actions to multiple cases
- integrate toolbar into `CaseSummary` to show bulk actions when several cases are selected

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b1190cecc832bbaf3c2db984e68bb