### PR TITLE
feat: configurable llm providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,18 @@ OPENAI_API_KEY=
 # Optional custom OpenAI base URL
 OPENAI_BASE_URL=
 
+# Optional additional providers (comma-separated ids)
+LLM_PROVIDERS=openai
+# Model/provider for each feature
+LLM_DRAFT_EMAIL_MODEL=gpt-4o
+LLM_DRAFT_EMAIL_PROVIDER=openai
+LLM_ANALYZE_IMAGES_MODEL=gpt-4o
+LLM_ANALYZE_IMAGES_PROVIDER=openai
+LLM_OCR_PAPERWORK_MODEL=gpt-4o
+LLM_OCR_PAPERWORK_PROVIDER=openai
+LLM_EXTRACT_INFO_MODEL=gpt-4o
+LLM_EXTRACT_INFO_PROVIDER=openai
+
 # Google Maps geocoding API key
 GOOGLE_MAPS_API_KEY=
 # Public Google Maps key for client

--- a/README.md
+++ b/README.md
@@ -51,13 +51,17 @@ Copy `.env.example` to `.env` and add your API key:
 OPENAI_API_KEY=your-key
 ```
 
-The helper in `src/lib/openai.ts` uses this key to analyze uploaded violation
-photos with OpenAI's vision model. It sends the image to the model and requests
+The helpers in `src/lib/openai.ts` use this key by default through the
+configuration defined in `src/lib/llm.ts`. They send images to the model and request
 a JSON response describing the violation. The response is validated with Zod to
 ensure it matches the expected schema. If validation fails, the helper retries
 the request, providing the previous response and error to guide the model. The
 JSON schema includes the violation type, location clues, and vehicle details
 such as make, model, color and license plate information.
+
+`src/lib/llm.ts` also allows selecting different providers and models for
+features like drafting emails or OCR. Set environment variables such as
+`LLM_DRAFT_EMAIL_MODEL` or `LLM_OCR_PAPERWORK_PROVIDER` to override the defaults.
 
 `ocrPaperwork` uses the same client to transcribe public paperwork images. It
 returns the full transcription exactly as it appears. After generating this raw

--- a/src/lib/__tests__/analyzeViolation.test.ts
+++ b/src/lib/__tests__/analyzeViolation.test.ts
@@ -1,6 +1,7 @@
 import type { ChatCompletion } from "openai/resources/chat/completions";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { analyzeViolation, openai } from "../openai";
+import { getLlm } from "../llm";
+import { analyzeViolation } from "../openai";
 
 const imgs = [{ url: "data:image/png;base64,AA", filename: "foo.png" }];
 
@@ -15,7 +16,8 @@ describe("analyzeViolation", () => {
     });
   });
   it("classifies cut off responses", async () => {
-    vi.spyOn(openai.chat.completions, "create").mockResolvedValue({
+    const { client } = getLlm("analyze_images");
+    vi.spyOn(client.chat.completions, "create").mockResolvedValue({
       choices: [{ message: { content: "{" }, finish_reason: "length" }],
     } as unknown as ChatCompletion);
 
@@ -25,7 +27,8 @@ describe("analyzeViolation", () => {
   });
 
   it("classifies parse failures", async () => {
-    vi.spyOn(openai.chat.completions, "create").mockResolvedValue({
+    const { client } = getLlm("analyze_images");
+    vi.spyOn(client.chat.completions, "create").mockResolvedValue({
       choices: [{ message: { content: "oops" }, finish_reason: "stop" }],
     } as unknown as ChatCompletion);
 
@@ -35,7 +38,8 @@ describe("analyzeViolation", () => {
   });
 
   it("classifies schema mismatches", async () => {
-    vi.spyOn(openai.chat.completions, "create").mockResolvedValue({
+    const { client } = getLlm("analyze_images");
+    vi.spyOn(client.chat.completions, "create").mockResolvedValue({
       choices: [{ message: { content: "{}" }, finish_reason: "stop" }],
     } as unknown as ChatCompletion);
 

--- a/src/lib/__tests__/caseReport.test.ts
+++ b/src/lib/__tests__/caseReport.test.ts
@@ -2,7 +2,7 @@ import type { ChatCompletion } from "openai/resources/chat/completions";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { draftEmail, draftOwnerNotification } from "../caseReport";
 import type { Case } from "../caseStore";
-import { openai } from "../openai";
+import { getLlm } from "../llm";
 import { reportModules } from "../reportModules";
 
 const baseCase: Case = {
@@ -30,7 +30,8 @@ beforeEach(() => {
 
 describe("draftEmail", () => {
   it("returns parsed email when response is valid", async () => {
-    vi.spyOn(openai.chat.completions, "create").mockResolvedValueOnce({
+    const { client } = getLlm("draft_email");
+    vi.spyOn(client.chat.completions, "create").mockResolvedValueOnce({
       choices: [
         { message: { content: JSON.stringify({ subject: "s", body: "b" }) } },
       ],
@@ -41,7 +42,8 @@ describe("draftEmail", () => {
   });
 
   it("retries when response is invalid", async () => {
-    vi.spyOn(openai.chat.completions, "create")
+    const { client } = getLlm("draft_email");
+    vi.spyOn(client.chat.completions, "create")
       .mockResolvedValueOnce({
         choices: [{ message: { content: "{}" } }],
       } as unknown as ChatCompletion)
@@ -58,7 +60,8 @@ describe("draftEmail", () => {
   });
 
   it("returns empty draft after repeated failures", async () => {
-    vi.spyOn(openai.chat.completions, "create").mockResolvedValue({
+    const { client } = getLlm("draft_email");
+    vi.spyOn(client.chat.completions, "create").mockResolvedValue({
       choices: [{ message: { content: "{}" } }],
     } as unknown as ChatCompletion);
 
@@ -69,7 +72,8 @@ describe("draftEmail", () => {
 
 describe("draftOwnerNotification", () => {
   it("returns parsed email when response is valid", async () => {
-    vi.spyOn(openai.chat.completions, "create").mockResolvedValueOnce({
+    const { client } = getLlm("draft_email");
+    vi.spyOn(client.chat.completions, "create").mockResolvedValueOnce({
       choices: [
         { message: { content: JSON.stringify({ subject: "s", body: "b" }) } },
       ],
@@ -82,7 +86,8 @@ describe("draftOwnerNotification", () => {
   });
 
   it("retries when response is invalid", async () => {
-    vi.spyOn(openai.chat.completions, "create")
+    const { client } = getLlm("draft_email");
+    vi.spyOn(client.chat.completions, "create")
       .mockResolvedValueOnce({
         choices: [{ message: { content: "{}" } }],
       } as unknown as ChatCompletion)
@@ -101,7 +106,8 @@ describe("draftOwnerNotification", () => {
   });
 
   it("returns empty draft after repeated failures", async () => {
-    vi.spyOn(openai.chat.completions, "create").mockResolvedValue({
+    const { client } = getLlm("draft_email");
+    vi.spyOn(client.chat.completions, "create").mockResolvedValue({
       choices: [{ message: { content: "{}" } }],
     } as unknown as ChatCompletion);
 

--- a/src/lib/__tests__/openai.test.ts
+++ b/src/lib/__tests__/openai.test.ts
@@ -1,14 +1,17 @@
 import type { ChatCompletion } from "openai/resources/chat/completions";
 import { describe, expect, it, vi } from "vitest";
-import { extractPaperworkInfo, ocrPaperwork, openai } from "../openai";
+import { getLlm } from "../llm";
+import { extractPaperworkInfo, ocrPaperwork } from "../openai";
 
 describe("openai client", () => {
-  it("exports a client instance", () => {
-    expect(openai).toBeDefined();
+  it("provides a client instance", () => {
+    const { client } = getLlm("ocr_paperwork");
+    expect(client).toBeDefined();
   });
 
   it("ocrPaperwork returns text and info", async () => {
-    vi.spyOn(openai.chat.completions, "create")
+    const { client } = getLlm("ocr_paperwork");
+    vi.spyOn(client.chat.completions, "create")
       .mockResolvedValueOnce({
         choices: [{ message: { content: "hello" } }],
       } as unknown as ChatCompletion)

--- a/src/lib/caseReport.ts
+++ b/src/lib/caseReport.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { z } from "zod";
 import "./zod-setup";
 import type { Case, SentEmail } from "./caseStore";
-import { openai } from "./openai";
+import { getLlm } from "./llm";
 import type { ReportModule } from "./reportModules";
 
 function logBadResponse(
@@ -82,9 +82,10 @@ Mention that photos are attached. Respond with JSON matching this schema: ${JSON
   ];
 
   const messages = [...baseMessages];
+  const { client, model } = getLlm("draft_email");
   for (let attempt = 0; attempt < 3; attempt++) {
-    const res = await openai.chat.completions.create({
-      model: "gpt-4o",
+    const res = await client.chat.completions.create({
+      model,
       messages,
       max_tokens: 800,
       response_format: { type: "json_object" },
@@ -153,9 +154,10 @@ Ask about the current citation status and mention that photos are attached again
   console.log(`draftFollowUp prompt: ${prompt.replace(/\n/g, " ")}`);
 
   const messages = [...baseMessages];
+  const { client, model } = getLlm("draft_email");
   for (let attempt = 0; attempt < 3; attempt++) {
-    const res = await openai.chat.completions.create({
-      model: "gpt-4o",
+    const res = await client.chat.completions.create({
+      model,
       messages,
       max_tokens: 800,
       response_format: { type: "json_object" },
@@ -219,9 +221,10 @@ export async function draftOwnerNotification(
     { role: "user", content: prompt },
   ];
   const messages = [...baseMessages];
+  const { client, model } = getLlm("draft_email");
   for (let attempt = 0; attempt < 3; attempt++) {
-    const res = await openai.chat.completions.create({
-      model: "gpt-4o",
+    const res = await client.chat.completions.create({
+      model,
       messages,
       max_tokens: 800,
       response_format: { type: "json_object" },

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -1,0 +1,70 @@
+import dotenv from "dotenv";
+import OpenAI from "openai";
+
+dotenv.config();
+
+export interface LlmProvider {
+  id: string;
+  apiKey: string;
+  baseURL?: string;
+}
+
+export type LlmFeature =
+  | "draft_email"
+  | "analyze_images"
+  | "ocr_paperwork"
+  | "extract_info";
+
+function loadProviders(): Record<string, LlmProvider> {
+  const list = (process.env.LLM_PROVIDERS || "openai").split(/[,\s]+/);
+  const map: Record<string, LlmProvider> = {};
+  for (const name of list) {
+    if (!name) continue;
+    const key = name.trim();
+    const upper = key.toUpperCase().replace(/-/g, "_");
+    map[key] = {
+      id: key,
+      apiKey: process.env[`${upper}_API_KEY`] || "",
+      baseURL: process.env[`${upper}_BASE_URL`],
+    };
+  }
+  return map;
+}
+
+export const providers = loadProviders();
+const clients: Record<string, OpenAI> = {};
+
+function getClient(id: string): OpenAI {
+  if (!clients[id]) {
+    const p = providers[id];
+    clients[id] = new OpenAI({
+      apiKey: p.apiKey,
+      baseURL: p.baseURL,
+      dangerouslyAllowBrowser: true,
+    });
+  }
+  return clients[id];
+}
+
+function toEnvKey(feature: LlmFeature): string {
+  return feature.toUpperCase();
+}
+
+function getFeatureProvider(feature: LlmFeature): string {
+  const env = process.env[`LLM_${toEnvKey(feature)}_PROVIDER`];
+  return env || "openai";
+}
+
+function getFeatureModel(feature: LlmFeature): string {
+  const env = process.env[`LLM_${toEnvKey(feature)}_MODEL`];
+  return env || "gpt-4o";
+}
+
+export function getLlm(feature: LlmFeature): { client: OpenAI; model: string } {
+  const providerId = getFeatureProvider(feature);
+  const provider = providers[providerId];
+  if (!provider) throw new Error(`Unknown provider ${providerId}`);
+  const client = getClient(providerId);
+  const model = getFeatureModel(feature);
+  return { client, model };
+}


### PR DESCRIPTION
## Summary
- configure provider & model per feature via `llm.ts`
- use new helper from image analysis, OCR and email drafting code
- document LLM settings in README and `.env.example`
- update unit tests for configurable client

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c4432b95c832ba8834fdda9ecc71a