### PR TITLE
docs: timezone reminder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,11 @@ This repository is a Next.js TypeScript project using Vitest and Biome.
 - Terminate statements with semicolons.
 - Import Node.js builtin modules using the `node:` protocol (e.g. `import fs from "node:fs";`).
 
+## Dates and Times
+- Parse and store timestamps in UTC ISO format.
+- Avoid formatting dates on the server. Let the client format and display dates
+  using `toLocaleString` with the browser's locale.
+
 ## Next.js Dynamic APIs
 - Type `params` and `searchParams` as `Promise` objects and `await` them before using their properties.
 

--- a/src/lib/caseReport.ts
+++ b/src/lib/caseReport.ts
@@ -67,7 +67,7 @@ Include these details if available:
 - Description: ${analysis?.details || ""}
 - Location: ${location}
 - License Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}
- - Time: ${new Date(time).toLocaleString()}
+ - Time: ${new Date(time).toISOString()}
 ${paperworkTexts ? `Attached paperwork:\n${paperworkTexts}` : ""}
 Mention that photos are attached. Respond with JSON matching this schema: ${JSON.stringify(
     schema,
@@ -207,7 +207,7 @@ export async function draftOwnerNotification(
   };
   const authorityList =
     authorities.length > 0 ? authorities.join(", ") : "no authorities";
-  const prompt = `Draft a short, professional email to the registered owner informing them of their violation and case status. Mention that the following authorities have been contacted: ${authorityList}. Do not reveal any information about the sender. Chastise the owner professionally and note that further action from authorities is pending. Include any applicable municipal or state codes for the violation. Include these details if available:\n- Violation: ${analysis?.violationType || ""}\n- Description: ${analysis?.details || ""}\n- Location: ${location}\n- License Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}\n- Time: ${new Date(time).toLocaleString()}\nMention that photos are attached. Respond with JSON matching this schema: ${JSON.stringify(
+  const prompt = `Draft a short, professional email to the registered owner informing them of their violation and case status. Mention that the following authorities have been contacted: ${authorityList}. Do not reveal any information about the sender. Chastise the owner professionally and note that further action from authorities is pending. Include any applicable municipal or state codes for the violation. Include these details if available:\n- Violation: ${analysis?.violationType || ""}\n- Description: ${analysis?.details || ""}\n- Location: ${location}\n- License Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}\n- Time: ${new Date(time).toISOString()}\nMention that photos are attached. Respond with JSON matching this schema: ${JSON.stringify(
     schema,
   )}`;
   const baseMessages = [


### PR DESCRIPTION
## Summary
- document timezone and locale formatting guidelines in AGENTS
- store time in UTC when generating email prompts

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2027e718832baa7e65d59535292d