### PR TITLE
fix: allow deletion when case actions disabled

### DIFF
--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -10,13 +10,6 @@ export default function CaseToolbar({
   disabled?: boolean;
   hasOwner?: boolean;
 }) {
-  if (disabled) {
-    return (
-      <div className="bg-gray-100 dark:bg-gray-800 px-8 py-2 flex justify-end text-gray-500 dark:text-gray-400">
-        No actions available
-      </div>
-    );
-  }
   return (
     <div className="bg-gray-100 dark:bg-gray-800 px-8 py-2 flex justify-end">
       <details className="relative">
@@ -24,36 +17,42 @@ export default function CaseToolbar({
           Actions
         </summary>
         <div className="absolute right-0 mt-1 bg-white dark:bg-gray-900 border rounded shadow">
-          <button
-            type="button"
-            onClick={async () => {
-              await fetch(`/api/cases/${caseId}/reanalyze`, { method: "POST" });
-              window.location.reload();
-            }}
-            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
-          >
-            Re-run Analysis
-          </button>
-          <Link
-            href={`/cases/${caseId}/compose`}
-            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-          >
-            Draft Email to Authorities
-          </Link>
-          {hasOwner ? null : (
-            <Link
-              href={`/cases/${caseId}/ownership`}
-              className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-            >
-              Request Ownership Info
-            </Link>
+          {disabled ? null : (
+            <>
+              <button
+                type="button"
+                onClick={async () => {
+                  await fetch(`/api/cases/${caseId}/reanalyze`, {
+                    method: "POST",
+                  });
+                  window.location.reload();
+                }}
+                className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+              >
+                Re-run Analysis
+              </button>
+              <Link
+                href={`/cases/${caseId}/compose`}
+                className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+              >
+                Draft Email to Authorities
+              </Link>
+              {hasOwner ? null : (
+                <Link
+                  href={`/cases/${caseId}/ownership`}
+                  className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                >
+                  Request Ownership Info
+                </Link>
+              )}
+              <Link
+                href={`/cases/${caseId}/notify-owner`}
+                className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+              >
+                Notify Registered Owner
+              </Link>
+            </>
           )}
-          <Link
-            href={`/cases/${caseId}/notify-owner`}
-            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-          >
-            Notify Registered Owner
-          </Link>
           <button
             type="button"
             onClick={async () => {

--- a/src/app/components/MultiCaseToolbar.tsx
+++ b/src/app/components/MultiCaseToolbar.tsx
@@ -10,13 +10,6 @@ export default function MultiCaseToolbar({
   disabled?: boolean;
   hasOwner?: boolean;
 }) {
-  if (disabled) {
-    return (
-      <div className="bg-gray-100 dark:bg-gray-800 px-8 py-2 flex justify-end text-gray-500 dark:text-gray-400">
-        No actions available
-      </div>
-    );
-  }
   const idsParam = caseIds.join(",");
   const first = caseIds[0];
   return (
@@ -26,40 +19,44 @@ export default function MultiCaseToolbar({
           Actions
         </summary>
         <div className="absolute right-0 mt-1 bg-white dark:bg-gray-900 border rounded shadow">
-          <button
-            type="button"
-            onClick={async () => {
-              await Promise.all(
-                caseIds.map((id) =>
-                  fetch(`/api/cases/${id}/reanalyze`, { method: "POST" }),
-                ),
-              );
-              window.location.reload();
-            }}
-            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
-          >
-            Re-run Analysis
-          </button>
-          <Link
-            href={`/cases/${first}/compose?ids=${idsParam}`}
-            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-          >
-            Draft Email to Authorities
-          </Link>
-          {hasOwner ? null : (
-            <Link
-              href={`/cases/${first}/ownership?ids=${idsParam}`}
-              className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-            >
-              Request Ownership Info
-            </Link>
+          {disabled ? null : (
+            <>
+              <button
+                type="button"
+                onClick={async () => {
+                  await Promise.all(
+                    caseIds.map((id) =>
+                      fetch(`/api/cases/${id}/reanalyze`, { method: "POST" }),
+                    ),
+                  );
+                  window.location.reload();
+                }}
+                className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+              >
+                Re-run Analysis
+              </button>
+              <Link
+                href={`/cases/${first}/compose?ids=${idsParam}`}
+                className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+              >
+                Draft Email to Authorities
+              </Link>
+              {hasOwner ? null : (
+                <Link
+                  href={`/cases/${first}/ownership?ids=${idsParam}`}
+                  className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                >
+                  Request Ownership Info
+                </Link>
+              )}
+              <Link
+                href={`/cases/${first}/notify-owner?ids=${idsParam}`}
+                className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+              >
+                Notify Registered Owner
+              </Link>
+            </>
           )}
-          <Link
-            href={`/cases/${first}/notify-owner?ids=${idsParam}`}
-            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-          >
-            Notify Registered Owner
-          </Link>
           <button
             type="button"
             onClick={async () => {


### PR DESCRIPTION
## Summary
- always render CaseToolbar and MultiCaseToolbar dropdowns
- keep delete case actions visible even when other actions disabled

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c46397154832b8e792ac7161c2a03