### PR TITLE
Limit progress graph labels

### DIFF
--- a/src/app/components/CaseProgressGraph.tsx
+++ b/src/app/components/CaseProgressGraph.tsx
@@ -103,11 +103,14 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
           ["confirm", "sent", true, "citation processing"],
           ["sent", "received", true, "awaiting delivery"],
         ];
+    const activeFromIdx = firstPending > 0 ? firstPending - 1 : -1;
+    const activeFrom = activeFromIdx >= 0 ? steps[activeFromIdx].id : null;
+    const activeTo = firstPending >= 0 ? steps[firstPending].id : null;
     const edges = edgesList
-      .map(
-        ([a, b, hard, label]) =>
-          `${a}${hard ? "-->" : "-.->"}${label ? `|${label}|` : ""}${b}`,
-      )
+      .map(([a, b, hard, label]) => {
+        const show = label && a === activeFrom && b === activeTo;
+        return `${a}${hard ? "-->" : "-.->"}${show ? `|${label}|` : ""}${b}`;
+      })
       .join("\n");
     const classAssignments = steps
       .map((s, i) => {


### PR DESCRIPTION
## Summary
- show transition labels on the DAG only for the currently active edge

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cb97fc948832bbfc16809f3245258