### PR TITLE
Add step-based analysis progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .DS_Store
 .env
 website/dist
+data

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-progress": "^1.1.7",
         "bree": "^9.2.4",
         "dotenv": "^16.5.0",
         "exif-parser": "^0.1.12",
@@ -4411,6 +4412,30 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-progress": "^1.1.7",
     "bree": "^9.2.4",
     "dotenv": "^16.5.0",
     "exif-parser": "^0.1.12",

--- a/src/app/api/cases/[id]/photos/route.ts
+++ b/src/app/api/cases/[id]/photos/route.ts
@@ -13,7 +13,14 @@ export async function DELETE(
   if (!updated) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
-  analyzeCaseInBackground(updated);
+  const p = updateCase(updated.id, {
+    analysisProgress: {
+      stage: "upload",
+      index: 0,
+      total: updated.photos.length,
+    },
+  });
+  analyzeCaseInBackground(p || updated);
   const layered = getCase(id);
   return NextResponse.json(layered);
 }
@@ -31,7 +38,14 @@ export async function POST(
   if (!updated) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
-  analyzeCaseInBackground(updated);
+  const p = updateCase(updated.id, {
+    analysisProgress: {
+      stage: "upload",
+      index: 0,
+      total: updated.photos.length,
+    },
+  });
+  analyzeCaseInBackground(p || updated);
   const layered = getCase(id);
   return NextResponse.json(layered);
 }

