### PR TITLE
Disable successful contact methods

### DIFF
--- a/src/app/api/cases/[id]/report/route.ts
+++ b/src/app/api/cases/[id]/report/route.ts
@@ -38,35 +38,38 @@ export async function POST(
   }
   const reportModule = reportModules["oak-park"];
   const to = reportModule.authorityEmail;
+  const results: Record<string, { success: boolean; error?: string }> = {};
   try {
-    await sendEmail({
-      to,
-      subject,
-      body,
-      attachments,
-    });
-    if (snailMail && reportModule.authorityAddress) {
+    await sendEmail({ to, subject, body, attachments });
+    results.email = { success: true };
+  } catch (err) {
+    console.error("Failed to send email", err);
+    results.email = { success: false, error: (err as Error).message };
+  }
+  if (snailMail && reportModule.authorityAddress) {
+    try {
       await sendSnailMail({
         address: reportModule.authorityAddress,
         subject,
         body,
         attachments,
       });
+      results.snailMail = { success: true };
+    } catch (err) {
+      console.error("Failed to send snail mail", err);
+      results.snailMail = { success: false, error: (err as Error).message };
     }
-  } catch (err) {
-    console.error("Failed to send email", err);
-    return NextResponse.json(
-      { error: "Failed to send email" },
-      { status: 500 },
-    );
   }
-  const updated = addCaseEmail(id, {
-    to,
-    subject,
-    body,
-    attachments,
-    sentAt: new Date().toISOString(),
-    replyTo: null,
-  });
-  return NextResponse.json(updated);
+  let updated = c;
+  if (results.email?.success) {
+    updated = addCaseEmail(id, {
+      to,
+      subject,
+      body,
+      attachments,
+      sentAt: new Date().toISOString(),
+      replyTo: null,
+    });
+  }
+  return NextResponse.json({ case: updated, results });
 }

--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -1,7 +1,9 @@
 "use client";
 import type { EmailDraft } from "@/lib/caseReport";
