### PR TITLE
Fix iOS camera display

### DIFF
--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -14,11 +14,21 @@ export default function PointAndShootPage() {
     async function startCamera() {
       try {
         const stream = await navigator.mediaDevices.getUserMedia({
+          audio: false,
           video: { facingMode: "environment" },
         });
         if (videoRef.current) {
-          videoRef.current.srcObject = stream;
-          await videoRef.current.play().catch(() => {});
+          const v = videoRef.current;
+          v.setAttribute("autoplay", "");
+          v.setAttribute("muted", "");
+          v.setAttribute("playsinline", "");
+          if ("srcObject" in v) {
+            v.srcObject = stream;
+          } else {
+            // @ts-ignore - fallback for older browsers
+            v.src = URL.createObjectURL(stream);
+          }
+          v.play().catch(() => {});
         }
       } catch (err) {
         console.error("Could not access camera", err);
@@ -61,7 +71,7 @@ export default function PointAndShootPage() {
         autoPlay
         muted
         playsInline
-        className="fixed inset-0 w-full h-full object-cover -z-10"
+        className="absolute inset-0 w-full h-full object-cover z-0"
       >
         <track kind="captions" label="" />
       </video>


### PR DESCRIPTION
## Summary
- request the environment camera using the simple facingMode syntax
- keep autoplay, muted and playsinline attributes before playing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d4206cd6c832bb3be6540f198fbc3