### PR TITLE
Fix drag overlay persistence

### DIFF
--- a/src/app/api/snail-mail-providers/[id]/route.ts
+++ b/src/app/api/snail-mail-providers/[id]/route.ts
@@ -1,7 +1,13 @@
-import { getSnailMailProviderStatuses, setActiveSnailMailProvider } from "@/lib/snailMailProviders";
+import {
+  getSnailMailProviderStatuses,
+  setActiveSnailMailProvider,
+} from "@/lib/snailMailProviders";
 import { NextResponse } from "next/server";
 
-export async function PUT(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function PUT(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
   const { id } = await params;
   const result = setActiveSnailMailProvider(id);
   if (!result) {

--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -7,6 +7,7 @@ import { getRepresentativePhoto } from "../../lib/caseUtils";
 import AnalysisInfo from "../components/AnalysisInfo";
 import MapPreview from "../components/MapPreview";
 import useNewCaseFromFiles from "../useNewCaseFromFiles";
+import useDragReset from "./useDragReset";
 
 export default function ClientCasesPage({
   initialCases,
@@ -44,6 +45,11 @@ export default function ClientCasesPage({
     return () => es.close();
   }, []);
 
+  useDragReset(() => {
+    setDragging(false);
+    setDropCase(null);
+  });
+
   async function uploadFilesToCase(id: string, files: FileList) {
     await Promise.all(
       Array.from(files).map((file) => {
@@ -57,7 +63,7 @@ export default function ClientCasesPage({
 
   return (
     <div
-      className="p-8 relative"
+      className="p-8 relative overflow-hidden"
       onDragOver={(e) => e.preventDefault()}
       onDragEnter={(e) => {
         e.preventDefault();
@@ -155,7 +161,7 @@ export default function ClientCasesPage({
         ))}
       </ul>
       {dragging ? (
-        <div className="fixed inset-0 bg-black/50 text-white flex items-center justify-center pointer-events-none text-xl">
+        <div className="absolute inset-0 bg-black/50 text-white flex items-center justify-center pointer-events-none text-xl overflow-hidden">
           {dropCase
             ? `Add photos to case ${dropCase}`
             : "Drop photos to create case"}

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -19,6 +19,7 @@ import CaseToolbar from "../../components/CaseToolbar";
 import EditableText from "../../components/EditableText";
 import ImageHighlights from "../../components/ImageHighlights";
 import MapPreview from "../../components/MapPreview";
+import useDragReset from "../useDragReset";
 
 function buildThreads(c: Case): SentEmail[] {
   const mails = c.sentEmails ?? [];
@@ -64,6 +65,10 @@ export default function ClientCasePage({
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [dragging, setDragging] = useState(false);
+
+  useDragReset(() => {
+    setDragging(false);
+  });
 
   useEffect(() => {
     const stored = sessionStorage.getItem(`preview-${caseId}`);

--- a/src/app/cases/__tests__/useDragReset.test.tsx
+++ b/src/app/cases/__tests__/useDragReset.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import useDragReset from "../useDragReset";
+
+describe("useDragReset", () => {
+  it("invokes reset on dragleave with no relatedTarget", () => {
+    const fn = vi.fn();
+    renderHook(() => useDragReset(fn));
+    const leave = new Event("dragleave");
+    Object.defineProperty(leave, "relatedTarget", { value: null });
+    window.dispatchEvent(leave);
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it("invokes reset on dragend", () => {
+    const fn = vi.fn();
+    renderHook(() => useDragReset(fn));
+    window.dispatchEvent(new Event("dragend"));
+    expect(fn).toHaveBeenCalled();
+  });
+});

--- a/src/app/cases/useDragReset.ts
+++ b/src/app/cases/useDragReset.ts
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+
+export default function useDragReset(reset: () => void) {
+  useEffect(() => {
+    function handleDragEnd() {
+      reset();
+    }
+    function handleDragLeave(e: DragEvent) {
+      if (!e.relatedTarget) {
+        reset();
+      }
+    }
+    window.addEventListener("dragend", handleDragEnd);
+    window.addEventListener("drop", handleDragEnd);
+    window.addEventListener("dragleave", handleDragLeave);
+    return () => {
+      window.removeEventListener("dragend", handleDragEnd);
+      window.removeEventListener("drop", handleDragEnd);
+      window.removeEventListener("dragleave", handleDragLeave);
+    };
+  }, [reset]);
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -15,7 +15,9 @@ interface SnailMailProviderStatus {
 
 export default function SettingsPage() {
   const [sources, setSources] = useState<VinSourceStatus[]>([]);
-  const [mailProviders, setMailProviders] = useState<SnailMailProviderStatus[]>([]);
+  const [mailProviders, setMailProviders] = useState<SnailMailProviderStatus[]>(
+    [],
+  );
 
   useEffect(() => {
     fetch("/api/vin-sources")
@@ -73,7 +75,9 @@ export default function SettingsPage() {
               {p.id} (failures: {p.failureCount})
             </span>
             {p.active ? (
-              <span className="px-2 py-1 bg-green-500 text-white rounded">Active</span>
+              <span className="px-2 py-1 bg-green-500 text-white rounded">
+                Active
+              </span>
             ) : (
               <button
                 type="button"

--- a/src/lib/apiContract.ts
+++ b/src/lib/apiContract.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import { caseSchema } from "../generated/zod/caseStore";
 import { emailOptionsSchema } from "../generated/zod/email";
 import { reportModuleSchema } from "../generated/zod/reportModules";
-import { vinSourceStatusSchema } from "../generated/zod/vinSources";
 import { snailMailProviderStatusSchema } from "../generated/zod/snailMailProviders";
+import { vinSourceStatusSchema } from "../generated/zod/vinSources";
 
 const c = initContract();
 

--- a/src/lib/snailMailProviders.ts
+++ b/src/lib/snailMailProviders.ts
@@ -28,7 +28,9 @@ function loadStatuses(): SnailMailProviderStatus[] {
     return defaults;
   }
   try {
-    return JSON.parse(fs.readFileSync(dataFile, "utf8")) as SnailMailProviderStatus[];
+    return JSON.parse(
+      fs.readFileSync(dataFile, "utf8"),
+    ) as SnailMailProviderStatus[];
   } catch {
     return defaultStatuses();
   }
@@ -43,7 +45,9 @@ export function getSnailMailProviderStatuses(): SnailMailProviderStatus[] {
   return loadStatuses();
 }
 
-export function setActiveSnailMailProvider(id: string): SnailMailProviderStatus | undefined {
+export function setActiveSnailMailProvider(
+  id: string,
+): SnailMailProviderStatus | undefined {
   const list = loadStatuses();
   if (!list.some((p) => p.id === id)) return undefined;
   const updated = list.map((p) => ({ ...p, active: p.id === id }));

--- a/test/snailMailProviders.test.ts
+++ b/test/snailMailProviders.test.ts
@@ -14,7 +14,10 @@ beforeEach(async () => {
     active: idx === 0,
     failureCount: 0,
   }));
-  fs.writeFileSync(process.env.SNAIL_MAIL_PROVIDER_FILE, JSON.stringify(statuses));
+  fs.writeFileSync(
+    process.env.SNAIL_MAIL_PROVIDER_FILE,
+    JSON.stringify(statuses),
+  );
 });
 
 afterEach(() => {
@@ -35,7 +38,9 @@ describe("snail mail provider store", () => {
   it("records failures", async () => {
     const store = await import("../src/lib/snailMailProviders");
     store.recordProviderFailure("mock");
-    const item = store.getSnailMailProviderStatuses().find((p) => p.id === "mock");
+    const item = store
+      .getSnailMailProviderStatuses()
+      .find((p) => p.id === "mock");
     expect(item?.failureCount).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- reset drag state with a reusable hook
- use the hook in case pages
- add unit test for drag reset behavior
- constrain drop overlay to case list container and apply repo-wide formatting

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cb82b3898832ba79028ff43a3fe63