### PR TITLE
Add GitHub Actions deployment for marketing site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,10 @@ jobs:
       - run: npm run e2e
       - run: npm run build-storybook
       - name: Deploy Storybook to GitHub Pages
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./storybook-static
           publish_branch: gh-pages
+          destination_dir: storybook

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,25 @@
+name: Deploy Marketing Website
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run website
+      - name: Deploy Website to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./website/dist
+          destination_dir: website


### PR DESCRIPTION
## Summary
- build the Eleventy marketing site on pushes to `main`
- deploy the marketing site to `gh-pages/website`
- deploy the Storybook preview to `gh-pages/storybook` only for push events to `main`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684df6b7ec28832bb38816a5e0c559f2