### PR TITLE
Hide GPS coords on case view

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -351,19 +351,14 @@ export default function ClientCasePage({
                 </p>
               ) : null}
               {caseData.gps ? (
-                <>
-                  <p>
-                    <span className="font-semibold">GPS:</span>{" "}
-                    {caseData.gps.lat}, {caseData.gps.lon}
-                  </p>
-                  <MapPreview
-                    lat={caseData.gps.lat}
-                    lon={caseData.gps.lon}
-                    width={600}
-                    height={300}
-                    className="w-full aspect-[2/1] md:max-w-xl"
-                  />
-                </>
+                <MapPreview
+                  lat={caseData.gps.lat}
+                  lon={caseData.gps.lon}
+                  width={600}
+                  height={300}
+                  className="w-full aspect-[2/1] md:max-w-xl"
+                  link={`https://www.google.com/maps?q=${caseData.gps.lat},${caseData.gps.lon}`}
+                />
               ) : null}
               <p>
                 <span className="font-semibold">VIN:</span>{" "}

--- a/src/app/components/MapPreview.tsx
+++ b/src/app/components/MapPreview.tsx
@@ -6,18 +6,20 @@ export default function MapPreview({
   width,
   height,
   className,
+  link,
 }: {
   lat: number;
   lon: number;
   width: number;
   height: number;
   className?: string;
+  link?: string;
 }) {
   const key = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
   const url = key
     ? `https://maps.googleapis.com/maps/api/staticmap?center=${lat},${lon}&zoom=16&size=${width}x${height}&markers=color:red|${lat},${lon}&key=${key}`
     : `https://staticmap.openstreetmap.de/staticmap.php?center=${lat},${lon}&zoom=16&size=${width}x${height}&markers=${lat},${lon},red`;
-  return (
+  const img = (
     <div
       className={`relative ${className ?? ""}`}
       style={{ aspectRatio: `${width} / ${height}` }}
@@ -30,5 +32,12 @@ export default function MapPreview({
         sizes="100vw"
       />
     </div>
+  );
+  return link ? (
+    <a href={link} target="_blank" rel="noopener noreferrer">
+      {img}
+    </a>
+  ) : (
+    img
   );
 }


### PR DESCRIPTION
## Summary
- hide GPS text in case view and link map preview to Google Maps

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: cannot load native bindings)*

------
https://chatgpt.com/codex/tasks/task_e_684d582e473c832ba8331c7ef47e3856