### PR TITLE
Improve unsupported ownership state message

### DIFF
--- a/src/app/cases/[id]/ownership/page.tsx
+++ b/src/app/cases/[id]/ownership/page.tsx
@@ -12,6 +12,18 @@ export default async function OwnershipPage({
   if (!c) return <div className="p-8">Case not found</div>;
   const state = c.analysis?.vehicle?.licensePlateState?.toLowerCase();
   const mod = state ? ownershipModules[state] : undefined;
-  if (!mod) return <div className="p-8">No module for this state</div>;
+  if (!mod) {
+    const supported = Object.keys(ownershipModules)
+      .map((s) => s.toUpperCase())
+      .join(", ");
+    const label = state ? state.toUpperCase() : "unknown";
+    return (
+      <div className="p-8">
+        No ownership module for state <strong>{label}</strong>. Supported
+        states: {supported}. Please ensure the license plate state uses a
+        two-letter abbreviation.
+      </div>
+    );
+  }
   return <OwnershipEditor caseId={id} module={mod} />;
 }


### PR DESCRIPTION
## Summary
- clarify unsupported state message when requesting ownership info

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e096d3e30832b9a6d626b2e361165