### PR TITLE
feat: show delete badge on hover

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -431,7 +431,7 @@ export default function ClientCasePage({
             ) : null}
             <div className="flex gap-2 flex-wrap">
               {evidencePhotos.map((p) => (
-                <div key={p} className="relative">
+                <div key={p} className="relative group">
                   <button
                     type="button"
                     onClick={() => setSelectedPhoto(p)}
@@ -461,7 +461,7 @@ export default function ClientCasePage({
                   <button
                     type="button"
                     onClick={() => removePhoto(p)}
-                    className="absolute -top-1 -right-1 bg-red-600 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"
+                    className="absolute -top-1 -right-1 bg-red-600 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs opacity-0 group-hover:opacity-100 transition-opacity"
                   >
                     ×
                   </button>


### PR DESCRIPTION
## Summary
- show the red delete badge only when hovering over case photos

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dc7268d84832b831fe5a5acfb4ed7