### PR TITLE
Add snail mail location option

### DIFF
--- a/src/app/api/cases/[id]/notify-owner/route.ts
+++ b/src/app/api/cases/[id]/notify-owner/route.ts
@@ -28,12 +28,14 @@ export async function GET(
     email,
     attachments: c.photos,
     contactInfo,
+    violationAddress: c.streetAddress,
     availableMethods: [
       contactInfo.email ? "email" : null,
       contactInfo.phone ? "sms" : null,
       contactInfo.phone ? "whatsapp" : null,
       contactInfo.phone ? "robocall" : null,
       contactInfo.address ? "snailMail" : null,
+      c.streetAddress ? "snailMailLocation" : null,
     ].filter(Boolean),
   });
 }
@@ -81,6 +83,16 @@ export async function POST(
     notifications.push(
       sendSnailMail({
         address: contactInfo.address,
+        subject,
+        body,
+        attachments,
+      }),
+    );
+  }
+  if (methods.includes("snailMailLocation") && c.streetAddress) {
+    notifications.push(
+      sendSnailMail({
+        address: c.streetAddress,
         subject,
         body,
         attachments,

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
@@ -7,6 +7,7 @@ export default function NotifyOwnerEditor({
   initialDraft,
   attachments,
   contactInfo,
+  violationAddress,
   availableMethods,
   caseId,
 }: {
@@ -17,6 +18,7 @@ export default function NotifyOwnerEditor({
     phone?: string;
     address?: string;
   };
+  violationAddress?: string;
   availableMethods: string[];
   caseId: string;
 }) {
@@ -137,6 +139,22 @@ export default function NotifyOwnerEditor({
               }}
             />
             <span>Snail Mail: {contactInfo.address}</span>
+          </label>
+        )}
+        {violationAddress && (
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={methods.includes("snailMailLocation")}
+              onChange={(e) => {
+                if (e.target.checked) {
+                  setMethods([...methods, "snailMailLocation"]);
+                } else {
+                  setMethods(methods.filter((m) => m !== "snailMailLocation"));
+                }
+              }}
+            />
+            <span>Mail to address of violation: {violationAddress}</span>
           </label>
         )}
       </div>

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerModal.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerModal.tsx
@@ -12,6 +12,7 @@ interface DraftData {
     phone?: string;
     address?: string;
   };
+  violationAddress?: string | null;
   availableMethods: string[];
 }
 
@@ -48,6 +49,7 @@ export default function NotifyOwnerModal({
                 initialDraft={data.email}
                 attachments={data.attachments}
                 contactInfo={data.contactInfo}
+                violationAddress={data.violationAddress ?? undefined}
                 availableMethods={data.availableMethods}
               />
             ) : (


### PR DESCRIPTION
## Summary
- support snail mail to the case's violation location address
- expose location address option in the notify owner UI

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: Cannot find lightningcss binary)*

------
https://chatgpt.com/codex/tasks/task_e_684c45e63cc8832b973f092e6405baa4