### PR TITLE
test: stub userMedia and next/image

### DIFF
--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -33,7 +33,6 @@ export default function DraftEditor({
     Record<string, { status: string; error?: string }>
   >({});
   const [threadUrl, setThreadUrl] = useState<string | null>(null);
-  const router = useRouter();
 
   useEffect(() => {
     if (initialDraft) {

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
@@ -34,7 +34,6 @@ export default function NotifyOwnerEditor({
   const [methods, setMethods] = useState<string[]>(availableMethods);
   const [disabledMethods, setDisabledMethods] = useState<string[]>([]);
   const [threadUrl, setThreadUrl] = useState<string | null>(null);
-  const router = useRouter();
 
   useEffect(() => {
     if (initialDraft) {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,31 @@
 import "@testing-library/jest-dom";
+import type { ImgHTMLAttributes } from "react";
+import { createElement } from "react";
+import { afterAll, beforeAll, vi } from "vitest";
+
+let getUserMediaSpy: ReturnType<typeof vi.fn> | undefined;
+
+beforeAll(() => {
+  if (!navigator.mediaDevices) {
+    // @ts-ignore - jsdom may not implement mediaDevices
+    navigator.mediaDevices = {} as MediaDevices;
+  }
+  if (!navigator.mediaDevices.getUserMedia) {
+    // @ts-ignore - jsdom may not implement getUserMedia
+    navigator.mediaDevices.getUserMedia = async () => undefined;
+  }
+  getUserMediaSpy = vi
+    .spyOn(navigator.mediaDevices, "getUserMedia")
+    .mockResolvedValue(undefined);
+
+  vi.mock("next/image", () => ({
+    __esModule: true,
+    default: (props: ImgHTMLAttributes<HTMLImageElement>) =>
+      createElement("img", props),
+  }));
+});
+
+afterAll(() => {
+  getUserMediaSpy?.mockRestore();
+  vi.unmock("next/image");
+});


### PR DESCRIPTION
## Summary
- stub `navigator.mediaDevices.getUserMedia` in Vitest setup
- mock `next/image` with a basic `<img>` implementation
- remove duplicate router declarations to satisfy lint

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd764637c832b9211f2fd36555baf