### PR TITLE
Integrate Twilio messaging

### DIFF
--- a/src/lib/__tests__/contactMethods.test.ts
+++ b/src/lib/__tests__/contactMethods.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
-import { makeRobocall } from "../contactMethods";
+import { makeRobocall, sendSms, sendWhatsapp } from "../contactMethods";
 
-const createMock = vi.fn();
+const callCreateMock = vi.fn();
+const messageCreateMock = vi.fn();
 vi.mock("twilio", () => ({
-  default: vi.fn(() => ({ calls: { create: createMock } })),
+  default: vi.fn(() => ({
+    calls: { create: callCreateMock },
+    messages: { create: messageCreateMock },
+  })),
 }));
 
 describe("makeRobocall", () => {
@@ -11,11 +15,11 @@ describe("makeRobocall", () => {
     process.env.TWILIO_ACCOUNT_SID = "sid";
     process.env.TWILIO_AUTH_TOKEN = "token";
     process.env.TWILIO_FROM_NUMBER = "+15551234567";
-    createMock.mockResolvedValue({});
+    callCreateMock.mockResolvedValue({});
 
     await makeRobocall("+15557654321", "hello");
 
-    expect(createMock).toHaveBeenCalledWith({
+    expect(callCreateMock).toHaveBeenCalledWith({
       to: "+15557654321",
       from: "+15551234567",
       twiml: "<Response><Say>hello</Say></Response>",
@@ -26,10 +30,66 @@ describe("makeRobocall", () => {
     process.env.TWILIO_ACCOUNT_SID = "";
     process.env.TWILIO_AUTH_TOKEN = "";
     process.env.TWILIO_FROM_NUMBER = "";
-    createMock.mockClear();
+    callCreateMock.mockClear();
 
     await makeRobocall("+15557654321", "hello");
 
-    expect(createMock).not.toHaveBeenCalled();
+    expect(callCreateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendSms", () => {
+  it("calls Twilio when configured", async () => {
+    process.env.TWILIO_ACCOUNT_SID = "sid";
+    process.env.TWILIO_AUTH_TOKEN = "token";
+    process.env.TWILIO_FROM_NUMBER = "+15551234567";
+    messageCreateMock.mockResolvedValue({});
+
+    await sendSms("+15557654321", "hello");
+
+    expect(messageCreateMock).toHaveBeenCalledWith({
+      to: "+15557654321",
+      from: "+15551234567",
+      body: "hello",
+    });
+  });
+
+  it("skips when Twilio is not configured", async () => {
+    process.env.TWILIO_ACCOUNT_SID = "";
+    process.env.TWILIO_AUTH_TOKEN = "";
+    process.env.TWILIO_FROM_NUMBER = "";
+    messageCreateMock.mockClear();
+
+    await sendSms("+15557654321", "hello");
+
+    expect(messageCreateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendWhatsapp", () => {
+  it("calls Twilio when configured", async () => {
+    process.env.TWILIO_ACCOUNT_SID = "sid";
+    process.env.TWILIO_AUTH_TOKEN = "token";
+    process.env.TWILIO_FROM_NUMBER = "+15551234567";
+    messageCreateMock.mockResolvedValue({});
+
+    await sendWhatsapp("+15557654321", "hello");
+
+    expect(messageCreateMock).toHaveBeenCalledWith({
+      to: "whatsapp:+15557654321",
+      from: "whatsapp:+15551234567",
+      body: "hello",
+    });
+  });
+
+  it("skips when Twilio is not configured", async () => {
+    process.env.TWILIO_ACCOUNT_SID = "";
+    process.env.TWILIO_AUTH_TOKEN = "";
+    process.env.TWILIO_FROM_NUMBER = "";
+    messageCreateMock.mockClear();
+
+    await sendWhatsapp("+15557654321", "hello");
+
+    expect(messageCreateMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/contactMethods.ts
+++ b/src/lib/contactMethods.ts
@@ -33,11 +33,35 @@ function parseAddress(text: string): MailingAddress {
 }
 
 export async function sendSms(to: string, message: string): Promise<void> {
-  console.log(`sendSms to=${to} message=${message}`);
+  const sid = process.env.TWILIO_ACCOUNT_SID;
+  const token = process.env.TWILIO_AUTH_TOKEN;
+  const from = process.env.TWILIO_FROM_NUMBER;
+  if (!sid || !token || !from) {
+    console.warn("Twilio not configured");
+    return;
+  }
+  const client = twilio(sid, token);
+  await client.messages.create({
+    to,
+    from,
+    body: message,
+  });
 }
 
 export async function sendWhatsapp(to: string, message: string): Promise<void> {
-  console.log(`sendWhatsapp to=${to} message=${message}`);
+  const sid = process.env.TWILIO_ACCOUNT_SID;
+  const token = process.env.TWILIO_AUTH_TOKEN;
+  const from = process.env.TWILIO_FROM_NUMBER;
+  if (!sid || !token || !from) {
+    console.warn("Twilio not configured");
+    return;
+  }
+  const client = twilio(sid, token);
+  await client.messages.create({
+    to: `whatsapp:${to}`,
+    from: `whatsapp:${from}`,
+    body: message,
+  });
 }
 
 export async function makeRobocall(to: string, message: string): Promise<void> {


### PR DESCRIPTION
## Summary
- use Twilio to send SMS and WhatsApp messages
- test Twilio SMS and WhatsApp integrations

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c4c03f480832b97f92167cb471bef