### PR TITLE
Handle report drafting errors

### DIFF
--- a/src/app/cases/[id]/draft/DraftModal.tsx
+++ b/src/app/cases/[id]/draft/DraftModal.tsx
@@ -24,14 +24,22 @@ export default function DraftModal({
   useEffect(() => {
     let canceled = false;
     fetch(`/api/cases/${caseId}/report`)
-      .then((res) => res.json())
+      .then(async (res) => {
+        if (res.ok) {
+          return res.json();
+        }
+        const err = await res.json().catch(() => ({}));
+        alert(err.error || "Failed to draft report");
+        onClose();
+        return null;
+      })
       .then((d) => {
-        if (!canceled) setData(d as DraftData);
+        if (d && !canceled) setData(d as DraftData);
       });
     return () => {
       canceled = true;
     };
-  }, [caseId]);
+  }, [caseId, onClose]);
 
   return (
     <Dialog.Root open onOpenChange={(o) => !o && onClose()}>


### PR DESCRIPTION
## Summary
- improve error handling when drafting a report

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd3999780832b82d0b60e8cce2a68