### PR TITLE
Move analysis action to DAG dropdown

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -321,14 +321,6 @@ export default function ClientCasePage({
           <>
             <div className="order-first bg-gray-100 dark:bg-gray-800 p-4 rounded flex flex-col gap-2 text-sm">
               {analysisBlock}
-              <button
-                type="button"
-                onClick={reanalyzeCase}
-                disabled={caseData.analysisStatus === "pending"}
-                className="bg-blue-500 text-white px-2 py-1 rounded disabled:opacity-50 self-start"
-              >
-                Re-run Analysis
-              </button>
               {ownerContact ? (
                 <p>
                   <span className="font-semibold">Owner:</span> {ownerContact}

--- a/src/app/components/CaseProgressGraph.tsx
+++ b/src/app/components/CaseProgressGraph.tsx
@@ -359,6 +359,7 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
           url: `/cases/${caseData.id}`,
           preview: getAnalysisSummary(caseData.analysis),
           isImage: false,
+          extra: `<details class="mt-2"><summary class="cursor-pointer select-none bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded text-sm">Actions</summary><button type="button" class="block px-4 py-1 text-left w-full hover:bg-gray-100 dark:hover:bg-gray-700" onclick="(async()=>{await fetch('/api/cases/${caseData.id}/reanalyze',{method:'POST'});window.location.reload();})()">Re-run Analysis</button></details>`,
         };
       const escapeHtml = (s: string) =>
         s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -393,15 +394,20 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
               : "";
             return `<div class="flex flex-col items-center"><img src="${info.preview}" class="max-h-40" />${caption}</div>`;
           }
-          return `<div class="max-w-xs whitespace-pre-wrap">${escapeHtml(
+          const main = `<div class="max-w-xs whitespace-pre-wrap">${escapeHtml(
             info.preview as string,
           )}</div>`;
+          return info.extra ? `${main}${info.extra}` : main;
         })();
         const inst = tippy(el, {
           content,
           allowHTML: true,
+          interactive: id === "analysis",
+          trigger: id === "analysis" ? "click" : "mouseenter focus",
         });
-        el.addEventListener("click", () => window.open(info.url, "_blank"));
+        if (id !== "analysis") {
+          el.addEventListener("click", () => window.open(info.url, "_blank"));
+        }
         instances.push(inst);
       }
     };


### PR DESCRIPTION
## Summary
- remove redundant button from case view sidebar
- add dropdown menu to analysis step in progress graph

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d59d2dff0832ba0901ada4b8a8da6