+import type { Case } from "@/lib/caseStore";
 import type { ReportModule } from "@/lib/reportModules";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 export default function DraftEditor({
@@ -25,6 +27,12 @@ export default function DraftEditor({
   const [body, setBody] = useState(initialDraft?.body || "");
   const [sending, setSending] = useState(false);
   const [snailMail, setSnailMail] = useState(false);
+  const [snailMailDisabled, setSnailMailDisabled] = useState(false);
+  const [results, setResults] = useState<
+    Record<string, { status: string; error?: string }>
+  >({});
+  const [threadUrl, setThreadUrl] = useState<string | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     if (initialDraft) {
@@ -35,6 +43,11 @@ export default function DraftEditor({
 
   async function sendEmail() {
     setSending(true);
+    const pending: Record<string, { status: string; error?: string }> = {
+      email: { status: "sending" },
+    };
+    if (snailMail) pending.snailMail = { status: "sending" };
+    setResults(pending);
     try {
       const res = await fetch(`/api/cases/${caseId}/${action}`, {
         method: "POST",
@@ -48,9 +61,40 @@ export default function DraftEditor({
         }),
       });
       if (res.ok) {
-        alert("Email sent");
+        const data = (await res.json()) as {
+          case: Case;
+          results: Record<string, { success: boolean; error?: string }>;
+        };
+        const r: Record<string, { status: string; error?: string }> = {};
+        for (const [k, v] of Object.entries(data.results)) {
+          r[k] = v.success
+            ? { status: "success" }
+            : { status: "error", error: v.error };
+        }
+        setResults(r);
+        if (r.snailMail?.status === "success") {
+          setSnailMail(false);
+          setSnailMailDisabled(true);
+        }
+        const newEmail = data.case.sentEmails?.at(-1);
+        const url = newEmail
+          ? `/cases/${caseId}/thread/${encodeURIComponent(newEmail.sentAt)}`
+          : null;
+        if (Object.values(r).every((x) => x.status === "success")) {
+          if (url) {
+            router.push(url);
+            return;
+          }
+          alert("Notification sent");
+        } else if (r.email && r.email.status === "success") {
+          if (url) setThreadUrl(url);
+          alert("Email sent with some errors");
+        } else {
+          alert("Failed to send notification");
+        }
       } else {
-        alert("Failed to send email");
+        setResults({ email: { status: "error", error: res.statusText } });
+        alert("Failed to send notification");
       }
     } finally {
       setSending(false);
@@ -106,6 +150,7 @@ export default function DraftEditor({
             type="checkbox"
             checked={snailMail}
             onChange={(e) => setSnailMail(e.target.checked)}
+            disabled={snailMailDisabled}
           />
           <span>Send via snail mail to {module.authorityAddress}</span>
         </label>
@@ -118,6 +163,30 @@ export default function DraftEditor({
       >
         {sending ? "Sending..." : "Send"}
       </button>
+      {Object.entries(results).length > 0 && (
+        <ul className="mt-2 text-sm">
+          {Object.entries(results).map(([k, v]) => (
+            <li key={k}>
+              {k}:{" "}
+              {v.status === "sending"
+                ? "Sending"
+                : v.status === "success"
+                  ? "Sent"
+                  : `Failed - ${v.error}`}
+            </li>
+          ))}
+        </ul>
+      )}
+      {threadUrl && (
+        <a
+          href={threadUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-500 underline mt-2 text-sm"
+        >
+          View Thread
+        </a>
+      )}
     </div>
   );
 }

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
@@ -1,6 +1,8 @@
 "use client";
 import type { EmailDraft } from "@/lib/caseReport";
+import type { Case } from "@/lib/caseStore";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 export default function NotifyOwnerEditor({
@@ -25,7 +27,13 @@ export default function NotifyOwnerEditor({
   const [subject, setSubject] = useState(initialDraft?.subject || "");
   const [body, setBody] = useState(initialDraft?.body || "");
   const [sending, setSending] = useState(false);
+  const [results, setResults] = useState<
+    Record<string, { status: string; error?: string }>
+  >({});
   const [methods, setMethods] = useState<string[]>(availableMethods);
+  const [disabledMethods, setDisabledMethods] = useState<string[]>([]);
+  const [threadUrl, setThreadUrl] = useState<string | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     if (initialDraft) {
@@ -36,6 +44,9 @@ export default function NotifyOwnerEditor({
 
   async function sendNotification() {
     setSending(true);
+    setResults(
+      Object.fromEntries(methods.map((m) => [m, { status: "sending" }])),
+    );
     try {
       const res = await fetch(`/api/cases/${caseId}/notify-owner`, {
         method: "POST",
@@ -43,8 +54,49 @@ export default function NotifyOwnerEditor({
         body: JSON.stringify({ subject, body, attachments, methods }),
       });
       if (res.ok) {
-        alert("Notification sent");
+        const data = (await res.json()) as {
+          case: Case;
+          results: Record<string, { success: boolean; error?: string }>;
+        };
+        const r: Record<string, { status: string; error?: string }> = {};
+        for (const [k, v] of Object.entries(data.results)) {
+          r[k] = v.success
+            ? { status: "success" }
+            : { status: "error", error: v.error };
+        }
+        setResults(r);
+        const successes = Object.entries(r)
+          .filter(([, v]) => v.status === "success")
+          .map(([k]) => k);
+        if (successes.length > 0) {
+          setMethods((prev) => prev.filter((m) => !successes.includes(m)));
+          setDisabledMethods((prev) => [
+            ...prev,
+            ...successes.filter((m) => !prev.includes(m)),
+          ]);
+        }
+        const newEmail = data.case.sentEmails?.at(-1);
+        const url = newEmail
+          ? `/cases/${caseId}/thread/${encodeURIComponent(newEmail.sentAt)}`
+          : null;
+        if (Object.values(r).every((x) => x.status === "success")) {
+          if (url) {
+            router.push(url);
+            return;
+          }
+          alert("Notification sent");
+        } else if (r.email && r.email.status === "success") {
+          if (url) setThreadUrl(url);
+          alert("Some notifications failed");
+        } else {
+          alert("Some notifications failed");
+        }
       } else {
+        setResults({
+          ...Object.fromEntries(
+            methods.map((m) => [m, { status: "error", error: res.statusText }]),
+          ),
+        });
         alert("Failed to send notification");
       }
     } finally {
@@ -75,6 +127,7 @@ export default function NotifyOwnerEditor({
                   setMethods(methods.filter((m) => m !== "email"));
                 }
               }}
+              disabled={disabledMethods.includes("email")}
             />
             <span>Email: {contactInfo.email}</span>
           </label>
@@ -92,6 +145,7 @@ export default function NotifyOwnerEditor({
                     setMethods(methods.filter((m) => m !== "sms"));
                   }
                 }}
+                disabled={disabledMethods.includes("sms")}
               />
               <span>SMS: {contactInfo.phone}</span>
             </label>
@@ -106,6 +160,7 @@ export default function NotifyOwnerEditor({
                     setMethods(methods.filter((m) => m !== "whatsapp"));
                   }
                 }}
+                disabled={disabledMethods.includes("whatsapp")}
               />
               <span>WhatsApp: {contactInfo.phone}</span>
             </label>
@@ -120,6 +175,7 @@ export default function NotifyOwnerEditor({
                     setMethods(methods.filter((m) => m !== "robocall"));
                   }
                 }}
+                disabled={disabledMethods.includes("robocall")}
               />
               <span>Robocall: {contactInfo.phone}</span>
             </label>
@@ -137,6 +193,7 @@ export default function NotifyOwnerEditor({
                   setMethods(methods.filter((m) => m !== "snailMail"));
                 }
               }}
+              disabled={disabledMethods.includes("snailMail")}
             />
             <span>Snail Mail: {contactInfo.address}</span>
           </label>
@@ -153,6 +210,7 @@ export default function NotifyOwnerEditor({
                   setMethods(methods.filter((m) => m !== "snailMailLocation"));
                 }
               }}
+              disabled={disabledMethods.includes("snailMailLocation")}
             />
             <span>Mail to address of violation: {violationAddress}</span>
           </label>
@@ -196,6 +254,30 @@ export default function NotifyOwnerEditor({
       >
         {sending ? "Sending..." : "Send Notification"}
       </button>
+      {Object.entries(results).length > 0 && (
+        <ul className="mt-2 text-sm">
+          {Object.entries(results).map(([k, v]) => (
+            <li key={k}>
+              {k}:{" "}
+              {v.status === "sending"
+                ? "Sending"
+                : v.status === "success"
+                  ? "Sent"
+                  : `Failed - ${v.error}`}
+            </li>
+          ))}
+        </ul>
+      )}
+      {threadUrl && (
+        <a
+          href={threadUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-500 underline mt-2 text-sm"
+        >
+          View Thread
+        </a>
+      )}
     </div>
   );
 }

--- a/src/lib/__tests__/contactMethods.test.ts
+++ b/src/lib/__tests__/contactMethods.test.ts
@@ -26,14 +26,12 @@ describe("makeRobocall", () => {
     });
   });
 
-  it("skips when Twilio is not configured", async () => {
+  it("fails when Twilio is not configured", async () => {
     process.env.TWILIO_ACCOUNT_SID = "";
     process.env.TWILIO_AUTH_TOKEN = "";
     process.env.TWILIO_FROM_NUMBER = "";
     callCreateMock.mockClear();
-
-    await makeRobocall("+15557654321", "hello");
-
+    await expect(makeRobocall("+15557654321", "hello")).rejects.toThrow();
     expect(callCreateMock).not.toHaveBeenCalled();
   });
 });
@@ -54,14 +52,12 @@ describe("sendSms", () => {
     });
   });
 
-  it("skips when Twilio is not configured", async () => {
+  it("fails when Twilio is not configured", async () => {
     process.env.TWILIO_ACCOUNT_SID = "";
     process.env.TWILIO_AUTH_TOKEN = "";
     process.env.TWILIO_FROM_NUMBER = "";
     messageCreateMock.mockClear();
-
-    await sendSms("+15557654321", "hello");
-
+    await expect(sendSms("+15557654321", "hello")).rejects.toThrow();
     expect(messageCreateMock).not.toHaveBeenCalled();
   });
 });
@@ -82,14 +78,12 @@ describe("sendWhatsapp", () => {
     });
   });
 
-  it("skips when Twilio is not configured", async () => {
+  it("fails when Twilio is not configured", async () => {
     process.env.TWILIO_ACCOUNT_SID = "";
     process.env.TWILIO_AUTH_TOKEN = "";
     process.env.TWILIO_FROM_NUMBER = "";
     messageCreateMock.mockClear();
-
-    await sendWhatsapp("+15557654321", "hello");
-
+    await expect(sendWhatsapp("+15557654321", "hello")).rejects.toThrow();
     expect(messageCreateMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/contactMethods.ts
+++ b/src/lib/contactMethods.ts
@@ -38,8 +38,7 @@ export async function sendSms(to: string, message: string): Promise<void> {
   const token = process.env.TWILIO_AUTH_TOKEN;
   const from = process.env.TWILIO_FROM_NUMBER;
   if (!sid || !token || !from) {
-    console.warn("Twilio not configured");
-    return;
+    throw new Error("Twilio SMS not configured");
   }
   const client = twilio(sid, token);
   await client.messages.create({
@@ -54,8 +53,7 @@ export async function sendWhatsapp(to: string, message: string): Promise<void> {
   const token = process.env.TWILIO_AUTH_TOKEN;
   const from = process.env.TWILIO_FROM_NUMBER;
   if (!sid || !token || !from) {
-    console.warn("Twilio not configured");
-    return;
+    throw new Error("Twilio WhatsApp not configured");
   }
   const client = twilio(sid, token);
   await client.messages.create({
@@ -70,8 +68,7 @@ export async function makeRobocall(to: string, message: string): Promise<void> {
   const token = process.env.TWILIO_AUTH_TOKEN;
   const from = process.env.TWILIO_FROM_NUMBER;
   if (!sid || !token || !from) {
-    console.warn("Twilio not configured");
-    return;
+    throw new Error("Twilio voice not configured");
   }
   const client = twilio(sid, token);
   await client.calls.create({
@@ -90,8 +87,7 @@ export async function sendSnailMail(options: {
   const provider = process.env.SNAIL_MAIL_PROVIDER || "mock";
   const returnAddr = process.env.RETURN_ADDRESS;
   if (!returnAddr) {
-    console.warn("RETURN_ADDRESS not configured");
-    return;
+    throw new Error("RETURN_ADDRESS not configured");
   }
   const to = parseAddress(options.address);
   const from = parseAddress(returnAddr);


### PR DESCRIPTION
## Summary
- track disabled snail mail option in DraftEditor and turn it off after success
- keep owner notification methods unchecked/disabled after they succeed

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dc5491700832bb7ea65ef7b37db30