### PR TITLE
Add missing Storybook stories and fix alias

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,11 +1,21 @@
 import type { StorybookConfig } from "@storybook/nextjs";
 
+import path from "node:path";
+
 const config: StorybookConfig = {
   stories: ["../src/**/*.stories.@(ts|tsx)"],
   addons: ["@storybook/addon-essentials", "@storybook/addon-interactions"],
   framework: {
     name: "@storybook/nextjs",
     options: { builder: { useSWC: true } },
+  },
+  webpackFinal: async (config) => {
+    config.resolve = config.resolve ?? { alias: {}, modules: [] };
+    config.resolve.alias = {
+      ...(config.resolve.alias ?? {}),
+      "@": path.resolve(__dirname, "../src"),
+    };
+    return config;
   },
 };
 

--- a/src/app/components/MapPreview.stories.tsx
+++ b/src/app/components/MapPreview.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import MapPreview from "./MapPreview";
+
+const meta: Meta<typeof MapPreview> = {
+  component: MapPreview,
+  title: "Components/MapPreview",
+};
+export default meta;
+
+type Story = StoryObj<typeof MapPreview>;
+
+export const Default: Story = {
+  render: () => (
+    <MapPreview lat={41.88} lon={-87.78} width={400} height={300} />
+  ),
+};

--- a/src/app/components/NavBar.stories.tsx
+++ b/src/app/components/NavBar.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import NavBar from "./NavBar";
+
+const meta: Meta<typeof NavBar> = {
+  component: NavBar,
+  title: "Components/NavBar",
+};
+export default meta;
+
+type Story = StoryObj<typeof NavBar>;
+
+export const Default: Story = {
+  render: () => <NavBar />,
+};


### PR DESCRIPTION
## Summary
- enable `@` path alias in Storybook webpack config
- add `MapPreview` story
- add `NavBar` story

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run build-storybook`

------
https://chatgpt.com/codex/tasks/task_e_684dc9e9b82c832bac93e2fe4f0320fa