### PR TITLE
Add fetch error alerts on client case actions

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -84,6 +84,8 @@ export default function ClientCasePage({
       if (res.ok) {
         const data = (await res.json()) as Case;
         setCaseData(data);
+      } else {
+        alert("Failed to load case");
       }
     });
     const es = new EventSource("/api/cases/stream");
@@ -117,18 +119,24 @@ export default function ClientCasePage({
 
   async function uploadFiles(files: FileList) {
     if (!files || files.length === 0) return;
-    await Promise.all(
-      Array.from(files).map((file) => {
-        const formData = new FormData();
-        formData.append("photo", file);
-        formData.append("caseId", caseId);
-        return fetch("/api/upload", { method: "POST", body: formData });
-      }),
-    );
+    for (const file of Array.from(files)) {
+      const formData = new FormData();
+      formData.append("photo", file);
+      formData.append("caseId", caseId);
+      const res = await fetch("/api/upload", {
+        method: "POST",
+        body: formData,
+      });
+      if (!res.ok) {
+        alert("Failed to upload file");
+      }
+    }
     const res = await fetch(`/api/cases/${caseId}`);
     if (res.ok) {
       const data = (await res.json()) as Case;
       setCaseData(data);
+    } else {
+      alert("Failed to refresh case");
     }
     router.refresh();
     if (fileInputRef.current) fileInputRef.current.value = "";
@@ -144,11 +152,13 @@ export default function ClientCasePage({
     if (res.ok) {
       const data = (await res.json()) as Case;
       setCaseData(data);
+    } else {
+      alert("Failed to refresh case");
     }
   }
 
   async function updateVehicle(plateNum: string, plateSt: string) {
-    await fetch(`/api/cases/${caseId}/override`, {
+    const res = await fetch(`/api/cases/${caseId}/override`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -158,6 +168,9 @@ export default function ClientCasePage({
         },
       }),
     });
+    if (!res.ok) {
+      alert("Failed to update vehicle information");
+    }
     await refreshCase();
   }
 
@@ -183,22 +196,33 @@ export default function ClientCasePage({
 
   async function updateVinFn(value: string) {
     setVin(value);
-    await fetch(`/api/cases/${caseId}/vin`, {
+    const res = await fetch(`/api/cases/${caseId}/vin`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ vin: value || null }),
     });
+    if (!res.ok) {
+      alert("Failed to update VIN");
+    }
     await refreshCase();
   }
 
   async function clearVin() {
     setVin("");
-    await fetch(`/api/cases/${caseId}/vin`, { method: "DELETE" });
+    const res = await fetch(`/api/cases/${caseId}/vin`, { method: "DELETE" });
+    if (!res.ok) {
+      alert("Failed to clear VIN");
+    }
     await refreshCase();
   }
 
   async function reanalyzeCase() {
-    await fetch(`/api/cases/${caseId}/reanalyze`, { method: "POST" });
+    const res = await fetch(`/api/cases/${caseId}/reanalyze`, {
+      method: "POST",
+    });
+    if (!res.ok) {
+      alert("Failed to reanalyze case");
+    }
     await refreshCase();
   }
 
@@ -211,22 +235,31 @@ export default function ClientCasePage({
     )}`;
     if (caseData) setCaseData({ ...caseData, analysisStatus: "pending" });
     const res = await fetch(url, { method: "POST" });
-    if (res.ok && detailsEl) {
-      detailsEl.open = false;
+    if (res.ok) {
+      if (detailsEl) {
+        detailsEl.open = false;
+      }
+    } else {
+      alert("Failed to reanalyze photo");
     }
     await refreshCase();
   }
 
   async function removePhoto(photo: string) {
-    await fetch(`/api/cases/${caseId}/photos`, {
+    const resDelete = await fetch(`/api/cases/${caseId}/photos`, {
       method: "DELETE",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ photo }),
     });
+    if (!resDelete.ok) {
+      alert("Failed to remove photo");
+    }
     const res = await fetch(`/api/cases/${caseId}`);
     if (res.ok) {
       const data = (await res.json()) as Case;
       setCaseData(data);
+    } else {
+      alert("Failed to refresh case");
     }
     router.refresh();
   }


### PR DESCRIPTION
## Summary
- show alerts when the initial case load fails
- surface upload errors
- surface vehicle, VIN and re-analysis failures
- warn when photo deletion or refresh fails

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd3b7f188832bbabffb2f18655618