### PR TITLE
Set cases list as home route

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { beforeAll, describe, expect, it } from "vitest";
 import Home from "../page";
 
@@ -13,8 +12,13 @@ describe("Home page", () => {
       FakeEventSource as unknown as typeof EventSource;
   });
 
-  it("shows the cases list", async () => {
-    render(await Home({ searchParams: Promise.resolve({}) }));
-    expect(screen.getByText("Cases")).toBeInTheDocument();
+  it("redirects to /cases", () => {
+    try {
+      Home();
+    } catch (err) {
+      expect((err as { digest?: string }).digest).toContain("/cases");
+      return;
+    }
+    throw new Error("Expected redirect");
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,2 +1,6 @@
 export { dynamic } from "./cases/page";
-export { default } from "./cases/page";
+import { redirect } from "next/navigation";
+
+export default function Home() {
+  redirect("/cases");
+}

--- a/src/lib/contactMethods.ts
+++ b/src/lib/contactMethods.ts
@@ -7,9 +7,10 @@ export interface OwnerContactInfo {
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+
 import dotenv from "dotenv";
-import twilio from "twilio";
 import { PDFDocument, StandardFonts } from "pdf-lib";
+import twilio from "twilio";
 import {
   type MailingAddress,
   sendSnailMail as providerSendSnailMail,


### PR DESCRIPTION
## Summary
- redirect the home page to `/cases`
- adjust tests for redirect
- sort imports in contactMethods

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c6b8a2ffc832b8f7730428213a273