### PR TITLE
Improve mobile layout for case pages

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Image from "next/image";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import type { Case } from "../../../lib/caseStore";
@@ -233,7 +234,12 @@ export default function ClientCasePage({
     <CaseLayout
       header={
         <div className="flex items-center justify-between">
-          <h1 className="text-xl font-semibold">Case {caseData.id}</h1>
+          <div className="flex items-center gap-2">
+            <Link href="/cases" className="text-blue-500 underline md:hidden">
+              Back to Cases
+            </Link>
+            <h1 className="text-xl font-semibold">Case {caseData.id}</h1>
+          </div>
           <CaseToolbar
             caseId={caseId}
             disabled={!violationIdentified}

--- a/src/app/cases/layout.tsx
+++ b/src/app/cases/layout.tsx
@@ -6,16 +6,23 @@ export const dynamic = "force-dynamic";
 
 export default function CasesLayout({
   children,
+  params,
 }: {
   children: ReactNode;
+  params: { id?: string };
 }) {
   const cases = getCases();
+  const hasCase = Boolean(params.id);
   return (
-    <div className="grid grid-cols-[20%_80%] h-[calc(100vh-4rem)]">
-      <div className="border-r overflow-y-auto">
+    <div className="md:grid md:grid-cols-[20%_80%] h-[calc(100vh-4rem)]">
+      <div
+        className={`${hasCase ? "hidden md:block" : ""} border-r overflow-y-auto`}
+      >
         <ClientCasesPage initialCases={cases} />
       </div>
-      <div className="overflow-y-auto">{children}</div>
+      <div className={`${hasCase ? "" : "hidden md:block"} overflow-y-auto`}>
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/lib/contactMethods.ts
+++ b/src/lib/contactMethods.ts
@@ -8,8 +8,8 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import dotenv from "dotenv";
-import twilio from "twilio";
 import { PDFDocument, StandardFonts } from "pdf-lib";
+import twilio from "twilio";
 import {
   type MailingAddress,
   sendSnailMail as providerSendSnailMail,


### PR DESCRIPTION
## Summary
- hide the case list on mobile when viewing an individual case
- add a Back to Cases link on small screens
- sort imports via Biome

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(tests skipped)*


------
https://chatgpt.com/codex/tasks/task_e_684c6c0b0eb8832ba3a5af47253f49c5