### PR TITLE
fix CI storybook screenshot timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,13 @@ jobs:
       - run: npm run lint
       - run: npm test
       - run: npm run e2e
-      - run: npm run storybook:screenshot
+      - run: |
+          npm run build-storybook
+          npx storycap http://localhost:6006 \
+            --serverCmd "http-server storybook-static -p 6006" \
+            --serverTimeout 120000 \
+            --captureTimeout 60000 \
+            --out storybook-screenshots
       - uses: actions/upload-artifact@v4
         with:
           name: storybook-screenshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,7 @@ jobs:
       - run: npm run lint
       - run: npm test
       - run: npm run e2e
-      - run: |
-          npm run build-storybook
-          npx storycap http://localhost:6006 \
-            --serverCmd "http-server storybook-static -p 6006" \
-            --serverTimeout 120000 \
-            --captureTimeout 60000 \
-            --out storybook-screenshots
+      - run: npm run storybook:screenshot:ci
       - uses: actions/upload-artifact@v4
         with:
           name: storybook-screenshots

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "storybook:screenshot": "npm run build-storybook && storycap http://localhost:6006 --serverCmd \"http-server storybook-static -p 6006\" --out storybook-screenshots",
+    "storybook:screenshot:ci": "npm run build-storybook && storycap http://localhost:6006 --serverCmd \"http-server storybook-static -p 6006\" --serverTimeout 120000 --captureTimeout 60000 --out storybook-screenshots",
     "generate:schemas": "ts-to-zod --skipValidation --all",
     "generate:migrations": "drizzle-kit generate:sqlite",
     "website": "eleventy"


### PR DESCRIPTION
## Summary
- bump Storybook screenshot timeout in CI workflow so storycap waits longer

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: Test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_684de1555720832ba270b08b6659aaf5