### PR TITLE
Fix aborted OCR request

### DIFF
--- a/src/app/api/cases/[id]/reanalyze-photo/route.ts
+++ b/src/app/api/cases/[id]/reanalyze-photo/route.ts
@@ -56,14 +56,14 @@ export async function POST(
       undefined,
       ctrl.signal,
     );
+    const info = result.images?.[path.basename(photo)];
+    if (info?.paperwork && !info.paperworkText) {
+      const ocr = await ocrPaperwork({ url: dataUrl }, undefined, ctrl.signal);
+      info.paperworkText = ocr.text;
+      if (ocr.info) info.paperworkInfo = ocr.info;
+    }
   } finally {
     cancelPhotoAnalysis(id, photo);
-  }
-  const info = result.images?.[path.basename(photo)];
-  if (info?.paperwork && !info.paperworkText) {
-    const ocr = await ocrPaperwork({ url: dataUrl }, undefined, ctrl.signal);
-    info.paperworkText = ocr.text;
-    if (ocr.info) info.paperworkInfo = ocr.info;
   }
   const baseAnalysis = c.analysis ?? { vehicle: {}, images: {} };
   const newAnalysis = {


### PR DESCRIPTION
## Summary
- fix `reanalyze-photo` API to not abort OCR request prematurely

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684de5db1868832bad04341b6a59aed4