### PR TITLE
Fix progress bar width

### DIFF
--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -41,7 +41,7 @@ export default function CaseToolbar({
       ? ((progress.step - 1 + (requestValue ?? 0) / 100) / progress.steps) * 100
       : undefined;
   return (
-    <div className="bg-gray-100 dark:bg-gray-800 px-8 py-2 flex flex-col gap-2">
+    <div className="bg-gray-100 dark:bg-gray-800 px-8 py-2 flex flex-col gap-2 flex-1">
       {progress ? (
         <div className="flex flex-col gap-1">
           <Progress


### PR DESCRIPTION
## Summary
- expand the case toolbar to fill remaining header space so its progress bars
  use the full width

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dc3bb55d0832ba8c2db4a7612c4be