### PR TITLE
Fix drag overlay reset

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -70,7 +70,7 @@ export default function ClientCasesPage({
         setDragging(true);
       }}
       onDragLeave={(e) => {
-        if (e.currentTarget === e.target) {
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
           setDragging(false);
           setDropCase(null);
         }
@@ -97,7 +97,9 @@ export default function ClientCasesPage({
               setDragging(true);
             }}
             onDragLeave={(e) => {
-              if (e.currentTarget === e.target) setDropCase(null);
+              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                setDropCase(null);
+              }
             }}
             className={`border p-2 ${
               selectedIds.includes(c.id)

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -290,7 +290,9 @@ export default function ClientCasePage({
         setDragging(true);
       }}
       onDragLeave={(e) => {
-        if (e.currentTarget === e.target) setDragging(false);
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+          setDragging(false);
+        }
       }}
       onDrop={async (e) => {
         e.preventDefault();

--- a/src/app/components/CaseProgressGraph.tsx
+++ b/src/app/components/CaseProgressGraph.tsx
@@ -10,7 +10,9 @@ import {
 import dynamic from "next/dynamic";
 import { useEffect, useMemo, useRef, useState } from "react";
 import tippy from "tippy.js";
-import "tippy.js/dist/tippy.css";
+if (typeof window !== "undefined" && !process.env.VITEST) {
+  import("tippy.js/dist/tippy.css");
+}
 
 const Mermaid = dynamic(() => import("react-mermaid2"), { ssr: false });
 


### PR DESCRIPTION
## Summary
- ensure drag overlays reset when moving cursor out of drop zones
- avoid importing tooltip CSS during tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d445e98cc832ba65d3e1fbf60837d