### PR TITLE
Handle snail mail shortfall errors

### DIFF
--- a/src/lib/contactMethods.ts
+++ b/src/lib/contactMethods.ts
@@ -155,10 +155,18 @@ export async function sendSnailMail(options: {
     });
   }
   fs.writeFileSync(filePath, await pdf.save());
-  await providerSendSnailMail(provider, {
+  const result = await providerSendSnailMail(provider, {
     to,
     from,
     subject: options.subject,
     contents: filePath,
   });
+  if (result.status === "shortfall") {
+    throw new Error(
+      `Unable to send mail: provider shortfall of ${result.shortfall}`,
+    );
+  }
+  if (result.status !== "queued" && result.status !== "saved") {
+    throw new Error(`Unable to send mail: provider error ${result.status}`);
+  }
 }

--- a/src/lib/docsmitProvider.ts
+++ b/src/lib/docsmitProvider.ts
@@ -161,13 +161,19 @@ const provider: SnailMailProvider = {
       },
     );
     let shortfall: number | undefined;
-    if (res.status === 402) {
+    let statusText: string;
+    if (res.status === 201) {
+      statusText = "queued";
+    } else if (res.status === 402) {
       shortfall = (await res.json()).shortfall as number | undefined;
       console.log("Docsmit payment required", { shortfall });
+      statusText = "shortfall";
+    } else {
+      statusText = "error";
     }
     const status: SnailMailStatus = {
       id: messageID,
-      status: res.status === 201 ? "queued" : "error",
+      status: statusText,
       shortfall,
     };
     addSentMail({


### PR DESCRIPTION
## Summary
- allow snail mail provider to indicate payment shortfall via a new status
- bubble provider errors in contact method to surface failures

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd3d50208832bb96540efc8928b49