### PR TITLE
Ensure reanalyze option always available

### DIFF
--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -63,20 +63,20 @@ export default function CaseToolbar({
             Actions
           </summary>
           <div className="absolute right-0 mt-1 bg-white dark:bg-gray-900 border rounded shadow">
+            <button
+              type="button"
+              onClick={async () => {
+                await fetch(`/api/cases/${caseId}/reanalyze`, {
+                  method: "POST",
+                });
+                window.location.reload();
+              }}
+              className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+            >
+              Re-run Analysis
+            </button>
             {disabled ? null : (
               <>
-                <button
-                  type="button"
-                  onClick={async () => {
-                    await fetch(`/api/cases/${caseId}/reanalyze`, {
-                      method: "POST",
-                    });
-                    window.location.reload();
-                  }}
-                  className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
-                >
-                  Re-run Analysis
-                </button>
                 <Link
                   href={`/cases/${caseId}/compose`}
                   className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"

--- a/src/app/components/MultiCaseToolbar.tsx
+++ b/src/app/components/MultiCaseToolbar.tsx
@@ -19,22 +19,22 @@ export default function MultiCaseToolbar({
           Actions
         </summary>
         <div className="absolute right-0 mt-1 bg-white dark:bg-gray-900 border rounded shadow">
+          <button
+            type="button"
+            onClick={async () => {
+              await Promise.all(
+                caseIds.map((id) =>
+                  fetch(`/api/cases/${id}/reanalyze`, { method: "POST" }),
+                ),
+              );
+              window.location.reload();
+            }}
+            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+          >
+            Re-run Analysis
+          </button>
           {disabled ? null : (
             <>
-              <button
-                type="button"
-                onClick={async () => {
-                  await Promise.all(
-                    caseIds.map((id) =>
-                      fetch(`/api/cases/${id}/reanalyze`, { method: "POST" }),
-                    ),
-                  );
-                  window.location.reload();
-                }}
-                className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
-              >
-                Re-run Analysis
-              </button>
               <Link
                 href={`/cases/${first}/compose?ids=${idsParam}`}
                 className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"


### PR DESCRIPTION
## Summary
- keep the Re-run Analysis button visible even when other case actions are disabled
- apply the same logic for multi-case actions

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d790c21dc832bac90d9f743feb26f