### PR TITLE
Fix Storybook deploy permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -21,8 +23,9 @@ jobs:
       - run: npm run e2e
       - run: npm run build-storybook
       - name: Deploy Storybook to GitHub Pages
+        if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./storybook-static
-          destination_dir: ${{ github.head_ref || github.ref_name }}
+          publish_branch: gh-pages


### PR DESCRIPTION
## Summary
- configure workflow permissions to write to gh-pages
- restrict deploy step to pushes on `main`
- specify `publish_branch` when deploying Storybook

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_684df463cce0832b92d7ff31e1edd21e