### PR TITLE
Fix GitHub Pages base paths

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,7 @@
 module.exports = (eleventyConfig) => {
   eleventyConfig.addPassthroughCopy("website/style.css");
   return {
+    pathPrefix: process.env.PATH_PREFIX || "/",
     dir: {
       input: "website",
       output: "website/dist",

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -18,6 +18,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run website
+        env:
+          PATH_PREFIX: /photo-to-citation/website/
       - name: Deploy Website to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/website/_includes/layout.njk
+++ b/website/_includes/layout.njk
@@ -3,14 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <title>{{ title }}</title>
-    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="{{ '/style.css' | url }}" />
   </head>
   <body>
     <header>
       <nav>
-        <a href="/">Home</a>
-        <a href="/features/">Features</a>
-        <a href="/about/">About</a>
+        <a href="{{ '/' | url }}">Home</a>
+        <a href="{{ '/features/' | url }}">Features</a>
+        <a href="{{ '/about/' | url }}">About</a>
       </nav>
     </header>
     <main>


### PR DESCRIPTION
## Summary
- support a custom `PATH_PREFIX` when building the marketing site
- generate links with Eleventy's `url` filter
- deploy the site with the path prefix set in the workflow

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `PATH_PREFIX=/photo-to-citation/website/ npm run website`

------
https://chatgpt.com/codex/tasks/task_e_684e0711aafc832b902a8e25a88a2f0d