### PR TITLE
Fix GitHub Pages publish permission

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- fix website workflow so Pages deploy succeeds

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_684e029b8e04832b9aafb99b85a8dda0