### PR TITLE
Fix iOS camera display

### DIFF
--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -13,12 +13,25 @@ export default function PointAndShootPage() {
   useEffect(() => {
     async function startCamera() {
       try {
-        const stream = await navigator.mediaDevices.getUserMedia({
+        const constraints = {
+          audio: false,
           video: { facingMode: "environment" },
-        });
-        if (videoRef.current) {
-          videoRef.current.srcObject = stream;
-          await videoRef.current.play().catch(() => {});
+        } as const;
+        const stream = await navigator.mediaDevices.getUserMedia(constraints);
+        const v = videoRef.current;
+        if (v) {
+          v.setAttribute("autoplay", "");
+          v.setAttribute("muted", "");
+          v.setAttribute("playsinline", "");
+          if ("srcObject" in v) {
+            v.srcObject = stream;
+          } else {
+            // @ts-ignore - fallback for older browsers
+            v.src = URL.createObjectURL(stream);
+          }
+          v.onloadedmetadata = () => {
+            v.play().catch(() => {});
+          };
         }
       } catch (err) {
         console.error("Could not access camera", err);
@@ -61,7 +74,7 @@ export default function PointAndShootPage() {
         autoPlay
         muted
         playsInline
-        className="fixed inset-0 w-full h-full object-cover -z-10"
+        className="absolute inset-0 w-full h-full object-cover z-0"
       >
         <track kind="captions" label="" />
       </video>


### PR DESCRIPTION
## Summary
- tweak startCamera logic and camera constraints
- wait for loadedmetadata before playing video

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d4206cd6c832bb3be6540f198fbc3