### PR TITLE
Add marketing site styling

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,9 +1,12 @@
-module.exports = (eleventyConfig) => ({
-  dir: {
-    input: "website",
-    output: "website/dist",
-  },
-  markdownTemplateEngine: "liquid",
-  htmlTemplateEngine: "liquid",
-  dataTemplateEngine: "liquid",
-});
+module.exports = (eleventyConfig) => {
+  eleventyConfig.addPassthroughCopy("website/style.css");
+  return {
+    dir: {
+      input: "website",
+      output: "website/dist",
+    },
+    markdownTemplateEngine: "liquid",
+    htmlTemplateEngine: "liquid",
+    dataTemplateEngine: "liquid",
+  };
+};

--- a/website/_includes/layout.njk
+++ b/website/_includes/layout.njk
@@ -3,8 +3,16 @@
   <head>
     <meta charset="utf-8" />
     <title>{{ title }}</title>
+    <link rel="stylesheet" href="/style.css" />
   </head>
   <body>
+    <header>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/features/">Features</a>
+        <a href="/about/">About</a>
+      </nav>
+    </header>
     <main>
       {{ content | safe }}
     </main>

--- a/website/about.md
+++ b/website/about.md
@@ -5,4 +5,4 @@ layout: layout.njk
 
 # About Photo To Citation
 
-Learn more about the project and our mission to make streets safer.
+Photo To Citation began as a community project in Oak Park, IL. Our goal is to make it effortless for residents to document dangerous parking behavior and ensure violators are held accountable. By combining modern web tech with language models, we streamline everything from photo analysis to mailing citations.

--- a/website/features.md
+++ b/website/features.md
@@ -5,4 +5,11 @@ layout: layout.njk
 
 # Features
 
-A high level overview of what the application offers.
+Photo To Citation automates the tedious parts of reporting parking violations.
+
+- **Create cases from photos or inbound email** — upload images or forward them directly to your dedicated address.
+- **Automatic AI analysis** — a language model extracts vehicle details, location clues and violation type.
+- **Reverse geocoding** — GPS data from photos is converted into street addresses.
+- **Generate reports** — the app assembles everything into a clear PDF or email for the authorities.
+- **Multi-channel notifications** — send updates via email, SMS or even snail mail.
+- **Citation tracking** — built-in modules keep tabs on the status of each citation.

--- a/website/index.md
+++ b/website/index.md
@@ -3,6 +3,9 @@ title: Home
 layout: layout.njk
 ---
 
-# Photo To Citation
+<div class="hero">
+  <h1>Photo To Citation</h1>
+  <p>Turn street parking violations into real citations with just a photo.</p>
+</div>
 
-Welcome to the future home of our marketing site.
+Welcome to **Photo To Citation**, an experimental app that helps residents of Oak Park, IL report vehicles blocking sidewalks and bike lanes. Snap a picture, upload it, and the system prepares a formal report for the authorities.

--- a/website/style.css
+++ b/website/style.css
@@ -1,0 +1,45 @@
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  background: #111;
+  color: #eee;
+  line-height: 1.6;
+}
+
+header {
+  background: #000;
+  padding: 1rem;
+  text-align: center;
+}
+
+header a {
+  color: #eee;
+  margin: 0 1rem;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+header a:hover {
+  color: #2eaef0;
+}
+
+main {
+  padding: 2rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.hero {
+  text-align: center;
+  padding: 3rem 0;
+}
+
+.hero h1 {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  font-size: 1.2rem;
+  color: #ccc;
+}


### PR DESCRIPTION
## Summary
- improve Eleventy config to copy static files
- add navigation and global CSS
- flesh out marketing pages with information from README and docs

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run website`

------
https://chatgpt.com/codex/tasks/task_e_684c8129b478832b8c83023e4a2afb0e