### PR TITLE
Implement redirect after notification

### DIFF
--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -2,6 +2,7 @@
 import type { EmailDraft } from "@/lib/caseReport";
 import type { ReportModule } from "@/lib/reportModules";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 export default function DraftEditor({
@@ -21,6 +22,7 @@ export default function DraftEditor({
   replyTo?: string;
   to?: string;
 }) {
+  const router = useRouter();
   const [subject, setSubject] = useState(initialDraft?.subject || "");
   const [body, setBody] = useState(initialDraft?.body || "");
   const [sending, setSending] = useState(false);
@@ -49,6 +51,15 @@ export default function DraftEditor({
       });
       if (res.ok) {
         alert("Email sent");
+        const data = (await res.json()) as {
+          sentEmails?: { sentAt: string }[];
+        };
+        const sent = data.sentEmails?.at(-1)?.sentAt;
+        if (sent) {
+          router.push(`/cases/${caseId}/thread/${encodeURIComponent(sent)}`);
+        } else {
+          router.push(`/cases/${caseId}`);
+        }
       } else {
         alert("Failed to send email");
       }

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 import type { EmailDraft } from "@/lib/caseReport";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 export default function NotifyOwnerEditor({
@@ -22,6 +23,7 @@ export default function NotifyOwnerEditor({
   availableMethods: string[];
   caseId: string;
 }) {
+  const router = useRouter();
   const [subject, setSubject] = useState(initialDraft?.subject || "");
   const [body, setBody] = useState(initialDraft?.body || "");
   const [sending, setSending] = useState(false);
@@ -44,6 +46,15 @@ export default function NotifyOwnerEditor({
       });
       if (res.ok) {
         alert("Notification sent");
+        const data = (await res.json()) as {
+          sentEmails?: { sentAt: string }[];
+        };
+        const sent = data.sentEmails?.at(-1)?.sentAt;
+        if (sent) {
+          router.push(`/cases/${caseId}/thread/${encodeURIComponent(sent)}`);
+        } else {
+          router.push(`/cases/${caseId}`);
+        }
       } else {
         alert("Failed to send notification");
       }


### PR DESCRIPTION
## Summary
- redirect to newly sent thread after sending report or notification

## Testing
- `npm run lint`
- `npm test` *(fails: Could not locate the bindings file)*

------
https://chatgpt.com/codex/tasks/task_e_684dc4e6533c832b87b51b221050b321