--- a/src/app/api/cases/[id]/reanalyze/route.ts
+++ b/src/app/api/cases/[id]/reanalyze/route.ts
@@ -11,7 +11,10 @@ export async function POST(
   if (!c) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
-  const updated = updateCase(id, { analysisStatus: "pending" });
+  const updated = updateCase(id, {
+    analysisStatus: "pending",
+    analysisProgress: { stage: "upload", index: 0, total: c.photos.length },
+  });
   if (!updated) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -34,7 +34,14 @@ export async function POST(req: NextRequest) {
       updateCase(updated.id, { gps });
       fetchCaseLocationInBackground({ ...updated, gps });
     }
-    analyzeCaseInBackground(updated);
+    const p = updateCase(updated.id, {
+      analysisProgress: {
+        stage: "upload",
+        index: 0,
+        total: updated.photos.length,
+      },
+    });
+    analyzeCaseInBackground(p || updated);
     return NextResponse.json({ caseId: updated.id });
   }
   const newCase = createCase(
@@ -43,7 +50,14 @@ export async function POST(req: NextRequest) {
     clientId || undefined,
     takenAt,
   );
-  analyzeCaseInBackground(newCase);
+  const p = updateCase(newCase.id, {
+    analysisProgress: {
+      stage: "upload",
+      index: 0,
+      total: newCase.photos.length,
+    },
+  });
+  analyzeCaseInBackground(p || newCase);
   fetchCaseLocationInBackground(newCase);
   return NextResponse.json({ caseId: newCase.id });
 }

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -230,6 +230,21 @@ export default function ClientCasePage({
     caseData.analysisOverrides?.vehicle?.licensePlateState !== undefined;
   const ownerContact = getCaseOwnerContact(caseData);
 
+  const progress =
+    caseData.analysisStatus === "pending" ? caseData.analysisProgress : null;
+  const progressDescription = progress
+    ? `${progress.steps ? `Step ${progress.step} of ${progress.steps}: ` : ""}${
+        progress.stage === "upload"
+          ? progress.index > 0
+            ? `Uploading ${progress.index} of ${progress.total} photos (${Math.floor(
+                (progress.index / progress.total) * 100,
+              )}%)`
+            : "Uploading photos..."
+          : progress.done
+            ? "Processing results..."
+            : `Analyzing... ${progress.received} of ${progress.total} tokens`
+      }`
+    : "Analyzing photo...";
   const analysisBlock = caseData.analysis ? (
     <>
       <AnalysisInfo
@@ -239,11 +254,6 @@ export default function ClientCasePage({
         onClearPlate={plateNumberOverridden ? clearPlateNumber : undefined}
         onClearState={plateStateOverridden ? clearPlateState : undefined}
       />
-      {caseData.analysisStatus === "pending" ? (
-        <p className="text-sm text-gray-500 dark:text-gray-400">
-          Updating analysis...
-        </p>
-      ) : null}
     </>
   ) : caseData.analysisError ? (
     <p className="text-sm text-red-600">
@@ -313,6 +323,7 @@ export default function ClientCasePage({
               caseId={caseId}
               disabled={!violationIdentified}
               hasOwner={Boolean(ownerContact)}
+              progress={progress}
             />
           </div>
         }
@@ -390,13 +401,11 @@ export default function ClientCasePage({
                         analysis={caseData.analysis}
                         photo={selectedPhoto}
                       />
-                      {caseData.analysisStatus === "pending" ? (
-                        <p>Updating analysis...</p>
-                      ) : null}
+                      {progress ? <p>{progressDescription}</p> : null}
                     </div>
                   ) : (
                     <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white p-2 text-sm">
-                      Analyzing photo...
+                      {progress ? progressDescription : "Analyzing photo..."}
                     </div>
                   )}
                 </div>

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -1,76 +1,123 @@
 "use client";
+import { Progress } from "@/components/ui/progress";
+import type { LlmProgress } from "@/lib/openai";
 import Link from "next/link";
 
 export default function CaseToolbar({
   caseId,
   disabled = false,
   hasOwner = false,
+  progress,
 }: {
   caseId: string;
   disabled?: boolean;
   hasOwner?: boolean;
+  progress?: LlmProgress | null;
 }) {
+  const reqText = progress
+    ? progress.stage === "upload"
+      ? progress.index > 0
+        ? `Uploading ${progress.index} of ${progress.total} photos (${Math.floor(
+            (progress.index / progress.total) * 100,
+          )}%)`
+        : "Uploading photos..."
+      : progress.done
+        ? "Processing results..."
+        : `Analyzing... ${progress.received} of ${progress.total} tokens`
+    : null;
+  const progressText = progress
+    ? `${progress.steps ? `Step ${progress.step} of ${progress.steps}: ` : ""}${reqText}`
+    : null;
+
+  const requestValue = progress
+    ? progress.stage === "upload"
+      ? progress.index > 0
+        ? (progress.index / progress.total) * 100
+        : undefined
+      : Math.min((progress.received / progress.total) * 100, 100)
+    : undefined;
+  const overallValue =
+    progress?.steps !== undefined && progress.step !== undefined
+      ? ((progress.step - 1 + (requestValue ?? 0) / 100) / progress.steps) * 100
+      : undefined;
   return (
-    <div className="bg-gray-100 dark:bg-gray-800 px-8 py-2 flex justify-end">
-      <details className="relative">
-        <summary className="cursor-pointer select-none bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded">
-          Actions
-        </summary>
-        <div className="absolute right-0 mt-1 bg-white dark:bg-gray-900 border rounded shadow">
-          {disabled ? null : (
-            <>
-              <button
-                type="button"
-                onClick={async () => {
-                  await fetch(`/api/cases/${caseId}/reanalyze`, {
-                    method: "POST",
-                  });
-                  window.location.reload();
-                }}
-                className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
-              >
-                Re-run Analysis
-              </button>
-              <Link
-                href={`/cases/${caseId}/compose`}
-                className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-              >
-                Draft Email to Authorities
-              </Link>
-              {hasOwner ? null : (
+    <div className="bg-gray-100 dark:bg-gray-800 px-8 py-2 flex flex-col gap-2">
+      {progress ? (
+        <div className="flex flex-col gap-1">
+          <Progress
+            value={overallValue}
+            indeterminate={overallValue === undefined}
+          />
+          <Progress
+            value={requestValue}
+            indeterminate={requestValue === undefined}
+          />
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {progressText}
+          </p>
+        </div>
+      ) : null}
+      <div className="flex justify-end">
+        <details className="relative">
+          <summary className="cursor-pointer select-none bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded">
+            Actions
+          </summary>
+          <div className="absolute right-0 mt-1 bg-white dark:bg-gray-900 border rounded shadow">
+            {disabled ? null : (
+              <>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    await fetch(`/api/cases/${caseId}/reanalyze`, {
+                      method: "POST",
+                    });
+                    window.location.reload();
+                  }}
+                  className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+                >
+                  Re-run Analysis
+                </button>
                 <Link
-                  href={`/cases/${caseId}/ownership`}
+                  href={`/cases/${caseId}/compose`}
                   className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
                 >
-                  Request Ownership Info
+                  Draft Email to Authorities
                 </Link>
-              )}
-              <Link
-                href={`/cases/${caseId}/notify-owner`}
-                className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-              >
-                Notify Registered Owner
-              </Link>
-            </>
-          )}
-          <button
-            type="button"
-            onClick={async () => {
-              const code = Math.random().toString(36).slice(2, 6);
-              const input = prompt(
-                `Type '${code}' to confirm deleting this case.`,
-              );
-              if (input === code) {
-                await fetch(`/api/cases/${caseId}`, { method: "DELETE" });
-                window.location.href = "/cases";
-              }
-            }}
-            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
-          >
-            Delete Case
-          </button>
-        </div>
-      </details>
+                {hasOwner ? null : (
+                  <Link
+                    href={`/cases/${caseId}/ownership`}
+                    className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                  >
+                    Request Ownership Info
+                  </Link>
+                )}
+                <Link
+                  href={`/cases/${caseId}/notify-owner`}
+                  className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                >
+                  Notify Registered Owner
+                </Link>
+              </>
+            )}
+            <button
+              type="button"
+              onClick={async () => {
+                const code = Math.random().toString(36).slice(2, 6);
+                const input = prompt(
+                  `Type '${code}' to confirm deleting this case.`,
+                );
+                if (input === code) {
+                  await fetch(`/api/cases/${caseId}`, { method: "DELETE" });
+                  window.location.href = "/cases";
+                }
+              }}
+              className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+            >
+              Delete Case
+            </button>
+          </div>
+        </details>
+      </div>
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,16 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@keyframes progress-indeterminate {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
+.animate-progress {
+  animation: progress-indeterminate 1s linear infinite;
+}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,28 @@
+"use client";
+import * as ProgressPrimitive from "@radix-ui/react-progress";
+import * as React from "react";
+
+export interface ProgressProps
+  extends React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> {
+  value?: number;
+  indeterminate?: boolean;
+}
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  ProgressProps
+>(({ value, indeterminate, className, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={`relative h-2 w-full overflow-hidden rounded-full bg-gray-300 dark:bg-gray-700 ${className ?? ""}`}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className={`h-full w-full bg-blue-600 transition-transform ${indeterminate ? "animate-progress" : ""}`}
+      style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+));
+Progress.displayName = "Progress";
+
+export { Progress };

--- a/src/lib/caseAnalysis.ts
+++ b/src/lib/caseAnalysis.ts
@@ -30,18 +30,49 @@ export async function analyzeCase(caseData: Case): Promise<void> {
     const imageMap: Record<string, string> = Object.fromEntries(
       images.map((i) => [i.filename, i.url]),
     );
-    const result = await analyzeViolation(images);
+    let steps = 1 + caseData.photos.length;
+    const currentStep = 1;
+    updateCase(caseData.id, {
+      analysisProgress: {
+        stage: "upload",
+        index: 0,
+        total: images.length,
+        step: currentStep,
+        steps,
+      },
+    });
+    const result = await analyzeViolation(images, (p) => {
+      updateCase(caseData.id, {
+        analysisProgress: { ...p, step: currentStep, steps },
+      });
+    });
+    updateCase(caseData.id, { analysisProgress: null });
+    const paperwork: Array<[string, string]> = [];
     if (result.images) {
       for (const [name, info] of Object.entries(result.images)) {
         if (info.paperwork && !info.paperworkText) {
           const url = imageMap[name];
           if (url) {
-            const ocr = await ocrPaperwork({ url });
-            info.paperworkText = ocr.text;
-            if (ocr.info) info.paperworkInfo = ocr.info;
+            paperwork.push([name, url]);
           }
         }
       }
+    }
+    steps = 1 + paperwork.length;
+    let stepIndex = 2;
+    for (const [name, url] of paperwork) {
+      const ocr = await ocrPaperwork({ url }, (p) => {
+        updateCase(caseData.id, {
+          analysisProgress: { ...p, step: stepIndex, steps },
+        });
+      });
+      updateCase(caseData.id, { analysisProgress: null });
+      const info = result.images?.[name];
+      if (info) {
+        info.paperworkText = ocr.text;
+        if (ocr.info) info.paperworkInfo = ocr.info;
+      }
+      stepIndex++;
     }
     updateCase(caseData.id, {
       analysis: result,

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -26,6 +26,7 @@ export interface Case {
   analysisStatusCode?: number | null;
   /** @zod.enum(["truncated", "parse", "schema"]).nullable() */
   analysisError?: "truncated" | "parse" | "schema" | "images" | null;
+  analysisProgress?: import("./openai").LlmProgress | null;
   sentEmails?: SentEmail[];
   ownershipRequests?: OwnershipRequest[];
   threadImages?: ThreadImage[];
@@ -77,6 +78,7 @@ function loadCases(): Case[] {
       photos: c.photos ?? (c.photo ? [c.photo] : []),
       photoTimes: c.photoTimes ?? {},
       analysisStatus: c.analysisStatus ?? (c.analysis ? "complete" : "pending"),
+      analysisProgress: c.analysisProgress ?? null,
       sentEmails: (c.sentEmails ?? []).map((m: unknown) => {
         const mail = m as Partial<SentEmail> & { [key: string]: unknown };
         return {
@@ -153,6 +155,7 @@ export function createCase(
     analysisStatus: "pending",
     analysisStatusCode: null,
     analysisError: null,
+    analysisProgress: null,
     sentEmails: [],
     ownershipRequests: [],
     threadImages: [],


### PR DESCRIPTION
## Summary
- integrate progress feedback with token-aware streaming updates
- show determinate step progress and request progress bars
- expose progress messages with token counts

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d57d12bf4832bba125887aaa28af8