### PR TITLE
Move reanalyze action into DAG menu

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -186,11 +186,6 @@ export default function ClientCasePage({
     await refreshCase();
   }
 
-  async function reanalyzeCase() {
-    await fetch(`/api/cases/${caseId}/reanalyze`, { method: "POST" });
-    await refreshCase();
-  }
-
   async function removePhoto(photo: string) {
     await fetch(`/api/cases/${caseId}/photos`, {
       method: "DELETE",
@@ -321,14 +316,6 @@ export default function ClientCasePage({
           <>
             <div className="order-first bg-gray-100 dark:bg-gray-800 p-4 rounded flex flex-col gap-2 text-sm">
               {analysisBlock}
-              <button
-                type="button"
-                onClick={reanalyzeCase}
-                disabled={caseData.analysisStatus === "pending"}
-                className="bg-blue-500 text-white px-2 py-1 rounded disabled:opacity-50 self-start"
-              >
-                Re-run Analysis
-              </button>
               {ownerContact ? (
                 <p>
                   <span className="font-semibold">Owner:</span> {ownerContact}

--- a/src/app/components/CaseProgressGraph.tsx
+++ b/src/app/components/CaseProgressGraph.tsx
@@ -368,41 +368,68 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
           `[id^='flowchart-${id}-']`,
         ) as HTMLElement | null;
         if (!el) continue;
-        const content = (() => {
-          if (info.isImage !== false) {
-            if (Array.isArray(info.preview)) {
-              const small = info.preview.length > 1;
-              const imgClass = small ? "max-h-24 my-1" : "max-h-40";
-              const imgs = info.preview
-                .map((p) => `<img src="${p}" class="${imgClass}" />`)
-                .join("");
-              const extra =
-                info.count && info.count > info.preview.length
-                  ? info.count - info.preview.length
-                  : 0;
-              const extraLine =
-                extra > 0
-                  ? `<div class="text-xs text-center mt-1">and ${extra} more photo${extra === 1 ? "" : "s"} not shown</div>`
-                  : "";
-              return `<div class="flex flex-col items-center overflow-y-auto" style="max-height:60vh; max-width:80vw;">${imgs}${extraLine}</div>`;
+        if (id === "analysis" && caseData.analysisStatus === "complete") {
+          const menu = document.createElement("div");
+          menu.className = "flex flex-col";
+          const summary = document.createElement("div");
+          summary.className = "max-w-xs whitespace-pre-wrap mb-2";
+          summary.textContent = info.preview as string;
+          menu.appendChild(summary);
+          const btn = document.createElement("button");
+          btn.type = "button";
+          btn.textContent = "Re-run Analysis";
+          btn.className =
+            "bg-blue-500 text-white px-2 py-1 rounded hover:bg-blue-600";
+          btn.addEventListener("click", async () => {
+            await fetch(`/api/cases/${caseData.id}/reanalyze`, {
+              method: "POST",
+            });
+            window.location.reload();
+          });
+          menu.appendChild(btn);
+          const inst = tippy(el, {
+            content: menu,
+            interactive: true,
+            trigger: "click",
+          });
+          instances.push(inst);
+        } else {
+          const content = (() => {
+            if (info.isImage !== false) {
+              if (Array.isArray(info.preview)) {
+                const small = info.preview.length > 1;
+                const imgClass = small ? "max-h-24 my-1" : "max-h-40";
+                const imgs = info.preview
+                  .map((p) => `<img src="${p}" class="${imgClass}" />`)
+                  .join("");
+                const extra =
+                  info.count && info.count > info.preview.length
+                    ? info.count - info.preview.length
+                    : 0;
+                const extraLine =
+                  extra > 0
+                    ? `<div class="text-xs text-center mt-1">and ${extra} more photo${extra === 1 ? "" : "s"} not shown</div>`
+                    : "";
+                return `<div class="flex flex-col items-center overflow-y-auto" style="max-height:60vh; max-width:80vw;">${imgs}${extraLine}</div>`;
+              }
+              const caption = info.caption
+                ? `<div class="text-xs text-center mt-1">${escapeHtml(
+                    info.caption,
+                  )}</div>`
+                : "";
+              return `<div class="flex flex-col items-center"><img src="${info.preview}" class="max-h-40" />${caption}</div>`;
             }
-            const caption = info.caption
-              ? `<div class="text-xs text-center mt-1">${escapeHtml(
-                  info.caption,
-                )}</div>`
-              : "";
-            return `<div class="flex flex-col items-center"><img src="${info.preview}" class="max-h-40" />${caption}</div>`;
-          }
-          return `<div class="max-w-xs whitespace-pre-wrap">${escapeHtml(
-            info.preview as string,
-          )}</div>`;
-        })();
-        const inst = tippy(el, {
-          content,
-          allowHTML: true,
-        });
-        el.addEventListener("click", () => window.open(info.url, "_blank"));
-        instances.push(inst);
+            return `<div class="max-w-xs whitespace-pre-wrap">${escapeHtml(
+              info.preview as string,
+            )}</div>`;
+          })();
+          const inst = tippy(el, {
+            content,
+            allowHTML: true,
+          });
+          el.addEventListener("click", () => window.open(info.url, "_blank"));
+          instances.push(inst);
+        }
       }
     };
     const observer = new MutationObserver(() => apply());


### PR DESCRIPTION
## Summary
- drop `Re-run Analysis` button from case details panel
- add reanalyze dropdown to the analysis node in the case progress graph

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d59d2dff0832ba0901ada4b8a8da6