### PR TITLE
Add violation code lookup and caching

### DIFF
--- a/src/lib/__tests__/caseReport.test.ts
+++ b/src/lib/__tests__/caseReport.test.ts
@@ -4,6 +4,7 @@ import { draftEmail, draftOwnerNotification } from "../caseReport";
 import type { Case } from "../caseStore";
 import { getLlm } from "../llm";
 import { reportModules } from "../reportModules";
+import * as violationCodes from "../violationCodes";
 
 const baseCase: Case = {
   id: "1",
@@ -26,6 +27,7 @@ const baseCase: Case = {
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  vi.spyOn(violationCodes, "getViolationCode").mockResolvedValue("1-1-1");
 });
 
 describe("draftEmail", () => {

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -13,7 +13,8 @@ export type LlmFeature =
   | "draft_email"
   | "analyze_images"
   | "ocr_paperwork"
-  | "extract_info";
+  | "extract_info"
+  | "lookup_code";
 
 function loadProviders(): Record<string, LlmProvider> {
   const list = (process.env.LLM_PROVIDERS || "openai").split(/[,\s]+/);

--- a/src/lib/violationCodes.ts
+++ b/src/lib/violationCodes.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import path from "node:path";
+import { getLlm } from "./llm";
+
+export interface ViolationCodeMap {
+  [municipality: string]: Record<string, string>;
+}
+
+const dataFile = process.env.VIOLATION_CODE_FILE
+  ? path.resolve(process.env.VIOLATION_CODE_FILE)
+  : path.join(process.cwd(), "data", "violationCodes.json");
+
+function loadCodes(): ViolationCodeMap {
+  if (!fs.existsSync(dataFile)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(dataFile, "utf8")) as ViolationCodeMap;
+  } catch {
+    return {};
+  }
+}
+
+function saveCodes(map: ViolationCodeMap): void {
+  fs.mkdirSync(path.dirname(dataFile), { recursive: true });
+  fs.writeFileSync(dataFile, JSON.stringify(map, null, 2));
+}
+
+function getStoredCode(municipality: string, violation: string): string | null {
+  const map = loadCodes();
+  return map[municipality]?.[violation] ?? null;
+}
+
+function setStoredCode(
+  municipality: string,
+  violation: string,
+  code: string,
+): void {
+  const map = loadCodes();
+  if (!map[municipality]) map[municipality] = {};
+  map[municipality][violation] = code;
+  saveCodes(map);
+}
+
+export async function getViolationCode(
+  municipality: string,
+  violation: string,
+): Promise<string | null> {
+  const cached = getStoredCode(municipality, violation);
+  if (cached) return cached;
+  if (!municipality || !violation) return null;
+  try {
+    const schema = { type: "object", properties: { code: { type: "string" } } };
+    const prompt = `What municipal or state code applies to the following violation?\nMunicipality: ${municipality}\nViolation: ${violation}\nRespond with JSON matching this schema: ${JSON.stringify(
+      schema,
+    )}`;
+    const messages = [
+      {
+        role: "system",
+        content:
+          "You look up municipal or state codes for vehicle violations and respond in JSON only.",
+      },
+      { role: "user", content: prompt },
+    ];
+    const { client, model } = getLlm("lookup_code");
+    const res = await client.chat.completions.create({
+      model,
+      messages,
+      max_tokens: 60,
+      response_format: { type: "json_object" },
+    });
+    const text = res.choices[0]?.message?.content ?? "{}";
+    const parsed = JSON.parse(text) as { code?: string };
+    const code = parsed.code?.trim();
+    if (code) {
+      setStoredCode(municipality, violation, code);
+      return code;
+    }
+  } catch (err) {
+    console.error("lookupViolationCode failed", err);
+  }
+  return null;
+}

--- a/test/violationCodesLookup.test.ts
+++ b/test/violationCodesLookup.test.ts
@@ -1,0 +1,48 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ChatCompletion } from "openai/resources/chat/completions";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "vcode-"));
+  process.env.VIOLATION_CODE_FILE = path.join(dataDir, "codes.json");
+  vi.resetModules();
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  process.env.VIOLATION_CODE_FILE = undefined;
+  vi.resetModules();
+});
+
+describe("getViolationCode", () => {
+  it("uses llm when missing and caches result", async () => {
+    const mod = await import("../src/lib/violationCodes");
+    const { client } = (await import("../src/lib/llm")).getLlm("lookup_code");
+    vi.spyOn(client.chat.completions, "create").mockResolvedValueOnce({
+      choices: [{ message: { content: JSON.stringify({ code: "A1" }) } }],
+    } as unknown as ChatCompletion);
+    const code = await mod.getViolationCode("oak-park", "parking");
+    expect(code).toBe("A1");
+    const stored = JSON.parse(
+      fs.readFileSync(process.env.VIOLATION_CODE_FILE ?? "", "utf8"),
+    );
+    expect(stored["oak-park"].parking).toBe("A1");
+  });
+
+  it("returns cached code without llm call", async () => {
+    fs.writeFileSync(
+      process.env.VIOLATION_CODE_FILE ?? "",
+      JSON.stringify({ "oak-park": { parking: "B2" } }, null, 2),
+    );
+    const mod = await import("../src/lib/violationCodes");
+    const { client } = (await import("../src/lib/llm")).getLlm("lookup_code");
+    const spy = vi.spyOn(client.chat.completions, "create");
+    const code = await mod.getViolationCode("oak-park", "parking");
+    expect(code).toBe("B2");
+    expect(spy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- cache municipal violation codes via new module
- include applicable code when drafting emails
- extend LLM features
- add tests for code lookup and update existing tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c504e406c832b8dcaacd4271b1c2c