### PR TITLE
Add violation photo tooltip to graph

### DIFF
--- a/src/app/components/CaseProgressGraph.tsx
+++ b/src/app/components/CaseProgressGraph.tsx
@@ -1,6 +1,7 @@
 "use client";
 import type { Case } from "@/lib/caseStore";
 import {
+  getBestViolationPhoto,
   getCaseOwnerContact,
   getCasePlateNumber,
   getCasePlateState,
@@ -223,6 +224,7 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
           preview: string | string[];
           isImage?: boolean;
           count?: number;
+          caption?: string;
         } | null
       > = {};
       const platePhoto = (() => {
@@ -254,6 +256,7 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
       const notifyLink = firstEmail
         ? `/cases/${caseData.id}/thread/${encodeURIComponent(firstEmail.sentAt)}`
         : null;
+      const bestViolation = getBestViolationPhoto(caseData);
       if (caseData.photos.length > 0)
         map.uploaded = {
           url: caseData.photos[0],
@@ -274,6 +277,13 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
           url: notifyLink,
           preview: firstEmail?.body ?? "",
           isImage: false,
+        };
+      if (bestViolation)
+        map.violation = {
+          url: bestViolation.photo,
+          preview: bestViolation.photo,
+          isImage: true,
+          caption: bestViolation.caption,
         };
       const escapeHtml = (s: string) =>
         s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -301,7 +311,12 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
                   : "";
               return `<div class="flex flex-col items-center overflow-y-auto" style="max-height:60vh; max-width:80vw;">${imgs}${extraLine}</div>`;
             }
-            return `<img src="${info.preview}" class="max-h-40" />`;
+            const caption = info.caption
+              ? `<div class="text-xs text-center mt-1">${escapeHtml(
+                  info.caption,
+                )}</div>`
+              : "";
+            return `<div class="flex flex-col items-center"><img src="${info.preview}" class="max-h-40" />${caption}</div>`;
           }
           return `<div class="max-w-xs whitespace-pre-wrap">${escapeHtml(
             info.preview as string,

--- a/src/lib/caseUtils.ts
+++ b/src/lib/caseUtils.ts
@@ -112,3 +112,18 @@ export function getCaseOwnerContactInfo(
   if (!contact) return null;
   return parseContactInfo(contact);
 }
+
+export function getBestViolationPhoto(
+  caseData: Pick<Case, "photos" | "analysis">,
+): { photo: string; caption?: string } | null {
+  const imgs = caseData.analysis?.images ?? {};
+  const entries = Object.entries(imgs)
+    .filter(([, info]) => info.violation)
+    .sort((a, b) => b[1].representationScore - a[1].representationScore);
+  const best = entries[0];
+  if (!best) return null;
+  const [name, info] = best;
+  const file = caseData.photos.find((p) => basename(p) === name);
+  if (!file) return null;
+  return { photo: file, caption: info.highlights };
+}

--- a/test/violationUtils.test.ts
+++ b/test/violationUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { hasViolation } from "../src/lib/caseUtils";
+import { getBestViolationPhoto, hasViolation } from "../src/lib/caseUtils";
 
 describe("hasViolation", () => {
   it("detects violation from image flags", () => {
@@ -23,5 +23,46 @@ describe("hasViolation", () => {
   it("falls back to violationType when flags missing", () => {
     expect(hasViolation({ violationType: "parking" })).toBe(true);
     expect(hasViolation({ violationType: "" })).toBe(false);
+  });
+});
+
+describe("getBestViolationPhoto", () => {
+  it("returns best matching photo and caption", () => {
+    const result = getBestViolationPhoto({
+      photos: ["/a.jpg", "/b.jpg"],
+      analysis: {
+        violationType: "parking",
+        details: "",
+        vehicle: {},
+        images: {
+          "a.jpg": {
+            representationScore: 0.4,
+            violation: true,
+            highlights: "a caption",
+          },
+          "b.jpg": {
+            representationScore: 0.9,
+            violation: true,
+            highlights: "best caption",
+          },
+        },
+      },
+    });
+    expect(result).toEqual({ photo: "/b.jpg", caption: "best caption" });
+  });
+
+  it("returns null when no violation images", () => {
+    const result = getBestViolationPhoto({
+      photos: ["/a.jpg"],
+      analysis: {
+        violationType: "parking",
+        details: "",
+        vehicle: {},
+        images: {
+          "a.jpg": { representationScore: 0.5, violation: false },
+        },
+      },
+    });
+    expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- display best violation photo tooltip with caption in case progress graph
- support retrieving best violation photo in utilities
- test getBestViolationPhoto

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d4b30b554832bb523fd355c8f0996