### PR TITLE
Fix storybook stories and ignore build output

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": [".next"]
+    "ignore": [".next", "storybook-static"]
   },
   "formatter": {
     "enabled": true,

--- a/src/app/cases/ClientCasesPage.stories.tsx
+++ b/src/app/cases/ClientCasesPage.stories.tsx
@@ -10,6 +10,14 @@ export default meta;
 
 type Story = StoryObj<typeof ClientCasesPage>;
 
+function stubEventSource() {
+  (globalThis as unknown as { EventSource: typeof EventSource }).EventSource =
+    class {
+      onmessage: ((ev: MessageEvent) => void) | null = null;
+      close() {}
+    };
+}
+
 const caseBase: Omit<Case, "id"> = {
   photos: ["https://placehold.co/600x400?text=photo"],
   photoTimes: {},
@@ -30,6 +38,7 @@ const caseBase: Omit<Case, "id"> = {
 
 export const MultipleCases: Story = {
   render: () => {
+    stubEventSource();
     const cases: Case[] = [
       {
         id: "1",
@@ -58,6 +67,7 @@ export const MultipleCases: Story = {
 
 export const SelectedCase: Story = {
   render: () => {
+    stubEventSource();
     const cases: Case[] = [
       { id: "1", ...caseBase },
       { id: "2", ...caseBase },

--- a/src/app/cases/[id]/ClientCasePage.stories.tsx
+++ b/src/app/cases/[id]/ClientCasePage.stories.tsx
@@ -10,6 +10,17 @@ export default meta;
 
 type Story = StoryObj<typeof ClientCasePage>;
 
+function setupMocks(data: Case) {
+  (
+    globalThis as unknown as { fetch: (input: string) => Promise<Response> }
+  ).fetch = async () => new Response(JSON.stringify(data));
+  (globalThis as unknown as { EventSource: typeof EventSource }).EventSource =
+    class {
+      onmessage: ((ev: MessageEvent) => void) | null = null;
+      close() {}
+    };
+}
+
 const base: Case = {
   id: "123",
   photos: [
@@ -42,19 +53,21 @@ const base: Case = {
 };
 
 export const Completed: Story = {
-  render: () => <ClientCasePage caseId={base.id} initialCase={base} />,
+  render: () => {
+    setupMocks(base);
+    return <ClientCasePage caseId={base.id} initialCase={base} />;
+  },
 };
 
 export const PendingAnalysis: Story = {
-  render: () => (
-    <ClientCasePage
-      caseId="124"
-      initialCase={{
-        ...base,
-        id: "124",
-        analysis: null,
-        analysisStatus: "pending",
-      }}
-    />
-  ),
+  render: () => {
+    const data: Case = {
+      ...base,
+      id: "124",
+      analysis: null,
+      analysisStatus: "pending",
+    };
+    setupMocks(data);
+    return <ClientCasePage caseId="124" initialCase={data} />;
+  },
 };

--- a/src/app/cases/[id]/ComposeWrapper.stories.tsx
+++ b/src/app/cases/[id]/ComposeWrapper.stories.tsx
@@ -11,6 +11,14 @@ export default meta;
 
 type Story = StoryObj<typeof ComposeWrapper>;
 
+function stubEventSource() {
+  (globalThis as unknown as { EventSource: typeof EventSource }).EventSource =
+    class {
+      onmessage: ((ev: MessageEvent) => void) | null = null;
+      close() {}
+    };
+}
+
 const base: Case = {
   id: "123",
   photos: [
@@ -60,6 +68,7 @@ function mockFetch() {
 export const Default: Story = {
   render: () => {
     mockFetch();
+    stubEventSource();
     return <ComposeWrapper caseData={base} caseId={base.id} />;
   },
 };

--- a/src/app/cases/[id]/draft/DraftModal.stories.tsx
+++ b/src/app/cases/[id]/draft/DraftModal.stories.tsx
@@ -11,6 +11,14 @@ export default meta;
 
 type Story = StoryObj<typeof DraftModal>;
 
+function stubEventSource() {
+  (globalThis as unknown as { EventSource: typeof EventSource }).EventSource =
+    class {
+      onmessage: ((ev: MessageEvent) => void) | null = null;
+      close() {}
+    };
+}
+
 const base: Case = {
   id: "123",
   photos: [
@@ -60,6 +68,7 @@ function mockFetch() {
 export const Default: Story = {
   render: () => {
     mockFetch();
+    stubEventSource();
     return <DraftModal caseId={base.id} onClose={() => {}} />;
   },
 };


### PR DESCRIPTION
## Summary
- stub out EventSource in stories to stop runtime errors
- mock fetch calls and add setup helpers
- ignore `storybook-static` in Biome config

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_684df8d9f070832b91ac8fa4a0c697b0