### PR TITLE
Fix image browser height

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -398,7 +398,7 @@ export default function ClientCasePage({
             </div>
             {selectedPhoto ? (
               <>
-                <div className="relative w-full aspect-[3/2] md:max-w-2xl">
+                <div className="relative w-full aspect-[3/2] md:max-w-2xl shrink-0">
                   <Image
                     src={selectedPhoto}
                     alt="uploaded"


### PR DESCRIPTION
## Summary
- keep ClientCasePage image container from shrinking when switching images

## Testing
- `npm run lint`
- `npm test` *(fails: Could not locate the bindings file for better-sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_684dc43c99f4832bb660cc1c73463099