### PR TITLE
Fix migrations initialization

### DIFF
--- a/scripts/scanInbox.ts
+++ b/scripts/scanInbox.ts
@@ -1,6 +1,12 @@
+import { migrationsReady } from "../src/lib/db";
 import { scanInbox } from "../src/lib/inboxScanner";
 
-scanInbox().catch((err) => {
+async function run() {
+  await migrationsReady;
+  await scanInbox();
+}
+
+run().catch((err) => {
   console.error(err);
   process.exit(1);
 });

--- a/scripts/updateMissingAnalysis.ts
+++ b/scripts/updateMissingAnalysis.ts
@@ -1,7 +1,9 @@
 import { analyzeCase } from "../src/lib/caseAnalysis";
 import { getCases } from "../src/lib/caseStore";
+import { migrationsReady } from "../src/lib/db";
 
 async function run() {
+  await migrationsReady;
   const cases = getCases();
   for (const c of cases) {
     const status = c.analysisStatusCode;

--- a/src/jobs/analyzeCase.ts
+++ b/src/jobs/analyzeCase.ts
@@ -1,8 +1,10 @@
 import { parentPort, workerData } from "node:worker_threads";
 import { analyzeCase } from "../lib/caseAnalysis";
 import type { Case } from "../lib/caseStore";
+import { migrationsReady } from "../lib/db";
 
 (async () => {
+  await migrationsReady;
   const { jobData } = workerData as { jobData: Case };
   await analyzeCase(jobData);
   if (parentPort) parentPort.postMessage("done");

--- a/src/jobs/fetchCaseLocation.ts
+++ b/src/jobs/fetchCaseLocation.ts
@@ -1,8 +1,10 @@
 import { parentPort, workerData } from "node:worker_threads";
 import { fetchCaseLocation } from "../lib/caseLocation";
 import type { Case } from "../lib/caseStore";
+import { migrationsReady } from "../lib/db";
 
 (async () => {
+  await migrationsReady;
   const { jobData } = workerData as { jobData: Case };
   await fetchCaseLocation(jobData);
   if (parentPort) parentPort.postMessage("done");

--- a/src/jobs/fetchCaseVin.ts
+++ b/src/jobs/fetchCaseVin.ts
@@ -1,8 +1,10 @@
 import { parentPort, workerData } from "node:worker_threads";
 import type { Case } from "../lib/caseStore";
+import { migrationsReady } from "../lib/db";
 import { fetchCaseVin } from "../lib/vinLookup";
 
 (async () => {
+  await migrationsReady;
   const { jobData } = workerData as { jobData: Case };
   await fetchCaseVin(jobData);
   if (parentPort) parentPort.postMessage("done");

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -11,4 +11,4 @@ fs.mkdirSync(path.dirname(dbFile), { recursive: true });
 
 export const db = new Database(dbFile);
 
-await runMigrations(db);
+export const migrationsReady = runMigrations(db);

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -11,7 +11,9 @@ beforeEach(async () => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.json");
   vi.resetModules();
+  const dbModule = await import("../src/lib/db");
   caseStore = await import("../src/lib/caseStore");
+  await dbModule.migrationsReady;
 });
 
 afterEach(() => {

--- a/test/vinLookup.test.ts
+++ b/test/vinLookup.test.ts
@@ -17,6 +17,8 @@ beforeEach(async () => {
   }));
   fs.writeFileSync(process.env.VIN_SOURCE_FILE, JSON.stringify(statuses));
   vi.resetModules();
+  const dbModule = await import("../src/lib/db");
+  await dbModule.migrationsReady;
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary
- remove top-level await from database init
- wait for migrations in worker jobs and scripts
- ensure tests await database setup before running

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: Unexpected token 'S', "SQLite for"... is not valid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_684db040b68c832b977462e745893548