### PR TITLE
Add ownership info follow-up flow

### DIFF
--- a/src/app/api/cases/[id]/followup/route.ts
+++ b/src/app/api/cases/[id]/followup/route.ts
@@ -1,4 +1,4 @@
-import { draftFollowUp } from "@/lib/caseReport";
+import { draftFollowUp, draftFollowUpWithOwnerInfo } from "@/lib/caseReport";
 import type { Case, SentEmail } from "@/lib/caseStore";
 import { addCaseEmail, getCase } from "@/lib/caseStore";
 import { sendSnailMail } from "@/lib/contactMethods";
@@ -27,6 +27,7 @@ export async function GET(
   const { id } = await params;
   const url = new URL(req.url);
   const replyTo = url.searchParams.get("replyTo");
+  const owner = url.searchParams.get("owner");
   console.log(`followup GET case=${id} replyTo=${replyTo ?? "none"}`);
   const c = getCase(id);
   if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -41,7 +42,9 @@ export async function GET(
   console.log(
     `drafting followup for ${recipient} with ${thread.length} emails`,
   );
-  const email = await draftFollowUp(c, recipient, thread);
+  const email = owner
+    ? await draftFollowUpWithOwnerInfo(c, recipient, thread)
+    : await draftFollowUp(c, recipient, thread);
   console.log(`drafted email subject: ${email.subject}`);
   return NextResponse.json({
     email,

--- a/src/app/cases/[id]/FollowUpWrapper.tsx
+++ b/src/app/cases/[id]/FollowUpWrapper.tsx
@@ -14,12 +14,14 @@ export default function FollowUpWrapper({
   const router = useRouter();
   const params = useSearchParams();
   const replyTo = params.get("replyTo") || undefined;
+  const ownerInfo = params.get("owner") === "1";
   return (
     <>
       <ClientCasePage initialCase={caseData} caseId={caseId} />
       <FollowUpModal
         caseId={caseId}
         replyTo={replyTo || undefined}
+        ownerInfo={ownerInfo}
         onClose={() => router.push(`/cases/${caseId}`)}
       />
     </>

--- a/src/app/cases/[id]/ThreadWrapper.tsx
+++ b/src/app/cases/[id]/ThreadWrapper.tsx
@@ -16,6 +16,7 @@ export default function ThreadWrapper({
   const router = useRouter();
   const params = useSearchParams();
   const followup = params.get("followup");
+  const ownerInfo = params.get("owner") === "1";
   return (
     <>
       <ClientThreadPage
@@ -27,6 +28,7 @@ export default function ThreadWrapper({
         <FollowUpModal
           caseId={caseId}
           replyTo={startId}
+          ownerInfo={ownerInfo}
           onClose={() =>
             router.push(
               `/cases/${caseId}/thread/${encodeURIComponent(startId)}`,

--- a/src/app/cases/[id]/followup/FollowUpModal.tsx
+++ b/src/app/cases/[id]/followup/FollowUpModal.tsx
@@ -15,17 +15,22 @@ interface DraftData {
 export default function FollowUpModal({
   caseId,
   replyTo,
+  ownerInfo = false,
   onClose,
 }: {
   caseId: string;
   replyTo?: string;
+  ownerInfo?: boolean;
   onClose: () => void;
 }) {
   const [data, setData] = useState<DraftData | null>(null);
 
   useEffect(() => {
     let canceled = false;
-    const url = `/api/cases/${caseId}/followup${replyTo ? `?replyTo=${encodeURIComponent(replyTo)}` : ""}`;
+    const params = new URLSearchParams();
+    if (replyTo) params.set("replyTo", replyTo);
+    if (ownerInfo) params.set("owner", "1");
+    const url = `/api/cases/${caseId}/followup${params.size > 0 ? `?${params.toString()}` : ""}`;
     fetch(url)
       .then((res) => res.json())
       .then((d) => {
@@ -34,7 +39,7 @@ export default function FollowUpModal({
     return () => {
       canceled = true;
     };
-  }, [caseId, replyTo]);
+  }, [caseId, replyTo, ownerInfo]);
 
   return (
     <Dialog.Root open onOpenChange={(o) => !o && onClose()}>

--- a/src/lib/caseUtils.ts
+++ b/src/lib/caseUtils.ts
@@ -79,6 +79,10 @@ export function getCaseOwnerContact(caseData: Case): string | null {
     const contact = info.paperworkInfo?.contact;
     if (contact) return contact;
   }
+  for (const img of caseData.threadImages ?? []) {
+    const contact = img.ocrInfo?.contact;
+    if (contact) return contact;
+  }
   return null;
 }
 


### PR DESCRIPTION
## Summary
- provide follow-up emails with owner info for authorities
- add flag in followup route and modal to include owner info
- show follow-up transition in progress graph when appropriate
- test follow-up with owner info
- include thread images when checking owner contact

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d56e5988c832ba939bca635d52862