### PR TITLE
Handle missing photos during reanalysis

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -330,7 +330,7 @@ export default function ClientCasePage({
         : caseData.analysisError === "parse"
           ? "Analysis failed due to invalid JSON from the AI. Please try again."
           : caseData.analysisError === "images"
-            ? "Analysis failed because no images were provided."
+            ? "Analysis failed because no images were provided or some photo files were missing."
             : "Analysis failed because the AI response did not match the expected format. Please retry."}
     </p>
   ) : caseData.analysisStatusCode && caseData.analysisStatusCode >= 400 ? (


### PR DESCRIPTION
## Summary
- gracefully abort analysis if any photo files are missing
- surface a clearer message when no or missing images cause failure

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684df6229f18832bb699fd226ba8fe90