### PR TITLE
Fix navigator access in Vitest setup

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -48,13 +48,15 @@ beforeEach((context) => {
     context.consoleIntercept?.errors.push(args);
   };
 
-  originalGetUserMedia = navigator.mediaDevices?.getUserMedia;
-  if (!navigator.mediaDevices) {
-    (
-      navigator as unknown as { mediaDevices: Record<string, unknown> }
-    ).mediaDevices = {};
+  if (typeof navigator !== "undefined") {
+    originalGetUserMedia = navigator.mediaDevices?.getUserMedia;
+    if (!navigator.mediaDevices) {
+      (
+        navigator as unknown as { mediaDevices: Record<string, unknown> }
+      ).mediaDevices = {};
+    }
+    navigator.mediaDevices.getUserMedia = vi.fn(async () => undefined);
   }
-  navigator.mediaDevices.getUserMedia = vi.fn(async () => undefined);
 });
 
 afterEach((context) => {
@@ -65,11 +67,13 @@ afterEach((context) => {
   console.warn = originals.warn;
   console.error = originals.error;
 
-  if (originalGetUserMedia) {
-    navigator.mediaDevices.getUserMedia = originalGetUserMedia;
-  } else {
-    (navigator.mediaDevices as Record<string, unknown>).getUserMedia =
-      undefined;
+  if (typeof navigator !== "undefined") {
+    if (originalGetUserMedia) {
+      navigator.mediaDevices.getUserMedia = originalGetUserMedia;
+    } else if (navigator.mediaDevices) {
+      (navigator.mediaDevices as Record<string, unknown>).getUserMedia =
+        undefined;
+    }
   }
 
   if (context.task.result?.state === "fail") {


### PR DESCRIPTION
## Summary
- prevent reference errors when `navigator` is undefined

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684de8a522d4832b80944f402fd32a2d