### PR TITLE
Add case ordering controls

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -17,14 +17,17 @@ describe("Home page", () => {
       FakeEventSource as unknown as typeof EventSource;
   });
 
-  it("redirects mobile users to /point", () => {
+  it("redirects mobile users to /point", async () => {
     (headers as vi.Mock).mockReturnValueOnce(
-      new Headers({
-        "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X)",
-      }),
+      Promise.resolve(
+        new Headers({
+          "user-agent":
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X)",
+        }),
+      ),
     );
     try {
-      Home();
+      await Home();
     } catch (err) {
       expect((err as { digest?: string }).digest).toContain("/point");
       return;
@@ -32,12 +35,14 @@ describe("Home page", () => {
     throw new Error("Expected redirect");
   });
 
-  it("redirects desktop users to /cases", () => {
+  it("redirects desktop users to /cases", async () => {
     (headers as vi.Mock).mockReturnValueOnce(
-      new Headers({ "user-agent": "Mozilla/5.0 (X11; Linux x86_64)" }),
+      Promise.resolve(
+        new Headers({ "user-agent": "Mozilla/5.0 (X11; Linux x86_64)" }),
+      ),
     );
     try {
-      Home();
+      await Home();
     } catch (err) {
       expect((err as { digest?: string }).digest).toContain("/cases");
       return;

--- a/src/app/cases/ClientCasesPage.stories.tsx
+++ b/src/app/cases/ClientCasesPage.stories.tsx
@@ -14,6 +14,7 @@ const caseBase: Omit<Case, "id"> = {
   photos: ["https://placehold.co/600x400?text=photo"],
   photoTimes: {},
   createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
   gps: { lat: 41.88, lon: -87.78 },
   streetAddress: null,
   intersection: null,

--- a/src/app/cases/[id]/ClientCasePage.stories.tsx
+++ b/src/app/cases/[id]/ClientCasePage.stories.tsx
@@ -18,6 +18,7 @@ const base: Case = {
   ],
   photoTimes: {},
   createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
   gps: { lat: 41.88, lon: -87.78 },
   streetAddress: "123 Main St",
   intersection: "Main & 1st",

--- a/src/app/cases/[id]/ComposeWrapper.stories.tsx
+++ b/src/app/cases/[id]/ComposeWrapper.stories.tsx
@@ -19,6 +19,7 @@ const base: Case = {
   ],
   photoTimes: {},
   createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
   gps: { lat: 41.88, lon: -87.78 },
   streetAddress: "123 Main St",
   intersection: "Main & 1st",

--- a/src/app/cases/[id]/draft/DraftModal.stories.tsx
+++ b/src/app/cases/[id]/draft/DraftModal.stories.tsx
@@ -19,6 +19,7 @@ const base: Case = {
   ],
   photoTimes: {},
   createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
   gps: { lat: 41.88, lon: -87.78 },
   streetAddress: "123 Main St",
   intersection: "Main & 1st",

--- a/src/app/cases/__tests__/dragOverlayPosition.test.tsx
+++ b/src/app/cases/__tests__/dragOverlayPosition.test.tsx
@@ -37,6 +37,7 @@ const baseCase: Case = {
   photos: [],
   photoTimes: {},
   createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
   analysisStatus: "pending",
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,8 @@ export { dynamic } from "./cases/page";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
-export default function Home() {
-  const ua = headers().get("user-agent") ?? "";
+export default async function Home() {
+  const ua = (await headers()).get("user-agent") ?? "";
   const isMobile = /Mobile|Android|iPhone|iPad/i.test(ua);
   redirect(isMobile ? "/point" : "/cases");
 }

--- a/src/generated/zod/caseStore.ts
+++ b/src/generated/zod/caseStore.ts
@@ -42,6 +42,7 @@ export const caseSchema = z.object({
     )
     .optional(),
   createdAt: z.string(),
+  updatedAt: z.string(),
   gps: z
     .object({
       lat: z.number(),

--- a/src/lib/__tests__/caseReport.test.ts
+++ b/src/lib/__tests__/caseReport.test.ts
@@ -11,6 +11,7 @@ const baseCase: Case = {
   photos: ["/foo.jpg"],
   photoTimes: { "/foo.jpg": "2020-01-01T00:00:00.000Z" },
   createdAt: "2020-01-01T00:00:00.000Z",
+  updatedAt: "2020-01-01T00:00:00.000Z",
   gps: null,
   streetAddress: null,
   intersection: null,


### PR DESCRIPTION
## Summary
- add updatedAt field to cases and update whenever cases change
- generate new zod schemas
- add dropdown in Cases page to sort by creation date or last updated
- update tests for async headers and new field

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: ENOENT due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684dc2bca7b0832bb37fdc7a08321a83