### PR TITLE
Fix case worker db init

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Generate new migration files from the Drizzle schema with:
 npm run generate:migrations
 ```
 
-Migrations are stored as SQL files under the `migrations` folder and executed with [Umzug](https://github.com/sequelize/umzug). The default SQLite database is `data/cases.sqlite`.
+Migrations are stored as SQL files under the `migrations` folder and applied at runtime. The default SQLite database is `data/cases.sqlite`.
 
 ## OpenAI Integration
 

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,7 +1,9 @@
 import { db } from "../src/lib/db";
 import { runMigrations } from "../src/lib/migrate";
 
-runMigrations(db).catch((err) => {
+try {
+  runMigrations(db);
+} catch (err) {
   console.error(err);
   process.exit(1);
-});
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -11,4 +11,4 @@ fs.mkdirSync(path.dirname(dbFile), { recursive: true });
 
 export const db = new Database(dbFile);
 
-await runMigrations(db);
+runMigrations(db);

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -1,15 +1,10 @@
-import fs from "node:fs/promises";
+import fs from "node:fs";
 import path from "node:path";
 import type Database from "better-sqlite3";
-import { Umzug } from "umzug";
 
-interface MigrationContext {
-  db: Database;
-}
-
-export async function runMigrations(db: Database): Promise<void> {
+export function runMigrations(db: Database): void {
   const migrationsDir = path.join(process.cwd(), "migrations");
-  await fs.mkdir(migrationsDir, { recursive: true });
+  fs.mkdirSync(migrationsDir, { recursive: true });
 
   db.exec(`
     CREATE TABLE IF NOT EXISTS migrations (
@@ -17,36 +12,19 @@ export async function runMigrations(db: Database): Promise<void> {
     );
   `);
 
-  const storage = {
-    async executed() {
-      const rows = db
-        .prepare("SELECT name FROM migrations ORDER BY name")
-        .all() as Array<{ name: string }>;
-      return rows.map((r) => r.name);
-    },
-    async logMigration({ name }: { name: string }) {
-      db.prepare("INSERT INTO migrations (name) VALUES (?)").run(name);
-    },
-    async unlogMigration({ name }: { name: string }) {
-      db.prepare("DELETE FROM migrations WHERE name = ?").run(name);
-    },
-  };
+  const executedRows = db
+    .prepare("SELECT name FROM migrations ORDER BY name")
+    .all() as Array<{ name: string }>;
+  const executed = new Set(executedRows.map((r) => r.name));
 
-  const umzug = new Umzug<MigrationContext>({
-    migrations: {
-      glob: path.join(migrationsDir, "*.sql"),
-      resolve: ({ name, path: filepath }) => ({
-        name,
-        async up({ context }) {
-          const sql = await fs.readFile(filepath as string, "utf8");
-          context.db.exec(sql);
-        },
-      }),
-    },
-    context: { db },
-    storage,
-    logger: console,
-  });
-
-  await umzug.up();
+  const files = fs
+    .readdirSync(migrationsDir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+  for (const file of files) {
+    if (executed.has(file)) continue;
+    const sql = fs.readFileSync(path.join(migrationsDir, file), "utf8");
+    db.exec(sql);
+    db.prepare("INSERT INTO migrations (name) VALUES (?)").run(file);
+  }
 }


### PR DESCRIPTION
## Summary
- avoid top-level await in the DB module
- run migrations synchronously
- update migration script and docs

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Could not locate better-sqlite3 bindings)*

------
https://chatgpt.com/codex/tasks/task_e_684db208c958832bad198be319f18358