### PR TITLE
Fix info scope in reanalysis and handle navigator in tests

### DIFF
--- a/src/app/api/cases/[id]/reanalyze-photo/route.ts
+++ b/src/app/api/cases/[id]/reanalyze-photo/route.ts
@@ -50,13 +50,14 @@ export async function POST(
         : "image/jpeg";
   const dataUrl = `data:${mime};base64,${buffer.toString("base64")}`;
   let result: ViolationReport;
+  let info: ViolationReport["images"][string] | undefined;
   try {
     result = await analyzeViolation(
       [{ filename: path.basename(photo), url: dataUrl }],
       undefined,
       ctrl.signal,
     );
-    const info = result.images?.[path.basename(photo)];
+    info = result.images?.[path.basename(photo)];
     if (info?.paperwork && !info.paperworkText) {
       const ocr = await ocrPaperwork({ url: dataUrl }, undefined, ctrl.signal);
       info.paperworkText = ocr.text;

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -48,13 +48,15 @@ beforeEach((context) => {
     context.consoleIntercept?.errors.push(args);
   };
 
-  originalGetUserMedia = navigator.mediaDevices?.getUserMedia;
-  if (!navigator.mediaDevices) {
-    (
-      navigator as unknown as { mediaDevices: Record<string, unknown> }
-    ).mediaDevices = {};
+  if (typeof navigator !== "undefined") {
+    originalGetUserMedia = navigator.mediaDevices?.getUserMedia;
+    if (!navigator.mediaDevices) {
+      (
+        navigator as unknown as { mediaDevices: Record<string, unknown> }
+      ).mediaDevices = {} as MediaDevices;
+    }
+    navigator.mediaDevices.getUserMedia = vi.fn(async () => undefined);
   }
-  navigator.mediaDevices.getUserMedia = vi.fn(async () => undefined);
 });
 
 afterEach((context) => {
@@ -65,11 +67,13 @@ afterEach((context) => {
   console.warn = originals.warn;
   console.error = originals.error;
 
-  if (originalGetUserMedia) {
-    navigator.mediaDevices.getUserMedia = originalGetUserMedia;
-  } else {
-    (navigator.mediaDevices as Record<string, unknown>).getUserMedia =
-      undefined;
+  if (typeof navigator !== "undefined") {
+    if (originalGetUserMedia) {
+      navigator.mediaDevices.getUserMedia = originalGetUserMedia;
+    } else if (navigator.mediaDevices) {
+      (navigator.mediaDevices as Record<string, unknown>).getUserMedia =
+        undefined;
+    }
   }
 
   if (context.task.result?.state === "fail") {


### PR DESCRIPTION
## Summary
- fix ReferenceError by declaring `info` outside of `try` block in reanalyze-photo API
- guard navigator access in vitest setup to support node environment tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684de79fb36c832b988140ba5adc550e