### PR TITLE
fix: preserve forms during tests

### DIFF
--- a/test/snailMailAttachments.test.ts
+++ b/test/snailMailAttachments.test.ts
@@ -74,7 +74,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(path.join(root, "public"), { recursive: true, force: true });
+  fs.rmSync(path.join(root, "public", "uploads"), {
+    recursive: true,
+    force: true,
+  });
   fs.rmSync(tmpDir, { recursive: true, force: true });
   process.env.RETURN_ADDRESS = undefined;
   process.env.SNAIL_MAIL_PROVIDER = undefined;


### PR DESCRIPTION
## Summary
- avoid deleting the entire `public` folder in `snailMailAttachments` tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dff5f8a10832b9372e5fd3e4b3c93