### PR TITLE
Hide notify owner menu without contact info

### DIFF
--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -109,12 +109,14 @@ export default function CaseToolbar({
                     Request Ownership Info
                   </Link>
                 )}
-                <Link
-                  href={`/cases/${caseId}/notify-owner`}
-                  className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-                >
-                  Notify Registered Owner
-                </Link>
+                {hasOwner ? (
+                  <Link
+                    href={`/cases/${caseId}/notify-owner`}
+                    className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                  >
+                    Notify Registered Owner
+                  </Link>
+                ) : null}
               </>
             )}
             <button

--- a/src/app/components/MultiCaseToolbar.tsx
+++ b/src/app/components/MultiCaseToolbar.tsx
@@ -53,12 +53,14 @@ export default function MultiCaseToolbar({
                   Request Ownership Info
                 </Link>
               )}
-              <Link
-                href={`/cases/${first}/notify-owner?ids=${idsParam}`}
-                className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-              >
-                Notify Registered Owner
-              </Link>
+              {hasOwner ? (
+                <Link
+                  href={`/cases/${first}/notify-owner?ids=${idsParam}`}
+                  className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                >
+                  Notify Registered Owner
+                </Link>
+              ) : null}
             </>
           )}
           <button


### PR DESCRIPTION
## Summary
- hide the "Notify Registered Owner" menu item when no owner contact exists

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dcfeeae30832bab45b19a954c37d6