### PR TITLE
Update CI to deploy storybook to Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main]
+    branches-ignore:
+      - gh-pages
 
 jobs:
   build:
@@ -18,8 +19,10 @@ jobs:
       - run: npm run lint
       - run: npm test
       - run: npm run e2e
-      - run: npm run storybook:screenshot
-      - uses: actions/upload-artifact@v4
+      - run: npm run build-storybook
+      - name: Deploy Storybook to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          name: storybook-screenshots
-          path: storybook-screenshots
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./storybook-static
+          destination_dir: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Summary
- replace screenshot uploads with building Storybook and deploying to GitHub Pages
- publish each branch's Storybook to its own folder on the `gh-pages` branch

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e`
- `npm run build-storybook`


------
https://chatgpt.com/codex/tasks/task_e_684deee9ec04832b988919567750bc72