### PR TITLE
Fix dark mode contrast for Mermaid nodes

### DIFF
--- a/src/app/components/CaseProgressGraph.tsx
+++ b/src/app/components/CaseProgressGraph.tsx
@@ -189,6 +189,7 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
       currentStroke: "#92400E",
       pendingFill: "#F3F4F6",
       pendingStroke: "#6B7280",
+      text: "#000000",
     };
     const dark = {
       completedFill: "#064E3B",
@@ -197,10 +198,11 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
       currentStroke: "#FBBF24",
       pendingFill: "#1F2937",
       pendingStroke: "#9CA3AF",
+      text: "#FFFFFF",
     };
     const c = isDark ? dark : light;
     const edgeStyle = `linkStyle default fill:none,stroke:${c.pendingStroke},stroke-width:2px;`;
-    return `graph TD\n${nodes}\n${edges}\n${links}\nclassDef completed fill:${c.completedFill},stroke:${c.completedStroke};\nclassDef current fill:${c.currentFill},stroke:${c.currentStroke};\nclassDef pending fill:${c.pendingFill},stroke:${c.pendingStroke};\n${edgeStyle}\n${classAssignments}`;
+    return `graph TD\n${nodes}\n${edges}\n${links}\nclassDef completed fill:${c.completedFill},stroke:${c.completedStroke},color:${c.text};\nclassDef current fill:${c.currentFill},stroke:${c.currentStroke},color:${c.text};\nclassDef pending fill:${c.pendingFill},stroke:${c.pendingStroke},color:${c.text};\n${edgeStyle}\n${classAssignments}`;
   }, [status, firstPending, noviolation, steps, isDark, caseData]);
 
   const containerRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary
- improve text contrast in CaseProgressGraph's dark mode theme

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d3db2fa00832b9b2a0c4543026341