### PR TITLE
Remove duplicate reanalysis button

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -322,14 +322,6 @@ export default function ClientCasePage({
           <>
             <div className="order-first bg-gray-100 dark:bg-gray-800 p-4 rounded flex flex-col gap-2 text-sm">
               {analysisBlock}
-              <button
-                type="button"
-                onClick={reanalyzeCase}
-                disabled={caseData.analysisStatus === "pending"}
-                className="bg-blue-500 text-white px-2 py-1 rounded disabled:opacity-50 self-start"
-              >
-                Re-run Analysis
-              </button>
               {ownerContact ? (
                 <p>
                   <span className="font-semibold">Owner:</span> {ownerContact}


### PR DESCRIPTION
## Summary
- remove "Re-run Analysis" button from individual case view
- keep reanalysis actions in dropdown menus

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d6592b6bc832b8a1d1b002c30a550