### PR TITLE
Handle failed/canceled case analysis

### DIFF
--- a/src/app/api/cases/[id]/cancel-analysis/route.ts
+++ b/src/app/api/cases/[id]/cancel-analysis/route.ts
@@ -1,0 +1,16 @@
+import { cancelCaseAnalysis } from "@/lib/caseAnalysis";
+import { getCase } from "@/lib/caseStore";
+import { NextResponse } from "next/server";
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const ok = cancelCaseAnalysis(id);
+  const c = getCase(id);
+  if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (!ok) return NextResponse.json(c);
+  const layered = getCase(id);
+  return NextResponse.json(layered);
+}

--- a/src/app/api/cases/[id]/photos/route.ts
+++ b/src/app/api/cases/[id]/photos/route.ts
@@ -14,6 +14,7 @@ export async function DELETE(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
   const p = updateCase(updated.id, {
+    analysisStatus: "pending",
     analysisProgress: {
       stage: "upload",
       index: 0,
@@ -40,6 +41,7 @@ export async function POST(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
   const p = updateCase(updated.id, {
+    analysisStatus: "pending",
     analysisProgress: {
       stage: "upload",
       index: 0,

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -40,6 +40,7 @@ export async function POST(req: NextRequest) {
       fetchCaseLocationInBackground({ ...updated, gps });
     }
     const p = updateCase(updated.id, {
+      analysisStatus: "pending",
       analysisProgress: {
         stage: "upload",
         index: 0,
@@ -56,6 +57,7 @@ export async function POST(req: NextRequest) {
     takenAt,
   );
   const p = updateCase(newCase.id, {
+    analysisStatus: "pending",
     analysisProgress: {
       stage: "upload",
       index: 0,

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -232,7 +232,9 @@ export default function ClientCasePage({
   const ownerContact = getCaseOwnerContact(caseData);
 
   const progress =
-    caseData.analysisStatus === "pending" ? caseData.analysisProgress : null;
+    caseData.analysisStatus === "pending" && caseData.analysisProgress
+      ? caseData.analysisProgress
+      : null;
   const progressDescription = progress
     ? `${progress.steps ? `Step ${progress.step} of ${progress.steps}: ` : ""}${
         progress.stage === "upload"
@@ -245,7 +247,11 @@ export default function ClientCasePage({
             ? "Processing results..."
             : `Analyzing... ${progress.received} of ${progress.total} tokens`
       }`
-    : "Analyzing photo...";
+    : caseData.analysisStatus === "pending"
+      ? "Analyzing photo..."
+      : caseData.analysisStatus === "canceled"
+        ? "Analysis canceled."
+        : "Analysis failed.";
   const analysisBlock = caseData.analysis ? (
     <>
       <AnalysisInfo
@@ -270,10 +276,14 @@ export default function ClientCasePage({
     <p className="text-sm text-red-600">
       Analysis failed. Please try again later.
     </p>
-  ) : (
+  ) : caseData.analysisStatus === "canceled" ? (
+    <p className="text-sm text-red-600">Analysis canceled.</p>
+  ) : caseData.analysisStatus === "pending" && progress ? (
     <p className="text-sm text-gray-500 dark:text-gray-400">
-      Analyzing photo...
+      {progressDescription}
     </p>
+  ) : (
+    <p className="text-sm text-red-600">Analysis failed.</p>
   );
 
   const analysisImages = caseData.analysis?.images ?? {};
@@ -396,7 +406,7 @@ export default function ClientCasePage({
                     </div>
                   ) : (
                     <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white p-2 text-sm">
-                      {progress ? progressDescription : "Analyzing photo..."}
+                      {progressDescription}
                     </div>
                   )}
                 </div>

--- a/src/app/components/CaseProgressGraph.tsx
+++ b/src/app/components/CaseProgressGraph.tsx
@@ -43,9 +43,13 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
   const noviolation = analysisDone && !violation;
 
   const analysisPending =
-    caseData.analysisStatus === "pending" && !caseData.analysis;
+    caseData.analysisStatus === "pending" &&
+    !caseData.analysis &&
+    caseData.analysisProgress;
   const reanalysisPending =
-    caseData.analysisStatus === "pending" && Boolean(caseData.analysis);
+    caseData.analysisStatus === "pending" &&
+    Boolean(caseData.analysis) &&
+    caseData.analysisProgress;
 
   const steps = useMemo(() => {
     return noviolation

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -77,6 +77,20 @@ export default function CaseToolbar({
                 >
                   Re-run Analysis
                 </button>
+                {progress ? (
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      await fetch(`/api/cases/${caseId}/cancel-analysis`, {
+                        method: "POST",
+                      });
+                      window.location.reload();
+                    }}
+                    className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+                  >
+                    Cancel Analysis
+                  </button>
+                ) : null}
                 <Link
                   href={`/cases/${caseId}/compose`}
                   className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"

--- a/src/generated/zod/caseStore.ts
+++ b/src/generated/zod/caseStore.ts
@@ -31,6 +31,16 @@ export const caseSchema = z.object({
   id: z.string(),
   photos: z.array(z.string()),
   photoTimes: z.record(z.string().nullable()),
+  photoGps: z
+    .record(
+      z
+        .object({
+          lat: z.number(),
+          lon: z.number(),
+        })
+        .nullable(),
+    )
+    .optional(),
   createdAt: z.string(),
   gps: z
     .object({
@@ -45,7 +55,12 @@ export const caseSchema = z.object({
   vinOverride: z.string().optional().nullable(),
   analysis: violationReportSchema.optional().nullable(),
   analysisOverrides: violationReportSchema.partial().optional().nullable(),
-  analysisStatus: z.union([z.literal("pending"), z.literal("complete")]),
+  analysisStatus: z.union([
+    z.literal("pending"),
+    z.literal("complete"),
+    z.literal("failed"),
+    z.literal("canceled"),
+  ]),
   analysisStatusCode: z.number().optional().nullable(),
   analysisError: z
     .union([
@@ -56,6 +71,7 @@ export const caseSchema = z.object({
     ])
     .optional()
     .nullable(),
+  analysisProgress: z.any().optional().nullable(),
   sentEmails: z.array(sentEmailSchema).optional(),
   ownershipRequests: z.array(ownershipRequestSchema).optional(),
   threadImages: z.array(threadImageSchema).optional(),

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -23,8 +23,8 @@ export interface Case {
   vinOverride?: string | null;
   analysis?: ViolationReport | null;
   analysisOverrides?: Partial<ViolationReport> | null;
-  /** @zod.enum(["pending", "complete"]) */
-  analysisStatus: "pending" | "complete";
+  /** @zod.enum(["pending", "complete", "failed", "canceled"]) */
+  analysisStatus: "pending" | "complete" | "failed" | "canceled";
   analysisStatusCode?: number | null;
   /** @zod.enum(["truncated", "parse", "schema"]).nullable() */
   analysisError?: "truncated" | "parse" | "schema" | "images" | null;

--- a/src/lib/jobScheduler.ts
+++ b/src/lib/jobScheduler.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { Worker } from "node:worker_threads";
 import { caseEvents } from "./caseEvents";
 
-export function runJob(name: string, jobData: unknown): void {
+export function runJob(name: string, jobData: unknown): Worker {
   const jobPath = path.join(process.cwd(), "src", "jobs", `${name}.ts`);
   const wrapper = path.join(process.cwd(), "src", "jobs", "workerWrapper.js");
   const worker = new Worker(wrapper, {
@@ -16,4 +16,5 @@ export function runJob(name: string, jobData: unknown): void {
   worker.on("error", (err) => {
     console.error(`${name} worker failed`, err);
   });
+  return worker;
 }


### PR DESCRIPTION
## Summary
- add `failed` and `canceled` analysis statuses
- track running workers and allow canceling analysis
- mark analysis failed on worker errors
- update upload and photo APIs to reset status when starting analysis
- provide cancel option in case toolbar
- show analysis status more accurately in case pages and progress graph
- regenerate zod schemas

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d799b212c832bb3fde4c8f1916643