### PR TITLE
Fix Storybook router context

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,10 +1,6 @@
 import type { StorybookConfig } from "@storybook/nextjs";
 
-import path, { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import path from "node:path";
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.stories.@(ts|tsx)"],
@@ -17,7 +13,7 @@ const config: StorybookConfig = {
     config.resolve = config.resolve ?? { alias: {}, modules: [] };
     config.resolve.alias = {
       ...(config.resolve.alias ?? {}),
-      "@": path.resolve(__dirname, "../src"),
+      "@": path.resolve(process.cwd(), "src"),
     };
     return config;
   },

--- a/.storybook/routerDecorator.tsx
+++ b/.storybook/routerDecorator.tsx
@@ -1,3 +1,4 @@
+"use client";
 import type { Decorator } from "@storybook/react";
 import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import {


### PR DESCRIPTION
## Summary
- mark Storybook router decorator as a client component so `useSearchParams` works in stories

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`
- `npm run build-storybook`


------
https://chatgpt.com/codex/tasks/task_e_684e02084fd8832ba515156e53c1c5e2