### PR TITLE
Intercept console logs during tests

### DIFF
--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -33,7 +33,6 @@ export default function DraftEditor({
     Record<string, { status: string; error?: string }>
   >({});
   const [threadUrl, setThreadUrl] = useState<string | null>(null);
-  const router = useRouter();
 
   useEffect(() => {
     if (initialDraft) {

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
@@ -34,7 +34,6 @@ export default function NotifyOwnerEditor({
   const [methods, setMethods] = useState<string[]>(availableMethods);
   const [disabledMethods, setDisabledMethods] = useState<string[]>([]);
   const [threadUrl, setThreadUrl] = useState<string | null>(null);
-  const router = useRouter();
 
   useEffect(() => {
     if (initialDraft) {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,55 @@
 import "@testing-library/jest-dom";
+import { type TestContext, afterEach, beforeEach } from "vitest";
+
+declare module "vitest" {
+  interface TestContext {
+    consoleIntercept?: {
+      logs: unknown[][];
+      warns: unknown[][];
+      errors: unknown[][];
+      originals: {
+        log: typeof console.log;
+        warn: typeof console.warn;
+        error: typeof console.error;
+      };
+    };
+  }
+}
+
+beforeEach((context) => {
+  const originals = {
+    log: console.log,
+    warn: console.warn,
+    error: console.error,
+  };
+  context.consoleIntercept = {
+    logs: [],
+    warns: [],
+    errors: [],
+    originals,
+  };
+  console.log = (...args: unknown[]) => {
+    context.consoleIntercept?.logs.push(args);
+  };
+  console.warn = (...args: unknown[]) => {
+    context.consoleIntercept?.warns.push(args);
+  };
+  console.error = (...args: unknown[]) => {
+    context.consoleIntercept?.errors.push(args);
+  };
+});
+
+afterEach((context) => {
+  const intercept = context.consoleIntercept;
+  if (!intercept) return;
+  const { originals, logs, warns, errors } = intercept;
+  console.log = originals.log;
+  console.warn = originals.warn;
+  console.error = originals.error;
+
+  if (context.task.result?.state === "fail") {
+    for (const args of logs) originals.log(...args);
+    for (const args of warns) originals.warn(...args);
+    for (const args of errors) originals.error(...args);
+  }
+});


### PR DESCRIPTION
## Summary
- add console interception helpers in vitest.setup.ts
- fix duplicated `router` declarations in editor components

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd75f9300832b83efdaa050e5e47e