### PR TITLE
Implement Illinois ownership requests

### DIFF
--- a/src/lib/__tests__/ownershipModules.test.ts
+++ b/src/lib/__tests__/ownershipModules.test.ts
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { ownershipModules } from "../ownershipModules";
+import * as snailMail from "../snailMail";
+
+describe("ownershipModules.il.requestVin", () => {
+  it("generates a PDF and mails it", async () => {
+    process.env.RETURN_ADDRESS = "1 A St\nCity, IL 12345";
+    process.env.SNAIL_MAIL_PROVIDER = "mock";
+    const sendMock = vi
+      .spyOn(snailMail, "sendSnailMail")
+      .mockResolvedValue({ id: "1", status: "saved" });
+
+    await ownershipModules.il.requestVin({
+      plate: "ABC123",
+      state: "IL",
+      vin: "1HGCM82633A004352",
+    });
+
+    expect(sendMock).toHaveBeenCalled();
+    const opts = sendMock.mock.calls[0][1];
+    expect(fs.existsSync(opts.contents)).toBe(true);
+  });
+});

--- a/src/lib/ownershipModules.ts
+++ b/src/lib/ownershipModules.ts
@@ -1,9 +1,97 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { PDFDocument } from "pdf-lib";
+import type { MailingAddress } from "./snailMail";
+import { sendSnailMail as providerSendSnailMail } from "./snailMail";
+
+export interface OwnershipRequestInfo {
+  plate: string;
+  state: string;
+  vin?: string | null;
+  ownerName?: string | null;
+  address1?: string | null;
+  address2?: string | null;
+  city?: string | null;
+  postalCode?: string | null;
+}
+
 export interface OwnershipModule {
   id: string;
   state: string;
   address: string;
   fee: number;
   requiresCheck: boolean;
+  requestVin?: (info: OwnershipRequestInfo) => Promise<void>;
+  requestContactInfo?: (info: OwnershipRequestInfo) => Promise<void>;
+}
+
+function parseAddress(text: string): MailingAddress {
+  const lines = text.trim().split(/\n+/);
+  let name: string | undefined;
+  if (lines.length > 3) name = lines.shift();
+  const address1 = lines.shift() || "";
+  const possibleCity = lines.pop() || "";
+  const address2 = lines.length > 0 ? lines.shift() : undefined;
+  const m = possibleCity.match(/^(.*),\s*([A-Z]{2})\s+(\d{5}(?:-\d{4})?)/);
+  const city = m ? m[1] : "";
+  const state = m ? m[2] : "";
+  const postalCode = m ? m[3] : "";
+  return { name, address1, address2, city, state, postalCode };
+}
+
+async function mailPdf(address: string, pdfPath: string): Promise<void> {
+  const provider = process.env.SNAIL_MAIL_PROVIDER || "mock";
+  const returnAddr = process.env.RETURN_ADDRESS;
+  if (!returnAddr) throw new Error("RETURN_ADDRESS not configured");
+  const to = parseAddress(address);
+  const from = parseAddress(returnAddr);
+  const result = await providerSendSnailMail(provider, {
+    to,
+    from,
+    contents: pdfPath,
+  });
+  if (result.status === "shortfall") {
+    throw new Error(
+      `Unable to send mail: provider shortfall of ${result.shortfall}`,
+    );
+  }
+  if (result.status !== "queued" && result.status !== "saved") {
+    throw new Error(`Unable to send mail: provider error ${result.status}`);
+  }
+}
+
+export async function fillIlForm(info: OwnershipRequestInfo): Promise<string> {
+  const formPath = path.join(
+    __dirname,
+    "..",
+    "..",
+    "public",
+    "forms",
+    "il",
+    "vsd375.pdf",
+  );
+  const bytes = fs.readFileSync(formPath);
+  const pdf = await PDFDocument.load(new Uint8Array(bytes));
+  const form = pdf.getForm();
+  const set = (name: string, value: string | undefined) => {
+    try {
+      form.getTextField(name).setText(value ?? "");
+    } catch {}
+  };
+  set("1", info.plate);
+  set("2", info.state);
+  set("3", info.vin ?? "");
+  set("4", info.ownerName ?? "");
+  set("5", info.address1 ?? "");
+  set("6", info.address2 ?? "");
+  set("7", info.city ?? "");
+  set("8", info.postalCode ?? "");
+  const outDir = path.join(process.cwd(), "data", "ownership_tmp");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, `${crypto.randomUUID()}.pdf`);
+  fs.writeFileSync(outPath, await pdf.save());
+  return outPath;
 }
 
 export const ownershipModules: Record<string, OwnershipModule> = {
@@ -14,6 +102,14 @@ export const ownershipModules: Record<string, OwnershipModule> = {
       "Driver Records Unit\n2701 S. Dirksen Pkwy.\nSpringfield, IL 62723",
     fee: 12,
     requiresCheck: true,
+    async requestVin(info) {
+      const pdfPath = await fillIlForm(info);
+      await mailPdf(this.address, pdfPath);
+    },
+    async requestContactInfo(info) {
+      const pdfPath = await fillIlForm(info);
+      await mailPdf(this.address, pdfPath);
+    },
   },
   ca: {
     id: "ca",


### PR DESCRIPTION
## Summary
- restore `vsd375.pdf` Illinois ownership form
- create helper to fill Illinois ownership request PDF
- implement Illinois ownership module with PDF mailing
- test that the VIN request mails a filled PDF

## Testing
- `npm run format`
- `npm run lint`
- `mkdir -p public/forms/il && cp /tmp/vsd375.pdf public/forms/il/vsd375.pdf && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df54a5790832bad22e1647bfb2b1e