### PR TITLE
Handle SSE case deletion events

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -87,8 +87,11 @@ export default function ClientCasePage({
     });
     const es = new EventSource("/api/cases/stream");
     es.onmessage = (e) => {
-      const data = JSON.parse(e.data) as Case;
-      if (data.id === caseId) {
+      const data = JSON.parse(e.data) as Case & { deleted?: boolean };
+      if (data.id !== caseId) return;
+      if (data.deleted) {
+        setCaseData(null);
+      } else {
         setCaseData(data);
         sessionStorage.removeItem(`preview-${caseId}`);
       }

--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -40,8 +40,11 @@ export default function ClientThreadPage({
     });
     const es = new EventSource("/api/cases/stream");
     es.onmessage = (e) => {
-      const data = JSON.parse(e.data) as Case;
-      if (data.id === caseId) {
+      const data = JSON.parse(e.data) as Case & { deleted?: boolean };
+      if (data.id !== caseId) return;
+      if (data.deleted) {
+        setCaseData(null);
+      } else {
         setCaseData(data);
       }
     };


### PR DESCRIPTION
## Summary
- handle case deletion events in `ClientCasePage`
- handle case deletion events in thread page

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d77c893ec832b8d73bc97aa2b4627