### PR TITLE
Add progress callbacks for LLM requests

### DIFF
--- a/src/jobs/analyzeCase.ts
+++ b/src/jobs/analyzeCase.ts
@@ -4,7 +4,12 @@ import type { Case } from "../lib/caseStore";
 
 (async () => {
   const { jobData } = workerData as { jobData: Case };
-  await analyzeCase(jobData);
+  await analyzeCase(jobData, (update) => {
+    parentPort?.postMessage({
+      event: "update",
+      data: { id: jobData.id, progress: update },
+    });
+  });
   if (parentPort) parentPort.postMessage("done");
 })().catch((err) => {
   console.error("analyzeCase job failed", err);

--- a/src/lib/violationCodes.ts
+++ b/src/lib/violationCodes.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import { getLlm } from "./llm";
+import type OpenAI from "openai";
+import { runCompletion } from "./openai";
 
 export interface ViolationCodeMap {
   [municipality: string]: Record<string, string>;
@@ -60,14 +61,12 @@ export async function getViolationCode(
       },
       { role: "user", content: prompt },
     ];
-    const { client, model } = getLlm("lookup_code");
-    const res = await client.chat.completions.create({
-      model,
-      messages,
-      max_tokens: 60,
-      response_format: { type: "json_object" },
-    });
-    const text = res.choices[0]?.message?.content ?? "{}";
+    const { text } = await runCompletion(
+      "lookup_code",
+      messages as OpenAI.ChatCompletionMessageParam[],
+      60,
+      { type: "json_object" },
+    );
     const parsed = JSON.parse(text) as { code?: string };
     const code = parsed.code?.trim();
     if (code) {


### PR DESCRIPTION
## Summary
- expose `runCompletion` helper that streams tokens when requested
- add `LlmProgress` interface and optional progress callbacks
- report progress during case analysis and OCR
- send worker progress updates through `caseEvents`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d57d12bf4832bba125887aaa28af8