### PR TITLE
Add single image reanalysis

### DIFF
--- a/src/app/api/cases/[id]/reanalyze-image/route.ts
+++ b/src/app/api/cases/[id]/reanalyze-image/route.ts
@@ -1,0 +1,20 @@
+import { reanalyzeCaseImage } from "@/lib/caseAnalysis";
+import { getCase } from "@/lib/caseStore";
+import { NextResponse } from "next/server";
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const body = (await req.json()) as { photo: string };
+  const c = getCase(id);
+  if (!c || !c.photos.includes(body.photo)) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  await reanalyzeCaseImage(c, body.photo);
+  const updated = getCase(id);
+  if (!updated)
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(updated);
+}

--- a/test/e2e/reanalyzeImage.test.ts
+++ b/test/e2e/reanalyzeImage.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
+import { type TestServer, startServer } from "./startServer";
+
+let server: TestServer;
+let stub: OpenAIStub;
+let tmpDir: string;
+
+beforeAll(async () => {
+  const first = {
+    violationType: "parking",
+    details: "",
+    vehicle: {},
+    images: {},
+  };
+  const second = {
+    violationType: "parking",
+    details: "",
+    vehicle: { licensePlateNumber: "XYZ", licensePlateState: "IL" },
+    images: { "a.jpg": { representationScore: 1, violation: true } },
+  };
+  stub = await startOpenAIStub([first, second]);
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
+  const env = {
+    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+    OPENAI_BASE_URL: stub.url,
+  };
+  server = await startServer(3008, env);
+}, 120000);
+
+afterAll(async () => {
+  await server.close();
+  await stub.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}, 120000);
+
+describe("reanalyze single image", () => {
+  async function createCase(): Promise<string> {
+    const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+    const form = new FormData();
+    form.append("photo", file);
+    const res = await fetch(`${server.url}/api/upload`, {
+      method: "POST",
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { caseId: string };
+    return data.caseId;
+  }
+
+  it("updates missing fields from image", async () => {
+    const id = await createCase();
+    let res: Response | null = null;
+    for (let i = 0; i < 10; i++) {
+      const attempt = await fetch(`${server.url}/api/cases/${id}`);
+      if (attempt.status === 200) {
+        res = attempt;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    expect(res).not.toBeNull();
+    const initial = (await (res as Response).json()) as {
+      photos: string[];
+      analysis: Record<string, unknown>;
+    };
+    expect(initial.analysis.vehicle.licensePlateNumber).toBeUndefined();
+    const photo = initial.photos[0];
+    const update = await fetch(
+      `${server.url}/api/cases/${id}/reanalyze-image`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ photo }),
+      },
+    );
+    expect(update.status).toBe(200);
+    const updated = (await update.json()) as {
+      analysis: Record<string, unknown>;
+    };
+    expect(updated.analysis.vehicle.licensePlateNumber).toBe("XYZ");
+    expect(stub.requests.length).toBe(2);
+  }, 30000);
+});


### PR DESCRIPTION
## Summary
- implement `reanalyzeCaseImage` in caseAnalysis
- add API route to trigger single-image analysis
- test reanalyze-image flow end-to-end

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dc36aaa8c832b998bdd26977f20a7