### PR TITLE
Fix single photo badge

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -131,9 +131,11 @@ export default function ClientCasesPage({
                   width={80}
                   height={60}
                 />
-                <span className="absolute bottom-1 right-1 bg-black bg-opacity-75 text-white text-xs rounded px-1">
-                  {c.photos.length}
-                </span>
+                {c.photos.length > 1 ? (
+                  <span className="absolute bottom-1 right-1 bg-black bg-opacity-75 text-white text-xs rounded px-1">
+                    {c.photos.length}
+                  </span>
+                ) : null}
               </div>
               {(() => {
                 const g = getOfficialCaseGps(c);


### PR DESCRIPTION
## Summary
- don't show image count badge when a case only has one photo

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dc6c8e790832ba80be1fcd9fb5c1c