### PR TITLE
Fix upload error handling

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -103,7 +103,7 @@ export default function ClientCasesPage({
   });
 
   async function uploadFilesToCase(id: string, files: FileList) {
-    await Promise.all(
+    const results = await Promise.all(
       Array.from(files).map((file) => {
         const formData = new FormData();
         formData.append("photo", file);
@@ -111,6 +111,10 @@ export default function ClientCasesPage({
         return fetch("/api/upload", { method: "POST", body: formData });
       }),
     );
+    if (results.some((r) => !r.ok)) {
+      alert("Failed to upload one or more files.");
+      return;
+    }
   }
 
   return (

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -117,7 +117,7 @@ export default function ClientCasePage({
 
   async function uploadFiles(files: FileList) {
     if (!files || files.length === 0) return;
-    await Promise.all(
+    const results = await Promise.all(
       Array.from(files).map((file) => {
         const formData = new FormData();
         formData.append("photo", file);
@@ -125,6 +125,10 @@ export default function ClientCasePage({
         return fetch("/api/upload", { method: "POST", body: formData });
       }),
     );
+    if (results.some((r) => !r.ok)) {
+      alert("Failed to upload one or more files.");
+      return;
+    }
     const res = await fetch(`/api/cases/${caseId}`);
     if (res.ok) {
       const data = (await res.json()) as Case;

--- a/src/app/useNewCaseFromFiles.ts
+++ b/src/app/useNewCaseFromFiles.ts
@@ -9,7 +9,7 @@ export default function useNewCaseFromFiles() {
     const id = Date.now().toString();
     const preview = URL.createObjectURL(files[0]);
     sessionStorage.setItem(`preview-${id}`, preview);
-    await Promise.all(
+    const results = await Promise.all(
       Array.from(files).map((file, idx) => {
         const formData = new FormData();
         formData.append("photo", file);
@@ -23,6 +23,10 @@ export default function useNewCaseFromFiles() {
         return upload;
       }),
     );
+    if (results.some((r) => !r.ok)) {
+      alert("Failed to upload one or more files.");
+      return;
+    }
     router.push(`/cases/${id}`);
   };
 }


### PR DESCRIPTION
## Summary
- verify each upload succeeds before refreshing data
- alert the user if any upload fails

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd385657c832ba07369fb6bebf680