### PR TITLE
Fix e2e stubs

### DIFF
--- a/src/lib/caseUtils.ts
+++ b/src/lib/caseUtils.ts
@@ -1,6 +1,10 @@
-import path from "node:path";
 import type { Case } from "./caseStore";
 import type { ViolationReport } from "./openai";
+
+function baseName(filePath: string): string {
+  const parts = filePath.split(/[/\\]/);
+  return parts[parts.length - 1];
+}
 
 export function getRepresentativePhoto(
   caseData: Pick<Case, "photos" | "analysis">,
@@ -12,7 +16,7 @@ export function getRepresentativePhoto(
     const best = entries[0];
     if (best) {
       const name = best[0];
-      const file = caseData.photos.find((p) => path.basename(p) === name);
+      const file = caseData.photos.find((p) => baseName(p) === name);
       if (file) return file;
     }
   }

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -10,13 +10,20 @@ let stub: OpenAIStub;
 let tmpDir: string;
 
 beforeAll(async () => {
-  stub = await startOpenAIStub({ violationType: "parking" });
+  stub = await startOpenAIStub({
+    violationType: "parking",
+    details: "car parked illegally",
+    vehicle: {},
+    images: {},
+  });
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  process.env.CASE_STORE_FILE = path.join(tmpDir, "cases.json");
-  process.env.VIN_SOURCE_FILE = path.join(tmpDir, "vinSources.json");
-  process.env.OPENAI_BASE_URL = stub.url;
+  const env = {
+    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+    VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
+    OPENAI_BASE_URL: stub.url,
+  };
   fs.writeFileSync(
-    process.env.VIN_SOURCE_FILE,
+    env.VIN_SOURCE_FILE,
     JSON.stringify(
       [
         { id: "edmunds", enabled: false, failureCount: 0 },
@@ -26,16 +33,13 @@ beforeAll(async () => {
       2,
     ),
   );
-  server = await startServer(3003);
+  server = await startServer(3003, env);
 }, 120000);
 
 afterAll(async () => {
   await server.close();
   await stub.close();
   fs.rmSync(tmpDir, { recursive: true, force: true });
-  process.env.CASE_STORE_FILE = undefined;
-  process.env.VIN_SOURCE_FILE = undefined;
-  process.env.OPENAI_BASE_URL = undefined;
 }, 120000);
 
 describe("e2e flows", () => {

--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -10,13 +10,23 @@ let stub: OpenAIStub;
 let tmpDir: string;
 
 beforeAll(async () => {
-  stub = await startOpenAIStub({ subject: "s", body: "b" });
+  stub = await startOpenAIStub([
+    {
+      violationType: "parking",
+      details: "car parked illegally",
+      vehicle: {},
+      images: {},
+    },
+    { subject: "s", body: "b" },
+  ]);
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  process.env.CASE_STORE_FILE = path.join(tmpDir, "cases.json");
-  process.env.VIN_SOURCE_FILE = path.join(tmpDir, "vinSources.json");
-  process.env.OPENAI_BASE_URL = stub.url;
+  const env = {
+    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+    VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
+    OPENAI_BASE_URL: stub.url,
+  };
   fs.writeFileSync(
-    process.env.VIN_SOURCE_FILE,
+    env.VIN_SOURCE_FILE,
     JSON.stringify(
       [
         { id: "edmunds", enabled: false, failureCount: 0 },
@@ -26,16 +36,13 @@ beforeAll(async () => {
       2,
     ),
   );
-  server = await startServer(3005);
+  server = await startServer(3005, env);
 }, 120000);
 
 afterAll(async () => {
   await server.close();
   await stub.close();
   fs.rmSync(tmpDir, { recursive: true, force: true });
-  process.env.CASE_STORE_FILE = undefined;
-  process.env.VIN_SOURCE_FILE = undefined;
-  process.env.OPENAI_BASE_URL = undefined;
 }, 120000);
 
 describe("follow up", () => {

--- a/test/e2e/openaiStub.ts
+++ b/test/e2e/openaiStub.ts
@@ -49,7 +49,7 @@ export async function startOpenAIStub(
   await new Promise((resolve) => server.listen(0, resolve));
   const { port } = server.address() as AddressInfo;
   return {
-    url: `http://localhost:${port}`,
+    url: `http://127.0.0.1:${port}`,
     requests,
     close: () => new Promise((resolve) => server.close(() => resolve())),
   };

--- a/test/e2e/startServer.ts
+++ b/test/e2e/startServer.ts
@@ -18,10 +18,13 @@ function waitForServer(port: number): Promise<void> {
   });
 }
 
-export async function startServer(port = 3002): Promise<TestServer> {
+export async function startServer(
+  port = 3002,
+  env: NodeJS.ProcessEnv = {},
+): Promise<TestServer> {
   const nextBin = path.join("node_modules", ".bin", "next");
   const proc = spawn(nextBin, ["dev", "-p", String(port)], {
-    env: { ...process.env, CI: "1" },
+    env: { ...process.env, ...env, CI: "1" },
     stdio: "inherit",
   });
   await waitForServer(port);

--- a/test/e2e/thread.test.ts
+++ b/test/e2e/thread.test.ts
@@ -9,14 +9,13 @@ let tmpDir: string;
 
 beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  process.env.CASE_STORE_FILE = path.join(tmpDir, "cases.json");
-  server = await startServer(3006);
+  const env = { CASE_STORE_FILE: path.join(tmpDir, "cases.json") };
+  server = await startServer(3006, env);
 }, 120000);
 
 afterAll(async () => {
   await server.close();
   fs.rmSync(tmpDir, { recursive: true, force: true });
-  process.env.CASE_STORE_FILE = undefined;
 }, 120000);
 
 describe("thread page", () => {

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
     testTimeout: 30000,
     hookTimeout: 30000,
     threads: false,
+    maxConcurrency: 1,
+    isolate: false,
+    sequence: { concurrent: false },
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
## Summary
- return complete violation report in e2e OpenAI stub
- use sequential stub responses when testing followup logic
- ensure each test server gets its own env snapshot
- run e2e tests sequentially

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_684b3d40cf58832b9be98b4059eadca4