### PR TITLE
Fix follow-up and draft modal error handling

### DIFF
--- a/src/app/cases/[id]/draft/DraftModal.tsx
+++ b/src/app/cases/[id]/draft/DraftModal.tsx
@@ -24,14 +24,21 @@ export default function DraftModal({
   useEffect(() => {
     let canceled = false;
     fetch(`/api/cases/${caseId}/report`)
-      .then((res) => res.json())
+      .then(async (res) => {
+        if (res.ok) {
+          return res.json();
+        }
+        alert("Failed to draft report");
+        onClose();
+        return null;
+      })
       .then((d) => {
-        if (!canceled) setData(d as DraftData);
+        if (d && !canceled) setData(d as DraftData);
       });
     return () => {
       canceled = true;
     };
-  }, [caseId]);
+  }, [caseId, onClose]);
 
   return (
     <Dialog.Root open onOpenChange={(o) => !o && onClose()}>

--- a/src/app/cases/[id]/followup/FollowUpModal.tsx
+++ b/src/app/cases/[id]/followup/FollowUpModal.tsx
@@ -27,14 +27,21 @@ export default function FollowUpModal({
     let canceled = false;
     const url = `/api/cases/${caseId}/followup${replyTo ? `?replyTo=${encodeURIComponent(replyTo)}` : ""}`;
     fetch(url)
-      .then((res) => res.json())
+      .then(async (res) => {
+        if (res.ok) {
+          return res.json();
+        }
+        alert("Failed to draft follow-up");
+        onClose();
+        return null;
+      })
       .then((d) => {
-        if (!canceled) setData(d as DraftData);
+        if (d && !canceled) setData(d as DraftData);
       });
     return () => {
       canceled = true;
     };
-  }, [caseId, replyTo]);
+  }, [caseId, replyTo, onClose]);
 
   return (
     <Dialog.Root open onOpenChange={(o) => !o && onClose()}>


### PR DESCRIPTION
## Summary
- handle fetch failures in DraftModal
- handle fetch failures in FollowUpModal

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd3a38260832ba1580b44de5b495a