### PR TITLE
Move reanalysis control into graph

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -321,14 +321,6 @@ export default function ClientCasePage({
           <>
             <div className="order-first bg-gray-100 dark:bg-gray-800 p-4 rounded flex flex-col gap-2 text-sm">
               {analysisBlock}
-              <button
-                type="button"
-                onClick={reanalyzeCase}
-                disabled={caseData.analysisStatus === "pending"}
-                className="bg-blue-500 text-white px-2 py-1 rounded disabled:opacity-50 self-start"
-              >
-                Re-run Analysis
-              </button>
               {ownerContact ? (
                 <p>
                   <span className="font-semibold">Owner:</span> {ownerContact}

--- a/src/app/components/CaseProgressGraph.tsx
+++ b/src/app/components/CaseProgressGraph.tsx
@@ -96,7 +96,13 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
   }, []);
 
   const chart = useMemo(() => {
-    const nodes = steps.map((s) => `${s.id}["${s.label}"]`).join("\n");
+    const nodes = steps
+      .map((s) => {
+        let label = s.label;
+        if (s.id === "analysis" && analysisDone) label += " \u25BC";
+        return `${s.id}["${label}"]`;
+      })
+      .join("\n");
     const edgesList: Array<[string, string, boolean, string | null]> = [];
     edgesList.push([
       "uploaded",
@@ -254,6 +260,7 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
     caseData,
     analysisPending,
     reanalysisPending,
+    analysisDone,
   ]);
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -365,9 +372,10 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
       for (const [id, info] of Object.entries(map)) {
         if (!info) continue;
         const el = container.querySelector(
-          `[id^='flowchart-${id}-']`,
+          `[id$='-${id}']`,
         ) as HTMLElement | null;
         if (!el) continue;
+        const isAnalysis = id === "analysis";
         const content = (() => {
           if (info.isImage !== false) {
             if (Array.isArray(info.preview)) {
@@ -393,15 +401,40 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
               : "";
             return `<div class="flex flex-col items-center"><img src="${info.preview}" class="max-h-40" />${caption}</div>`;
           }
-          return `<div class="max-w-xs whitespace-pre-wrap">${escapeHtml(
+          let html = `<div class="max-w-xs whitespace-pre-wrap">${escapeHtml(
             info.preview as string,
           )}</div>`;
+          if (isAnalysis) {
+            html +=
+              '<div class="flex flex-col" style="min-width:8rem">' +
+              '<button data-reanalyze class="text-left px-2 py-1 hover:bg-gray-200 dark:hover:bg-gray-700">Re-run Analysis</button>' +
+              "</div>";
+          }
+          return html;
         })();
-        const inst = tippy(el, {
+        const opts: import("tippy.js").Props = {
           content,
           allowHTML: true,
-        });
-        el.addEventListener("click", () => window.open(info.url, "_blank"));
+          interactive: isAnalysis,
+        };
+        if (isAnalysis) opts.trigger = "click";
+        const inst = tippy(el, opts);
+        if (isAnalysis) {
+          el.addEventListener("click", (e) => e.preventDefault());
+          const btn = inst.popper.querySelector(
+            "[data-reanalyze]",
+          ) as HTMLButtonElement | null;
+          btn?.addEventListener("click", async (e) => {
+            e.stopPropagation();
+            btn.disabled = true;
+            await fetch(`/api/cases/${caseData.id}/reanalyze`, {
+              method: "POST",
+            });
+            window.location.reload();
+          });
+        } else {
+          el.addEventListener("click", () => window.open(info.url, "_blank"));
+        }
         instances.push(inst);
       }
     };


### PR DESCRIPTION
## Summary
- show a dropdown icon on the analysis node when analysis is complete
- open a small menu on click with a re-run option
- prevent navigation when clicking the analysis node so only the menu opens
- fix selector used to attach the menu so the dropdown actually appears

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d59d2dff0832ba0901ada4b8a8da6