### PR TITLE
Default mobile to camera page

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -1,5 +1,10 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { headers } from "next/headers";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import Home from "../page";
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+}));
 
 describe("Home page", () => {
   beforeAll(() => {
@@ -12,7 +17,25 @@ describe("Home page", () => {
       FakeEventSource as unknown as typeof EventSource;
   });
 
-  it("redirects to /cases", () => {
+  it("redirects mobile users to /point", () => {
+    (headers as vi.Mock).mockReturnValueOnce(
+      new Headers({
+        "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X)",
+      }),
+    );
+    try {
+      Home();
+    } catch (err) {
+      expect((err as { digest?: string }).digest).toContain("/point");
+      return;
+    }
+    throw new Error("Expected redirect");
+  });
+
+  it("redirects desktop users to /cases", () => {
+    (headers as vi.Mock).mockReturnValueOnce(
+      new Headers({ "user-agent": "Mozilla/5.0 (X11; Linux x86_64)" }),
+    );
     try {
       Home();
     } catch (err) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,9 @@
 export { dynamic } from "./cases/page";
+import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
 export default function Home() {
-  redirect("/cases");
+  const ua = headers().get("user-agent") ?? "";
+  const isMobile = /Mobile|Android|iPhone|iPad/i.test(ua);
+  redirect(isMobile ? "/point" : "/cases");
 }

--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -55,13 +55,13 @@ export default function PointAndShootPage() {
   }
 
   return (
-    <div className="relative h-[100dvh] bg-black">
+    <div className="relative h-[100dvh] overflow-hidden bg-black">
       <video
         ref={videoRef}
         autoPlay
         muted
         playsInline
-        className="w-full h-full object-cover"
+        className="fixed inset-0 w-full h-full object-cover -z-10"
       >
         <track kind="captions" label="" />
       </video>


### PR DESCRIPTION
## Summary
- redirect mobile user agents to `/point`
- render camera stream as the page background
- update tests for user agent-specific redirects

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cbc3bcf24832ba1675605b39e798d