### PR TITLE
Add violation photo tooltip

### DIFF
--- a/src/lib/__tests__/caseUtils.test.ts
+++ b/src/lib/__tests__/caseUtils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { Case } from "../caseStore";
+import { getViolationPhoto } from "../caseUtils";
+
+describe("getViolationPhoto", () => {
+  it("returns best violation photo and caption", () => {
+    const caseData = {
+      id: "1",
+      photos: ["/a.jpg", "/b.jpg"],
+      photoTimes: {},
+      createdAt: "",
+      analysis: {
+        images: {
+          "a.jpg": {
+            representationScore: 0.5,
+            violation: true,
+            highlights: "a",
+          },
+          "b.jpg": {
+            representationScore: 0.8,
+            violation: true,
+            highlights: "b",
+          },
+        },
+      },
+    } as unknown as Case;
+    expect(getViolationPhoto(caseData)).toEqual({
+      photo: "/b.jpg",
+      caption: "b",
+    });
+  });
+
+  it("returns null when no violation images", () => {
+    const caseData = {
+      id: "1",
+      photos: ["/a.jpg"],
+      photoTimes: {},
+      createdAt: "",
+      analysis: {
+        images: { "a.jpg": { representationScore: 0.5, violation: false } },
+      },
+    } as unknown as Case;
+    expect(getViolationPhoto(caseData)).toBeNull();
+  });
+});

--- a/src/lib/caseUtils.ts
+++ b/src/lib/caseUtils.ts
@@ -22,6 +22,21 @@ export function getRepresentativePhoto(
   return [...caseData.photos].sort()[0];
 }
 
+export function getViolationPhoto(
+  caseData: Pick<Case, "photos" | "analysis">,
+): { photo: string; caption?: string } | null {
+  const imgs = caseData.analysis?.images;
+  if (!imgs) return null;
+  const best = Object.entries(imgs)
+    .filter(([, info]) => info.violation === true)
+    .sort((a, b) => b[1].representationScore - a[1].representationScore)[0];
+  if (!best) return null;
+  const [name, info] = best;
+  const file = caseData.photos.find((p) => basename(p) === name);
+  if (!file) return null;
+  return { photo: file, caption: info.highlights };
+}
+
 export function hasViolation(report?: ViolationReport | null): boolean {
   if (!report) return false;
   if (report.images) {


### PR DESCRIPTION
## Summary
- show the best violation photo on the "Violation Identified" graph node
- expose helper `getViolationPhoto` to get the best violation image
- display optional captions in graph tooltips
- test `getViolationPhoto`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d4b30b554832bb523fd355c8f0996