### PR TITLE
Add analysis summary tooltip

### DIFF
--- a/src/app/components/CaseProgressGraph.tsx
+++ b/src/app/components/CaseProgressGraph.tsx
@@ -1,6 +1,7 @@
 "use client";
 import type { Case } from "@/lib/caseStore";
 import {
+  getAnalysisSummary,
   getCaseOwnerContact,
   getCasePlateNumber,
   getCasePlateState,
@@ -176,6 +177,8 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
     const notifyTip = firstEmail
       ? `Notification email to ${firstEmail.to} on ${new Date(firstEmail.sentAt).toLocaleString()}`
       : "View notification email";
+    const analysisTip =
+      caseData.analysis && getAnalysisSummary(caseData.analysis);
     const links = [
       caseData.photos[0]
         ? `click uploaded "${caseData.photos[0]}" "${clean(uploadedTip)}"`
@@ -183,6 +186,9 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
       platePhoto ? `click plate "${platePhoto}" "${clean(plateTip)}"` : null,
       ownerLink ? `click own "${ownerLink}" "${clean(ownerTip)}"` : null,
       notifyLink ? `click notify "${notifyLink}" "${clean(notifyTip)}"` : null,
+      analysisTip
+        ? `click analysis "/cases/${caseData.id}" "${clean(analysisTip)}"`
+        : null,
     ]
       .filter(Boolean)
       .join("\n");
@@ -273,6 +279,12 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
         map.notify = {
           url: notifyLink,
           preview: firstEmail?.body ?? "",
+          isImage: false,
+        };
+      if (caseData.analysis)
+        map.analysis = {
+          url: `/cases/${caseData.id}`,
+          preview: getAnalysisSummary(caseData.analysis),
           isImage: false,
         };
       const escapeHtml = (s: string) =>

--- a/src/lib/caseUtils.ts
+++ b/src/lib/caseUtils.ts
@@ -112,3 +112,15 @@ export function getCaseOwnerContactInfo(
   if (!contact) return null;
   return parseContactInfo(contact);
 }
+
+export function getAnalysisSummary(report: ViolationReport): string {
+  const parts = [`Violation: ${report.violationType}`, report.details];
+  if (report.location) parts.push(`Location: ${report.location}`);
+  const plate: string[] = [];
+  if (report.vehicle?.licensePlateState)
+    plate.push(report.vehicle.licensePlateState);
+  if (report.vehicle?.licensePlateNumber)
+    plate.push(report.vehicle.licensePlateNumber);
+  if (plate.length > 0) parts.push(`Plate: ${plate.join(" ")}`);
+  return parts.filter(Boolean).join("\n");
+}


### PR DESCRIPTION
## Summary
- show summary of analysis when hovering over 'Analysis Complete' step in case progress graph
- expose helper `getAnalysisSummary`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d4d0acbd4832bb0ae3f1678ef9012