### PR TITLE
Add tooltip previews for case graph links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-dom": "^19.0.0",
         "react-icons": "^4.12.0",
         "react-mermaid2": "^0.1.4",
+        "tippy.js": "^6.3.7",
         "ts-node": "^10.9.2",
         "twilio": "^4.23.0",
         "zod": "^3.23.8"
@@ -4208,6 +4209,16 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -34510,6 +34521,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
       }
     },
     "node_modules/tlds": {

--- a/package.json
+++ b/package.json
@@ -35,11 +35,13 @@
     "react-dom": "^19.0.0",
     "react-icons": "^4.12.0",
     "react-mermaid2": "^0.1.4",
+    "tippy.js": "^6.3.7",
     "ts-node": "^10.9.2",
     "twilio": "^4.23.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@11ty/eleventy": "^2.0.0",
     "@anatine/zod-openapi": "^2.2.8",
     "@biomejs/biome": "^1.9.4",
     "@eslint/eslintrc": "^3",
@@ -66,8 +68,7 @@
     "ts-to-zod": "^3.15.0",
     "typescript": "^5",
     "vite-tsconfig-paths": "^4.2.0",
-    "vitest": "^3.2.3",
-    "@11ty/eleventy": "^2.0.0"
+    "vitest": "^3.2.3"
   },
   "optionalDependencies": {
     "@biomejs/cli-linux-x64": "^1.9.4",

--- a/src/app/api/snail-mail-providers/[id]/route.ts
+++ b/src/app/api/snail-mail-providers/[id]/route.ts
@@ -1,7 +1,13 @@
-import { getSnailMailProviderStatuses, setActiveSnailMailProvider } from "@/lib/snailMailProviders";
+import {
+  getSnailMailProviderStatuses,
+  setActiveSnailMailProvider,
+} from "@/lib/snailMailProviders";
 import { NextResponse } from "next/server";
 
-export async function PUT(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function PUT(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
   const { id } = await params;
   const result = setActiveSnailMailProvider(id);
   if (!result) {

--- a/src/app/components/CaseProgressGraph.tsx
+++ b/src/app/components/CaseProgressGraph.tsx
@@ -8,7 +8,8 @@ import {
   hasViolation,
 } from "@/lib/caseUtils";
 import dynamic from "next/dynamic";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import tippy from "tippy.js";
 
 const Mermaid = dynamic(() => import("react-mermaid2"), { ssr: false });
 
@@ -116,6 +117,64 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
         return `class ${s.id} ${cls}`;
       })
       .join("\n");
+    const platePhoto = (() => {
+      const plate = getCasePlateNumber(caseData);
+      if (!plate || !caseData.analysis?.images)
+        return caseData.photos[0] ?? null;
+      for (const [name, info] of Object.entries(caseData.analysis.images)) {
+        if (
+          info.paperworkInfo?.vehicle?.licensePlateNumber === plate ||
+          info.highlights?.toLowerCase().includes("plate")
+        ) {
+          const file = caseData.photos.find((p) => p.split("/").pop() === name);
+          if (file) return file;
+        }
+      }
+      return caseData.photos[0] ?? null;
+    })();
+    const ownerDoc = (caseData.threadImages ?? []).find(
+      (i) => i.ocrInfo?.contact,
+    );
+    const ownerLink = ownerDoc
+      ? ownerDoc.threadParent
+        ? `/cases/${caseData.id}/thread/${encodeURIComponent(ownerDoc.threadParent)}`
+        : ownerDoc.url
+      : null;
+    const firstEmail = caseData.sentEmails?.[0];
+    const notifyLink = firstEmail
+      ? `/cases/${caseData.id}/thread/${encodeURIComponent(firstEmail.sentAt)}`
+      : null;
+    const clean = (t: string) => t.replace(/"/g, "'");
+    const uploadedAt = caseData.photoTimes[caseData.photos[0]] ?? null;
+    const uploadedTip = uploadedAt
+      ? `Photo taken ${new Date(uploadedAt).toLocaleString()}`
+      : "View uploaded photo";
+    const plateTipParts = [] as string[];
+    const plateNum = getCasePlateNumber(caseData);
+    const plateState = getCasePlateState(caseData);
+    if (plateNum) plateTipParts.push(`Plate: ${plateNum}`);
+    if (plateState) plateTipParts.push(`State: ${plateState}`);
+    if (platePhoto) plateTipParts.push("View plate photo");
+    const plateTip = plateTipParts.join(" \u2013 ");
+    const ownerContact = getCaseOwnerContact(caseData);
+    const ownerTip = ownerContact
+      ? `Owner info: ${ownerContact.slice(0, 40)}${
+          ownerContact.length > 40 ? "…" : ""
+        }`
+      : "View paperwork";
+    const notifyTip = firstEmail
+      ? `Notification email to ${firstEmail.to} on ${new Date(firstEmail.sentAt).toLocaleString()}`
+      : "View notification email";
+    const links = [
+      caseData.photos[0]
+        ? `click uploaded "${caseData.photos[0]}" "${clean(uploadedTip)}"`
+        : null,
+      platePhoto ? `click plate "${platePhoto}" "${clean(plateTip)}"` : null,
+      ownerLink ? `click own "${ownerLink}" "${clean(ownerTip)}"` : null,
+      notifyLink ? `click notify "${notifyLink}" "${clean(notifyTip)}"` : null,
+    ]
+      .filter(Boolean)
+      .join("\n");
     const light = {
       completedFill: "#D1FAE5",
       completedStroke: "#047857",
@@ -134,11 +193,71 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
     };
     const c = isDark ? dark : light;
     const edgeStyle = `linkStyle default fill:none,stroke:${c.pendingStroke},stroke-width:2px;`;
-    return `graph TD\n${nodes}\n${edges}\nclassDef completed fill:${c.completedFill},stroke:${c.completedStroke};\nclassDef current fill:${c.currentFill},stroke:${c.currentStroke};\nclassDef pending fill:${c.pendingFill},stroke:${c.pendingStroke};\n${edgeStyle}\n${classAssignments}`;
-  }, [status, firstPending, noviolation, steps, isDark]);
+    return `graph TD\n${nodes}\n${edges}\n${links}\nclassDef completed fill:${c.completedFill},stroke:${c.completedStroke};\nclassDef current fill:${c.currentFill},stroke:${c.currentStroke};\nclassDef pending fill:${c.pendingFill},stroke:${c.pendingStroke};\n${edgeStyle}\n${classAssignments}`;
+  }, [status, firstPending, noviolation, steps, isDark, caseData]);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const timers: number[] = [];
+    const apply = () => {
+      const map: Record<string, { url: string; preview: string } | null> = {};
+      const platePhoto = (() => {
+        const plate = getCasePlateNumber(caseData);
+        if (!plate || !caseData.analysis?.images)
+          return caseData.photos[0] ?? null;
+        for (const [name, info] of Object.entries(caseData.analysis.images)) {
+          if (
+            info.paperworkInfo?.vehicle?.licensePlateNumber === plate ||
+            info.highlights?.toLowerCase().includes("plate")
+          ) {
+            const file = caseData.photos.find(
+              (p) => p.split("/").pop() === name,
+            );
+            if (file) return file;
+          }
+        }
+        return caseData.photos[0] ?? null;
+      })();
+      const ownerDoc = (caseData.threadImages ?? []).find(
+        (i) => i.ocrInfo?.contact,
+      );
+      const ownerLink = ownerDoc
+        ? ownerDoc.threadParent
+          ? `/cases/${caseData.id}/thread/${encodeURIComponent(ownerDoc.threadParent)}`
+          : ownerDoc.url
+        : null;
+      const firstEmail = caseData.sentEmails?.[0];
+      const notifyLink = firstEmail
+        ? `/cases/${caseData.id}/thread/${encodeURIComponent(firstEmail.sentAt)}`
+        : null;
+      if (caseData.photos[0])
+        map.uploaded = { url: caseData.photos[0], preview: caseData.photos[0] };
+      if (platePhoto) map.plate = { url: platePhoto, preview: platePhoto };
+      if (ownerLink)
+        map.own = { url: ownerLink, preview: ownerDoc?.url ?? ownerLink };
+      if (notifyLink) map.notify = { url: notifyLink, preview: notifyLink };
+      for (const [id, info] of Object.entries(map)) {
+        if (!info) continue;
+        const el = container.querySelector(`#${id}`) as HTMLElement | null;
+        if (!el) continue;
+        tippy(el, {
+          content: `<img src="${info.preview}" class="max-h-40" />`,
+          allowHTML: true,
+        });
+        el.addEventListener("click", () => window.open(info.url, "_blank"));
+      }
+    };
+    const timer = window.setTimeout(apply, 100);
+    timers.push(timer);
+    return () => {
+      for (const t of timers) clearTimeout(t);
+    };
+  }, [caseData]);
 
   return (
-    <div className="max-w-full overflow-x-auto">
+    <div className="max-w-full overflow-x-auto" ref={containerRef}>
       <Mermaid chart={chart} key={chart} />
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "tippy.js/dist/tippy.css";
 
 :root {
   --background: #ffffff;

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -15,7 +15,9 @@ interface SnailMailProviderStatus {
 
 export default function SettingsPage() {
   const [sources, setSources] = useState<VinSourceStatus[]>([]);
-  const [mailProviders, setMailProviders] = useState<SnailMailProviderStatus[]>([]);
+  const [mailProviders, setMailProviders] = useState<SnailMailProviderStatus[]>(
+    [],
+  );
 
   useEffect(() => {
     fetch("/api/vin-sources")
@@ -73,7 +75,9 @@ export default function SettingsPage() {
               {p.id} (failures: {p.failureCount})
             </span>
             {p.active ? (
-              <span className="px-2 py-1 bg-green-500 text-white rounded">Active</span>
+              <span className="px-2 py-1 bg-green-500 text-white rounded">
+                Active
+              </span>
             ) : (
               <button
                 type="button"

--- a/src/lib/apiContract.ts
+++ b/src/lib/apiContract.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import { caseSchema } from "../generated/zod/caseStore";
 import { emailOptionsSchema } from "../generated/zod/email";
 import { reportModuleSchema } from "../generated/zod/reportModules";
-import { vinSourceStatusSchema } from "../generated/zod/vinSources";
 import { snailMailProviderStatusSchema } from "../generated/zod/snailMailProviders";
+import { vinSourceStatusSchema } from "../generated/zod/vinSources";
 
 const c = initContract();
 

--- a/src/lib/snailMailProviders.ts
+++ b/src/lib/snailMailProviders.ts
@@ -28,7 +28,9 @@ function loadStatuses(): SnailMailProviderStatus[] {
     return defaults;
   }
   try {
-    return JSON.parse(fs.readFileSync(dataFile, "utf8")) as SnailMailProviderStatus[];
+    return JSON.parse(
+      fs.readFileSync(dataFile, "utf8"),
+    ) as SnailMailProviderStatus[];
   } catch {
     return defaultStatuses();
   }
@@ -43,7 +45,9 @@ export function getSnailMailProviderStatuses(): SnailMailProviderStatus[] {
   return loadStatuses();
 }
 
-export function setActiveSnailMailProvider(id: string): SnailMailProviderStatus | undefined {
+export function setActiveSnailMailProvider(
+  id: string,
+): SnailMailProviderStatus | undefined {
   const list = loadStatuses();
   if (!list.some((p) => p.id === id)) return undefined;
   const updated = list.map((p) => ({ ...p, active: p.id === id }));

--- a/test/snailMailProviders.test.ts
+++ b/test/snailMailProviders.test.ts
@@ -14,7 +14,10 @@ beforeEach(async () => {
     active: idx === 0,
     failureCount: 0,
   }));
-  fs.writeFileSync(process.env.SNAIL_MAIL_PROVIDER_FILE, JSON.stringify(statuses));
+  fs.writeFileSync(
+    process.env.SNAIL_MAIL_PROVIDER_FILE,
+    JSON.stringify(statuses),
+  );
 });
 
 afterEach(() => {
@@ -35,7 +38,9 @@ describe("snail mail provider store", () => {
   it("records failures", async () => {
     const store = await import("../src/lib/snailMailProviders");
     store.recordProviderFailure("mock");
-    const item = store.getSnailMailProviderStatuses().find((p) => p.id === "mock");
+    const item = store
+      .getSnailMailProviderStatuses()
+      .find((p) => p.id === "mock");
     expect(item?.failureCount).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- use tippy.js to show previews when hovering over nodes in the case progress graph
- install tippy.js dependency
- load tooltip styles in global CSS

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cb141ecd0832ba2f041ae94bddb8f