### PR TITLE
Fix camera preview on iOS Safari

### DIFF
--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -17,8 +17,17 @@ export default function PointAndShootPage() {
           video: { facingMode: "environment" },
         });
         if (videoRef.current) {
-          videoRef.current.srcObject = stream;
-          await videoRef.current.play().catch(() => {});
+          const v = videoRef.current;
+          v.setAttribute("autoplay", "");
+          v.setAttribute("muted", "");
+          v.setAttribute("playsinline", "");
+          if ("srcObject" in v) {
+            v.srcObject = stream;
+          } else {
+            // @ts-ignore - older Safari fallback
+            v.src = URL.createObjectURL(stream);
+          }
+          await v.play().catch(() => {});
         }
       } catch (err) {
         console.error("Could not access camera", err);


### PR DESCRIPTION
## Summary
- set video attributes explicitly and provide a srcObject fallback for Safari

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d4206cd6c832bb3be6540f198fbc3