### PR TITLE
Update multi-case view

### DIFF
--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -1,12 +1,29 @@
+import type { Case } from "../../../lib/caseStore";
 import { getCase } from "../../../lib/caseStore";
+import CaseSummary from "../../components/CaseSummary";
 import ClientCasePage from "./ClientCasePage";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * Render the case view for a single case.
+ * If the optional "ids" query parameter contains multiple comma-separated
+ * IDs, the page instead shows a summary of those cases.
+ */
 export default async function CasePage({
   params,
-}: { params: Promise<{ id: string }> }) {
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams?: Promise<{ ids?: string }>;
+}) {
   const { id } = await params;
+  const { ids } = (await searchParams) ?? {};
+  const parsed = ids ? ids.split(",").filter(Boolean) : [];
+  if (parsed.length > 1) {
+    const cases = parsed.map((cid) => getCase(cid)).filter(Boolean) as Case[];
+    return <CaseSummary cases={cases} />;
+  }
   const c = getCase(id);
   return <ClientCasePage caseId={id} initialCase={c ?? null} />;
 }


### PR DESCRIPTION
## Summary
- show case summary for multiple selected cases via the `ids` query parameter
- fix CaseSummary import path
- document multi-case behavior in the case page

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1e9786b0832b839be1a5219eae85