### PR TITLE
Add map view for cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "nodemailer": "^7.0.3",
         "openai": "^5.2.0",
         "pdf-lib": "^1.17.1",
+        "pigeon-maps": "^0.22.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^4.12.0",
@@ -23797,6 +23798,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pigeon-maps": {
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/pigeon-maps/-/pigeon-maps-0.22.1.tgz",
+      "integrity": "sha512-mVWxgpIyhAekITeJvDGlFAo/Ytm6Fg7prpDiAuQ0Z6cJ/LwpnS8F0sF+0TDqyJu7C/DDHupkstFTNoIRqhdP5A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/pinkie": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-icons": "^4.12.0",
     "react-mermaid2": "^0.1.4",
     "tippy.js": "^6.3.7",
+    "pigeon-maps": "^0.22.1",
     "ts-node": "^10.9.2",
     "twilio": "^4.23.0",
     "zod": "^3.23.8"

--- a/src/app/cases/MapViewClient.tsx
+++ b/src/app/cases/MapViewClient.tsx
@@ -1,0 +1,99 @@
+"use client";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { Marker, Overlay, Map as PigeonMap } from "pigeon-maps";
+import { useEffect, useRef, useState } from "react";
+import type { Case } from "../../lib/caseStore";
+import { getRepresentativePhoto } from "../../lib/caseUtils";
+
+export default function MapViewClient({ cases }: { cases: Case[] }) {
+  const router = useRouter();
+  const mapRef = useRef<HTMLDivElement | null>(null);
+  const [center, setCenter] = useState<[number, number]>([0, 0]);
+  const [zoomLevel, setZoomLevel] = useState(11);
+  const [size, setSize] = useState({ width: 800, height: 600 });
+
+  useEffect(() => {
+    function updateSize() {
+      setSize({ width: window.innerWidth, height: window.innerHeight - 64 });
+    }
+    updateSize();
+    window.addEventListener("resize", updateSize);
+    return () => window.removeEventListener("resize", updateSize);
+  }, []);
+
+  useEffect(() => {
+    const coords = cases
+      .filter((c): c is Case & { gps: { lat: number; lon: number } } =>
+        Boolean(c.gps),
+      )
+      .map((c) => [c.gps.lat, c.gps.lon]);
+    if (coords.length === 0) return;
+    let minLat = coords[0][0];
+    let maxLat = coords[0][0];
+    let minLon = coords[0][1];
+    let maxLon = coords[0][1];
+    for (const [lat, lon] of coords) {
+      minLat = Math.min(minLat, lat);
+      maxLat = Math.max(maxLat, lat);
+      minLon = Math.min(minLon, lon);
+      maxLon = Math.max(maxLon, lon);
+    }
+    const mapW = size.width;
+    const mapH = size.height;
+
+    function latRad(lat: number): number {
+      const s = Math.sin((lat * Math.PI) / 180);
+      const r = Math.log((1 + s) / (1 - s)) / 2;
+      return Math.max(Math.min(r, Math.PI), -Math.PI) / 2;
+    }
+    function zoom(mapPx: number, worldPx: number, fraction: number): number {
+      return Math.floor(Math.log(mapPx / worldPx / fraction) / Math.LN2);
+    }
+    const latFraction = (latRad(maxLat) - latRad(minLat)) / Math.PI;
+    const lonDiff =
+      maxLon - minLon < 0 ? maxLon - minLon + 360 : maxLon - minLon;
+    const lonFraction = lonDiff / 360;
+    const latZoom = zoom(mapH, 256, latFraction * 1.2);
+    const lonZoom = zoom(mapW, 256, lonFraction * 1.2);
+    const zoomLvl = Math.min(latZoom, lonZoom, 21);
+    setZoomLevel(zoomLvl);
+    setCenter([(minLat + maxLat) / 2, (minLon + maxLon) / 2]);
+  }, [cases, size.height, size.width]);
+
+  return (
+    <PigeonMap
+      height={size.height}
+      width={size.width}
+      center={center}
+      zoom={zoomLevel}
+      ref={mapRef}
+    >
+      {cases.map((c) =>
+        c.gps ? (
+          <Marker
+            key={c.id}
+            width={40}
+            anchor={[c.gps.lat, c.gps.lon]}
+            onClick={() => router.push(`/cases/${c.id}`)}
+          >
+            <Overlay anchor={[c.gps.lat, c.gps.lon]} offset={[0, -40]}>
+              <button
+                type="button"
+                className="bg-white shadow rounded p-1 text-xs cursor-pointer"
+                onClick={() => router.push(`/cases/${c.id}`)}
+              >
+                <Image
+                  src={getRepresentativePhoto(c)}
+                  alt="preview"
+                  width={80}
+                  height={60}
+                />
+              </button>
+            </Overlay>
+          </Marker>
+        ) : null,
+      )}
+    </PigeonMap>
+  );
+}

--- a/src/app/cases/map/page.tsx
+++ b/src/app/cases/map/page.tsx
@@ -1,0 +1,9 @@
+import { getCases } from "../../../lib/caseStore";
+import MapViewClient from "../MapViewClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function MapPage() {
+  const cases = getCases();
+  return <MapViewClient cases={cases} />;
+}

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -55,6 +55,12 @@ export default function NavBar() {
           Cases
         </Link>
         <Link
+          href="/cases/map"
+          className="hover:text-gray-600 dark:hover:text-gray-300"
+        >
+          Map View
+        </Link>
+        <Link
           href="/settings"
           className="hover:text-gray-600 dark:hover:text-gray-300"
         >

--- a/test/caseLocation.test.ts
+++ b/test/caseLocation.test.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { computeBestGps } from "../src/lib/caseLocation";
+import type { Case } from "../src/lib/caseStore";
+
+let cwd: string;
+let dir: string;
+
+beforeEach(() => {
+  cwd = process.cwd();
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "gps-"));
+  process.chdir(dir);
+  fs.mkdirSync("public/uploads", { recursive: true });
+  fs.copyFileSync(
+    path.join(cwd, "node_modules/exif-parser/test/starfish.jpg"),
+    "public/uploads/starfish.jpg",
+  );
+  fs.copyFileSync(
+    path.join(cwd, "node_modules/exif-parser/test/test.jpg"),
+    "public/uploads/test.jpg",
+  );
+});
+
+afterEach(() => {
+  process.chdir(cwd);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("computeBestGps", () => {
+  it("selects gps from highest scoring photo", () => {
+    const caseData = {
+      id: "1",
+      photos: ["/uploads/test.jpg", "/uploads/starfish.jpg"],
+      photoTimes: {},
+      createdAt: "2020-01-01T00:00:00.000Z",
+      analysis: {
+        images: {
+          "test.jpg": { representationScore: 0.2, violation: true },
+          "starfish.jpg": { representationScore: 0.9, violation: true },
+        },
+      },
+    } as unknown as Case;
+    const gps = computeBestGps(caseData);
+    expect(gps).toBeDefined();
+    expect(gps?.lat).toBeCloseTo(55.0387, 3);
+    expect(gps?.lon).toBeCloseTo(8.45719, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- add interactive map client for case locations
- compute best GPS from representative image
- expose new map page and toolbar link
- update case analysis to store best coordinates
- test best GPS selection

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_684d58e664b4832bbb9bf5d061d9d531