### PR TITLE
Fix drag overlay persistence

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -7,6 +7,7 @@ import { getRepresentativePhoto } from "../../lib/caseUtils";
 import AnalysisInfo from "../components/AnalysisInfo";
 import MapPreview from "../components/MapPreview";
 import useNewCaseFromFiles from "../useNewCaseFromFiles";
+import useDragReset from "./useDragReset";
 
 export default function ClientCasesPage({
   initialCases,
@@ -43,6 +44,11 @@ export default function ClientCasesPage({
     };
     return () => es.close();
   }, []);
+
+  useDragReset(() => {
+    setDragging(false);
+    setDropCase(null);
+  });
 
   async function uploadFilesToCase(id: string, files: FileList) {
     await Promise.all(
@@ -155,7 +161,7 @@ export default function ClientCasesPage({
         ))}
       </ul>
       {dragging ? (
-        <div className="fixed inset-0 bg-black/50 text-white flex items-center justify-center pointer-events-none text-xl">
+        <div className="absolute inset-0 bg-black/50 text-white flex items-center justify-center pointer-events-none text-xl">
           {dropCase
             ? `Add photos to case ${dropCase}`
             : "Drop photos to create case"}

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -19,6 +19,7 @@ import CaseToolbar from "../../components/CaseToolbar";
 import EditableText from "../../components/EditableText";
 import ImageHighlights from "../../components/ImageHighlights";
 import MapPreview from "../../components/MapPreview";
+import useDragReset from "../useDragReset";
 
 function buildThreads(c: Case): SentEmail[] {
   const mails = c.sentEmails ?? [];
@@ -64,6 +65,10 @@ export default function ClientCasePage({
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [dragging, setDragging] = useState(false);
+
+  useDragReset(() => {
+    setDragging(false);
+  });
 
   useEffect(() => {
     const stored = sessionStorage.getItem(`preview-${caseId}`);
@@ -467,7 +472,7 @@ export default function ClientCasePage({
         ) : null}
       </CaseLayout>
       {dragging ? (
-        <div className="fixed inset-0 bg-black/50 text-white flex items-center justify-center pointer-events-none text-xl">
+        <div className="absolute inset-0 bg-black/50 text-white flex items-center justify-center pointer-events-none text-xl">
           Drop to add photos
         </div>
       ) : null}

--- a/src/app/cases/__tests__/useDragReset.test.tsx
+++ b/src/app/cases/__tests__/useDragReset.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import useDragReset from "../useDragReset";
+
+describe("useDragReset", () => {
+  it("invokes reset on dragleave with no relatedTarget", () => {
+    const fn = vi.fn();
+    renderHook(() => useDragReset(fn));
+    const leave = new Event("dragleave");
+    Object.defineProperty(leave, "relatedTarget", { value: null });
+    window.dispatchEvent(leave);
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it("invokes reset on dragend", () => {
+    const fn = vi.fn();
+    renderHook(() => useDragReset(fn));
+    window.dispatchEvent(new Event("dragend"));
+    expect(fn).toHaveBeenCalled();
+  });
+});

--- a/src/app/cases/useDragReset.ts
+++ b/src/app/cases/useDragReset.ts
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+
+export default function useDragReset(reset: () => void) {
+  useEffect(() => {
+    function handleDragEnd() {
+      reset();
+    }
+    function handleDragLeave(e: DragEvent) {
+      if (!e.relatedTarget) {
+        reset();
+      }
+    }
+    window.addEventListener("dragend", handleDragEnd);
+    window.addEventListener("drop", handleDragEnd);
+    window.addEventListener("dragleave", handleDragLeave);
+    return () => {
+      window.removeEventListener("dragend", handleDragEnd);
+      window.removeEventListener("drop", handleDragEnd);
+      window.removeEventListener("dragleave", handleDragLeave);
+    };
+  }, [reset]);
+}

--- a/src/lib/apiContract.ts
+++ b/src/lib/apiContract.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import { caseSchema } from "../generated/zod/caseStore";
 import { emailOptionsSchema } from "../generated/zod/email";
 import { reportModuleSchema } from "../generated/zod/reportModules";
-import { vinSourceStatusSchema } from "../generated/zod/vinSources";
 import { snailMailProviderStatusSchema } from "../generated/zod/snailMailProviders";
+import { vinSourceStatusSchema } from "../generated/zod/vinSources";
 
 const c = initContract();
 


### PR DESCRIPTION
## Summary
- reset drag state with a reusable hook
- use the hook in case pages
- add unit test for drag reset behavior
- limit drag overlays to each container so drop targets don't overlap

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cb82b3898832ba79028ff43a3fe63