### PR TITLE
Fix concurrency issue with case reanalysis

### DIFF
--- a/src/app/api/cases/[id]/reanalyze/route.ts
+++ b/src/app/api/cases/[id]/reanalyze/route.ts
@@ -1,4 +1,7 @@
-import { analyzeCaseInBackground } from "@/lib/caseAnalysis";
+import {
+  analyzeCaseInBackground,
+  cancelCaseAnalysis,
+} from "@/lib/caseAnalysis";
 import { getCase, updateCase } from "@/lib/caseStore";
 import { NextResponse } from "next/server";
 
@@ -11,6 +14,7 @@ export async function POST(
   if (!c) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
+  cancelCaseAnalysis(id);
   const updated = updateCase(id, {
     analysisStatus: "pending",
     analysisProgress: { stage: "upload", index: 0, total: c.photos.length },

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -113,6 +113,7 @@ export type ViolationReport = z.infer<typeof violationReportSchema>;
 export async function analyzeViolation(
   images: Array<{ url: string; filename: string }>,
   progress?: (info: LlmProgress) => void,
+  signal?: AbortSignal,
 ): Promise<ViolationReport> {
   if (images.length === 0) {
     throw new AnalysisError("images");
@@ -184,7 +185,9 @@ export async function analyzeViolation(
       response_format: { type: "json_object" },
     };
     if (progress) (req as Record<string, unknown>).stream = true;
-    const response = await client.chat.completions.create(req as never);
+    const response = await client.chat.completions.create(req as never, {
+      signal,
+    });
     let finish: string | null = null;
     let text = "";
     const totalTokens = req.max_tokens ?? 0;
@@ -318,6 +321,7 @@ export async function extractPaperworkInfo(
 export async function ocrPaperwork(
   image: { url: string },
   progress?: (info: LlmProgress) => void,
+  signal?: AbortSignal,
 ): Promise<PaperworkAnalysis> {
   const baseMessages = [
     {
@@ -344,7 +348,9 @@ export async function ocrPaperwork(
       max_tokens: 800,
     };
     if (progress) (req as Record<string, unknown>).stream = true;
-    const res = await client.chat.completions.create(req as never);
+    const res = await client.chat.completions.create(req as never, {
+      signal,
+    });
     let text = "";
     const totalTokens = req.max_tokens ?? 0;
     let receivedTokens = 0;

--- a/test/caseAnalysis.test.ts
+++ b/test/caseAnalysis.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+import { EventEmitter } from "node:events";
+import type { Worker } from "node:worker_threads";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Case } from "../src/lib/caseStore";
+
+const worker = new EventEmitter() as unknown as Worker;
+
+const runJobMock = vi.fn(() => worker);
+vi.mock("../src/lib/jobScheduler", () => ({ runJob: runJobMock }));
+
+describe("analyzeCaseInBackground", () => {
+  beforeEach(() => {
+    runJobMock.mockClear();
+  });
+
+  it("does not start a new worker when analysis is active", async () => {
+    const mod = await import("../src/lib/caseAnalysis");
+    const { analyzeCaseInBackground, isCaseAnalysisActive } = mod;
+    const c: Case = {
+      id: "1",
+      photos: ["/a.jpg"],
+      photoTimes: { "/a.jpg": null },
+      photoGps: {},
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      gps: null,
+      streetAddress: null,
+      intersection: null,
+      vin: null,
+      vinOverride: null,
+      analysis: null,
+      analysisOverrides: null,
+      analysisStatus: "pending",
+      analysisStatusCode: null,
+      analysisError: null,
+      analysisProgress: null,
+      sentEmails: [],
+      ownershipRequests: [],
+      threadImages: [],
+    };
+    analyzeCaseInBackground(c);
+    expect(runJobMock).toHaveBeenCalledTimes(1);
+    expect(isCaseAnalysisActive(c.id)).toBe(true);
+
+    analyzeCaseInBackground(c);
+    expect(runJobMock).toHaveBeenCalledTimes(1);
+
+    worker.emit("exit");
+    expect(isCaseAnalysisActive(c.id)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- cancel active workers when reanalysis is requested
- allow image reanalysis to interrupt any current job
- support abort signals in OpenAI helpers
- track and cancel photo-level analyses
- fix test setup for worker mock

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dd20826b0832b8c950820d11992f0