### PR TITLE
Add re-analysis button to case view

### DIFF
--- a/src/app/api/cases/[id]/reanalyze/route.ts
+++ b/src/app/api/cases/[id]/reanalyze/route.ts
@@ -1,0 +1,21 @@
+import { analyzeCaseInBackground } from "@/lib/caseAnalysis";
+import { getCase, updateCase } from "@/lib/caseStore";
+import { NextResponse } from "next/server";
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const c = getCase(id);
+  if (!c) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const updated = updateCase(id, { analysisStatus: "pending" });
+  if (!updated) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  analyzeCaseInBackground(updated);
+  const layered = getCase(id);
+  return NextResponse.json(layered);
+}

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -150,6 +150,11 @@ export default function ClientCasePage({
     await refreshCase();
   }
 
+  async function reanalyzeCase() {
+    await fetch(`/api/cases/${caseId}/reanalyze`, { method: "POST" });
+    await refreshCase();
+  }
+
   async function removePhoto(photo: string) {
     await fetch(`/api/cases/${caseId}/photos`, {
       method: "DELETE",
@@ -235,6 +240,14 @@ export default function ClientCasePage({
         <>
           <div className="order-first bg-gray-100 p-4 rounded flex flex-col gap-2 text-sm">
             {analysisBlock}
+            <button
+              type="button"
+              onClick={reanalyzeCase}
+              disabled={caseData.analysisStatus === "pending"}
+              className="bg-blue-500 text-white px-2 py-1 rounded disabled:opacity-50 self-start"
+            >
+              Re-run Analysis
+            </button>
             {ownerContact ? (
               <p>
                 <span className="font-semibold">Owner:</span> {ownerContact}

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -24,6 +24,16 @@ export default function CaseToolbar({
           Actions
         </summary>
         <div className="absolute right-0 mt-1 bg-white border rounded shadow">
+          <button
+            type="button"
+            onClick={async () => {
+              await fetch(`/api/cases/${caseId}/reanalyze`, { method: "POST" });
+              window.location.reload();
+            }}
+            className="block px-4 py-2 hover:bg-gray-100 w-full text-left"
+          >
+            Re-run Analysis
+          </button>
           <Link
             href={`/cases/${caseId}/compose`}
             className="block px-4 py-2 hover:bg-gray-100"

--- a/src/app/components/MultiCaseToolbar.tsx
+++ b/src/app/components/MultiCaseToolbar.tsx
@@ -26,6 +26,20 @@ export default function MultiCaseToolbar({
           Actions
         </summary>
         <div className="absolute right-0 mt-1 bg-white border rounded shadow">
+          <button
+            type="button"
+            onClick={async () => {
+              await Promise.all(
+                caseIds.map((id) =>
+                  fetch(`/api/cases/${id}/reanalyze`, { method: "POST" }),
+                ),
+              );
+              window.location.reload();
+            }}
+            className="block px-4 py-2 hover:bg-gray-100 w-full text-left"
+          >
+            Re-run Analysis
+          </button>
           <Link
             href={`/cases/${first}/compose?ids=${idsParam}`}
             className="block px-4 py-2 hover:bg-gray-100"


### PR DESCRIPTION
## Summary
- let client request re-analysis of a case
- add a new API endpoint to trigger re-analysis
- add button to case view to call the new API
- let case action menus also trigger re-analysis

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b377afdcc832ba086664569d6bfed