### PR TITLE
Fix iOS camera autoplay

### DIFF
--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -17,8 +17,14 @@ export default function PointAndShootPage() {
           video: { facingMode: "environment" },
         });
         if (videoRef.current) {
-          videoRef.current.srcObject = stream;
-          await videoRef.current.play().catch(() => {});
+          const v = videoRef.current;
+          // iOS Safari requires these attributes for autoplay
+          v.setAttribute("autoplay", "");
+          v.setAttribute("muted", "");
+          v.setAttribute("playsinline", "");
+          v.muted = true;
+          v.srcObject = stream;
+          await v.play().catch(() => {});
         }
       } catch (err) {
         console.error("Could not access camera", err);


### PR DESCRIPTION
## Summary
- update camera startup logic in `PointAndShootPage` to explicitly set `autoplay`, `muted`, and `playsinline` attributes so that the camera view appears in iOS Safari

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d4206cd6c832bb3be6540f198fbc3