### PR TITLE
Fix action menu closing

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -20,6 +20,7 @@ import CaseToolbar from "../../components/CaseToolbar";
 import EditableText from "../../components/EditableText";
 import ImageHighlights from "../../components/ImageHighlights";
 import MapPreview from "../../components/MapPreview";
+import useCloseOnOutsideClick from "../../useCloseOnOutsideClick";
 import useDragReset from "../useDragReset";
 
 function buildThreads(c: Case): SentEmail[] {
@@ -318,6 +319,8 @@ export default function ClientCasePage({
     ...paperworkPhotos.map((p) => ({ url: p, time: caseData.photoTimes[p] })),
     ...paperworkScans,
   ];
+  const photoMenuRef = useRef<HTMLDetailsElement>(null);
+  useCloseOnOutsideClick(photoMenuRef);
 
   return (
     <div
@@ -413,7 +416,10 @@ export default function ClientCasePage({
                     fill
                     className="object-contain"
                   />
-                  <details className="absolute top-1 right-1 text-white">
+                  <details
+                    ref={photoMenuRef}
+                    className="absolute top-1 right-1 text-white"
+                  >
                     <summary className="cursor-pointer select-none bg-black/40 rounded px-1 opacity-70">
                       ⋮
                     </summary>

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -2,6 +2,8 @@
 import { Progress } from "@/components/ui/progress";
 import type { LlmProgress } from "@/lib/openai";
 import Link from "next/link";
+import { useRef } from "react";
+import useCloseOnOutsideClick from "../useCloseOnOutsideClick";
 
 export default function CaseToolbar({
   caseId,
@@ -40,6 +42,8 @@ export default function CaseToolbar({
     progress?.steps !== undefined && progress.step !== undefined
       ? ((progress.step - 1 + (requestValue ?? 0) / 100) / progress.steps) * 100
       : undefined;
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+  useCloseOnOutsideClick(detailsRef);
   return (
     <div className="bg-gray-100 dark:bg-gray-800 px-8 py-2 flex flex-col gap-2 flex-1">
       {progress ? (
@@ -58,7 +62,7 @@ export default function CaseToolbar({
         </div>
       ) : null}
       <div className="flex justify-end">
-        <details className="relative">
+        <details ref={detailsRef} className="relative">
           <summary className="cursor-pointer select-none bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded">
             Actions
           </summary>

--- a/src/app/components/MultiCaseToolbar.tsx
+++ b/src/app/components/MultiCaseToolbar.tsx
@@ -1,5 +1,7 @@
 "use client";
 import Link from "next/link";
+import { useRef } from "react";
+import useCloseOnOutsideClick from "../useCloseOnOutsideClick";
 
 export default function MultiCaseToolbar({
   caseIds,
@@ -12,9 +14,11 @@ export default function MultiCaseToolbar({
 }) {
   const idsParam = caseIds.join(",");
   const first = caseIds[0];
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+  useCloseOnOutsideClick(detailsRef);
   return (
     <div className="bg-gray-100 dark:bg-gray-800 px-8 py-2 flex justify-end">
-      <details className="relative">
+      <details ref={detailsRef} className="relative">
         <summary className="cursor-pointer select-none bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded">
           Actions
         </summary>

--- a/src/app/useCloseOnOutsideClick.ts
+++ b/src/app/useCloseOnOutsideClick.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import type { RefObject } from "react";
+
+export default function useCloseOnOutsideClick(
+  ref: RefObject<HTMLDetailsElement>,
+) {
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      const el = ref.current;
+      if (el?.open && e.target instanceof Node && !el.contains(e.target)) {
+        el.removeAttribute("open");
+      }
+    }
+    document.addEventListener("click", handleClick);
+    return () => {
+      document.removeEventListener("click", handleClick);
+    };
+  }, [ref]);
+}


### PR DESCRIPTION
## Summary
- add hook to close details menus on outside click
- use the hook in `CaseToolbar`, `MultiCaseToolbar`, and case page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dca6e1b5c832ba47bd87dbee6c3d7