### PR TITLE
Fix params usage in cases layout

### DIFF
--- a/src/app/cases/CasesLayoutClient.tsx
+++ b/src/app/cases/CasesLayoutClient.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useParams } from "next/navigation";
+import type { ReactNode } from "react";
+import type { Case } from "../../lib/caseStore";
+import ClientCasesPage from "./ClientCasesPage";
+
+export default function CasesLayoutClient({
+  children,
+  initialCases,
+}: {
+  children: ReactNode;
+  initialCases: Case[];
+}) {
+  const params = useParams<{ id?: string }>();
+  const hasCase = Boolean(params.id);
+  return (
+    <div className="md:grid md:grid-cols-[20%_80%] h-[calc(100vh-4rem)]">
+      <div
+        className={`${hasCase ? "hidden md:block" : ""} border-r overflow-y-auto`}
+      >
+        <ClientCasesPage initialCases={initialCases} />
+      </div>
+      <div className={`${hasCase ? "" : "hidden md:block"} overflow-y-auto`}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/app/cases/layout.tsx
+++ b/src/app/cases/layout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { getCases } from "../../lib/caseStore";
-import ClientCasesPage from "./ClientCasesPage";
+import CasesLayoutClient from "./CasesLayoutClient";
 
 export const dynamic = "force-dynamic";
 
@@ -11,19 +11,7 @@ export default async function CasesLayout({
   children: ReactNode;
   params: Promise<{ id?: string }>;
 }) {
-  const { id } = await params;
+  await params;
   const cases = getCases();
-  const hasCase = Boolean(id);
-  return (
-    <div className="md:grid md:grid-cols-[20%_80%] h-[calc(100vh-4rem)]">
-      <div
-        className={`${hasCase ? "hidden md:block" : ""} border-r overflow-y-auto`}
-      >
-        <ClientCasesPage initialCases={cases} />
-      </div>
-      <div className={`${hasCase ? "" : "hidden md:block"} overflow-y-auto`}>
-        {children}
-      </div>
-    </div>
-  );
+  return <CasesLayoutClient initialCases={cases}>{children}</CasesLayoutClient>;
 }


### PR DESCRIPTION
## Summary
- await the params in `CasesLayout` to comply with dynamic API guidelines

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_684ca2426a18832b9ffa365042881721