### PR TITLE
Add error state stories

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.stories.tsx
+++ b/src/app/cases/[id]/ClientCasePage.stories.tsx
@@ -58,3 +58,34 @@ export const PendingAnalysis: Story = {
     />
   ),
 };
+
+export const FailedAnalysis: Story = {
+  render: () => (
+    <ClientCasePage
+      caseId="125"
+      initialCase={{
+        ...base,
+        id: "125",
+        analysis: null,
+        analysisStatus: "failed",
+        analysisStatusCode: 500,
+      }}
+    />
+  ),
+};
+
+export const TruncatedError: Story = {
+  render: () => (
+    <ClientCasePage
+      caseId="126"
+      initialCase={{
+        ...base,
+        id: "126",
+        analysis: null,
+        analysisStatus: "failed",
+        analysisStatusCode: 400,
+        analysisError: "truncated",
+      }}
+    />
+  ),
+};


### PR DESCRIPTION
## Summary
- extend `ClientCasePage` stories with failed analysis states

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e13414720832b991d31778a512c68