### PR TITLE
Fix selected photo resetting during case updates

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -104,7 +104,13 @@ export default function ClientCasePage({
       setPlate(getCasePlateNumber(caseData) || "");
       setPlateState(getCasePlateState(caseData) || "");
       setVin(getCaseVin(caseData) || "");
-      setSelectedPhoto(getRepresentativePhoto(caseData));
+      setSelectedPhoto((prev) => {
+        const all = new Set<string>([
+          ...caseData.photos,
+          ...(caseData.threadImages ?? []).map((img) => img.url),
+        ]);
+        return prev && all.has(prev) ? prev : getRepresentativePhoto(caseData);
+      });
     }
   }, [caseData]);
 


### PR DESCRIPTION
## Summary
- retain currently selected photo when case data updates

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d8a86bb4c832bb941309b7ee8bc7c