### PR TITLE
Add Twilio robocall integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,11 @@ SNAIL_MAIL_FILE=
 RETURN_ADDRESS=
 SNAIL_MAIL_PROVIDER=mock
 
+# Twilio configuration for SMS, WhatsApp, and robocalls
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_FROM_NUMBER=
+
 # Docsmit snail mail provider
 DOCSMIT_BASE_URL=
 DOCSMIT_EMAIL=

--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ SNAIL_MAIL_PROVIDER=docsmit
 All sent mail is logged to `data/snailMail.json` or the file specified by
 `SNAIL_MAIL_FILE`. Run `npm run poll:snailmail` to invoke provider polling.
 
+## Twilio Integration
+
+Configure Twilio credentials to enable SMS, WhatsApp, and robocall
+notifications:
+
+```bash
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_AUTH_TOKEN=your_auth_token
+TWILIO_FROM_NUMBER=+15551234567
+```
+
+If these variables are not set, phone notifications are skipped.
+
 ## Inbox Scanning
 
 Configure IMAP settings in `.env` to automatically create cases from incoming

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-icons": "^4.12.0",
         "react-mermaid2": "^0.1.4",
         "ts-node": "^10.9.2",
+        "twilio": "^4.23.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -7976,7 +7977,6 @@
     },
     "node_modules/axios": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -9211,6 +9211,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -12428,6 +12434,15 @@
       "version": "0.1.1",
       "license": "MIT"
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "license": "MIT"
@@ -14211,7 +14226,6 @@
     },
     "node_modules/form-data": {
       "version": "4.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -19800,6 +19814,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jsprim": {
       "version": "1.4.2",
       "license": "MIT",
@@ -19825,6 +19861,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/katex": {
@@ -20261,12 +20318,54 @@
       "version": "4.0.8",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lodash.sortby": {
@@ -25982,7 +26081,6 @@
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prr": {
@@ -31084,6 +31182,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/scmp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.1.0.tgz",
+      "integrity": "sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/selderee": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
@@ -33469,6 +33573,50 @@
       "version": "0.14.5",
       "license": "Unlicense"
     },
+    "node_modules/twilio": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-4.23.0.tgz",
+      "integrity": "sha512-LdNBQfOe0dY2oJH2sAsrxazpgfFQo5yXGxe96QA8UWB5uu+433PrUbkv8gQ5RmrRCqUTPQ0aOrIyAdBr1aB03Q==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.6.0",
+        "dayjs": "^1.11.9",
+        "https-proxy-agent": "^5.0.0",
+        "jsonwebtoken": "^9.0.0",
+        "qs": "^6.9.4",
+        "scmp": "^2.1.0",
+        "url-parse": "^1.5.9",
+        "xmlbuilder": "^13.0.2"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/twilio/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/twilio/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/type": {
       "version": "2.7.3",
       "license": "ISC"
@@ -35356,6 +35504,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
+      "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-icons": "^4.12.0",
     "react-mermaid2": "^0.1.4",
     "ts-node": "^10.9.2",
+    "twilio": "^4.23.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/lib/__tests__/contactMethods.test.ts
+++ b/src/lib/__tests__/contactMethods.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { makeRobocall } from "../contactMethods";
+
+const createMock = vi.fn();
+vi.mock("twilio", () => ({
+  default: vi.fn(() => ({ calls: { create: createMock } })),
+}));
+
+describe("makeRobocall", () => {
+  it("calls Twilio when configured", async () => {
+    process.env.TWILIO_ACCOUNT_SID = "sid";
+    process.env.TWILIO_AUTH_TOKEN = "token";
+    process.env.TWILIO_FROM_NUMBER = "+15551234567";
+    createMock.mockResolvedValue({});
+
+    await makeRobocall("+15557654321", "hello");
+
+    expect(createMock).toHaveBeenCalledWith({
+      to: "+15557654321",
+      from: "+15551234567",
+      twiml: "<Response><Say>hello</Say></Response>",
+    });
+  });
+
+  it("skips when Twilio is not configured", async () => {
+    process.env.TWILIO_ACCOUNT_SID = "";
+    process.env.TWILIO_AUTH_TOKEN = "";
+    process.env.TWILIO_FROM_NUMBER = "";
+    createMock.mockClear();
+
+    await makeRobocall("+15557654321", "hello");
+
+    expect(createMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/contactMethods.ts
+++ b/src/lib/contactMethods.ts
@@ -8,6 +8,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import dotenv from "dotenv";
+import twilio from "twilio";
 import {
   type MailingAddress,
   sendSnailMail as providerSendSnailMail,
@@ -40,7 +41,19 @@ export async function sendWhatsapp(to: string, message: string): Promise<void> {
 }
 
 export async function makeRobocall(to: string, message: string): Promise<void> {
-  console.log(`makeRobocall to=${to} message=${message}`);
+  const sid = process.env.TWILIO_ACCOUNT_SID;
+  const token = process.env.TWILIO_AUTH_TOKEN;
+  const from = process.env.TWILIO_FROM_NUMBER;
+  if (!sid || !token || !from) {
+    console.warn("Twilio not configured");
+    return;
+  }
+  const client = twilio(sid, token);
+  await client.calls.create({
+    to,
+    from,
+    twiml: `<Response><Say>${message}</Say></Response>`,
+  });
 }
 
 export async function sendSnailMail(options: {


### PR DESCRIPTION
## Summary
- hook up robocalls to Twilio voice calls
- document Twilio variables in README and `.env.example`
- add tests for `makeRobocall`
- install `twilio` dependency

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c469b7a1c832bae554dc1e25d45f7