### PR TITLE
Fix owner notification authority message

### DIFF
--- a/src/app/api/cases/[id]/notify-owner/route.ts
+++ b/src/app/api/cases/[id]/notify-owner/route.ts
@@ -22,7 +22,12 @@ export async function GET(
   if (!contactInfo) {
     return NextResponse.json({ error: "No owner contact" }, { status: 400 });
   }
-  const authorities = [reportModules["oak-park"].authorityName];
+  const reportModule = reportModules["oak-park"];
+  const authorities = c.sentEmails?.some(
+    (m) => m.to === reportModule.authorityEmail,
+  )
+    ? [reportModule.authorityName]
+    : [];
   const email = await draftOwnerNotification(c, authorities);
   return NextResponse.json({
     email,

--- a/src/app/api/snail-mail-providers/[id]/route.ts
+++ b/src/app/api/snail-mail-providers/[id]/route.ts
@@ -1,7 +1,13 @@
-import { getSnailMailProviderStatuses, setActiveSnailMailProvider } from "@/lib/snailMailProviders";
+import {
+  getSnailMailProviderStatuses,
+  setActiveSnailMailProvider,
+} from "@/lib/snailMailProviders";
 import { NextResponse } from "next/server";
 
-export async function PUT(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function PUT(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
   const { id } = await params;
   const result = setActiveSnailMailProvider(id);
   if (!result) {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -15,7 +15,9 @@ interface SnailMailProviderStatus {
 
 export default function SettingsPage() {
   const [sources, setSources] = useState<VinSourceStatus[]>([]);
-  const [mailProviders, setMailProviders] = useState<SnailMailProviderStatus[]>([]);
+  const [mailProviders, setMailProviders] = useState<SnailMailProviderStatus[]>(
+    [],
+  );
 
   useEffect(() => {
     fetch("/api/vin-sources")
@@ -73,7 +75,9 @@ export default function SettingsPage() {
               {p.id} (failures: {p.failureCount})
             </span>
             {p.active ? (
-              <span className="px-2 py-1 bg-green-500 text-white rounded">Active</span>
+              <span className="px-2 py-1 bg-green-500 text-white rounded">
+                Active
+              </span>
             ) : (
               <button
                 type="button"

--- a/src/lib/caseReport.ts
+++ b/src/lib/caseReport.ts
@@ -215,13 +215,16 @@ export async function draftOwnerNotification(
     type: "object",
     properties: { subject: { type: "string" }, body: { type: "string" } },
   };
-  const authorityList =
-    authorities.length > 0 ? authorities.join(", ") : "no authorities";
+  const authorityList = authorities.join(", ");
+  const authorityLine =
+    authorities.length > 0
+      ? `Mention that the following authorities have been contacted: ${authorityList}. `
+      : "";
   const code = await getViolationCode(
     "oak-park",
     analysis?.violationType || "",
   );
-  const prompt = `Draft a short, professional email to the registered owner informing them of their violation and case status. Mention that the following authorities have been contacted: ${authorityList}. Do not reveal any information about the sender. Chastise the owner professionally and note that further action from authorities is pending. Include any applicable municipal or state codes for the violation. Include these details if available:\n- Violation: ${analysis?.violationType || ""}\n- Description: ${analysis?.details || ""}\n- Location: ${location}\n- License Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}\n- Time: ${new Date(time).toISOString()}\n${code ? `Applicable code: ${code}\n` : ""}Mention that photos are attached. Respond with JSON matching this schema: ${JSON.stringify(
+  const prompt = `Draft a short, professional email to the registered owner informing them of their violation and case status. ${authorityLine}Do not reveal any information about the sender. Chastise the owner professionally and note that further action from authorities is pending. Include any applicable municipal or state codes for the violation. Include these details if available:\n- Violation: ${analysis?.violationType || ""}\n- Description: ${analysis?.details || ""}\n- Location: ${location}\n- License Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}\n- Time: ${new Date(time).toISOString()}\n${code ? `Applicable code: ${code}\n` : ""}Mention that photos are attached. Respond with JSON matching this schema: ${JSON.stringify(
     schema,
   )}`;
   const baseMessages = [

--- a/src/lib/snailMailProviders.ts
+++ b/src/lib/snailMailProviders.ts
@@ -28,7 +28,9 @@ function loadStatuses(): SnailMailProviderStatus[] {
     return defaults;
   }
   try {
-    return JSON.parse(fs.readFileSync(dataFile, "utf8")) as SnailMailProviderStatus[];
+    return JSON.parse(
+      fs.readFileSync(dataFile, "utf8"),
+    ) as SnailMailProviderStatus[];
   } catch {
     return defaultStatuses();
   }
@@ -43,7 +45,9 @@ export function getSnailMailProviderStatuses(): SnailMailProviderStatus[] {
   return loadStatuses();
 }
 
-export function setActiveSnailMailProvider(id: string): SnailMailProviderStatus | undefined {
+export function setActiveSnailMailProvider(
+  id: string,
+): SnailMailProviderStatus | undefined {
   const list = loadStatuses();
   if (!list.some((p) => p.id === id)) return undefined;
   const updated = list.map((p) => ({ ...p, active: p.id === id }));

--- a/test/snailMailProviders.test.ts
+++ b/test/snailMailProviders.test.ts
@@ -14,7 +14,10 @@ beforeEach(async () => {
     active: idx === 0,
     failureCount: 0,
   }));
-  fs.writeFileSync(process.env.SNAIL_MAIL_PROVIDER_FILE, JSON.stringify(statuses));
+  fs.writeFileSync(
+    process.env.SNAIL_MAIL_PROVIDER_FILE,
+    JSON.stringify(statuses),
+  );
 });
 
 afterEach(() => {
@@ -35,7 +38,9 @@ describe("snail mail provider store", () => {
   it("records failures", async () => {
     const store = await import("../src/lib/snailMailProviders");
     store.recordProviderFailure("mock");
-    const item = store.getSnailMailProviderStatuses().find((p) => p.id === "mock");
+    const item = store
+      .getSnailMailProviderStatuses()
+      .find((p) => p.id === "mock");
     expect(item?.failureCount).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- mention authorities in owner emails only if authorities actually contacted
- update owner notification API route to check case history
- run Biome formatting

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cbcfda7a0832ba89013ad324c1ce7