### PR TITLE
Add case analysis refactor plan

### DIFF
--- a/docs/case-analysis-plan.md
+++ b/docs/case-analysis-plan.md
@@ -1,0 +1,62 @@
+# Case Analysis Refactoring Plan
+
+This document proposes improvements to the current case image analysis pipeline.
+The goal is to keep all existing features while making the system easier to debug
+and inspect, with progressive feedback and better concurrency control.
+
+## Current Pipeline Overview
+- The `analyzeCase` function reads case images, runs them through `analyzeViolation`,
+  optionally performs OCR, then updates the case record. Progress is stored in the
+  case via `analysisProgress`.
+- `analyzeCaseInBackground` spawns a worker thread for each case using
+  `runJob` and tracks active workers.
+- SSE events from `caseEvents` notify clients when case data changes.
+
+## Pain Points
+- Worker management is manual and difficult to monitor.
+- Progress updates are tied to raw case mutations, which makes debugging tricky.
+- Adding or removing photos can race with ongoing analysis jobs.
+- Reanalyzing a single image requires canceling the entire case worker.
+
+## Proposed Architecture
+1. **Dedicated Job Queue**
+   - Introduce a lightweight job queue where each analysis or OCR task is a job.
+   - Jobs run in worker threads but are scheduled and logged centrally.
+   - Queueing avoids multiple workers per case and makes job order explicit.
+
+2. **State Machine per Case**
+   - Track case state (pending, analyzing, complete, failed, canceled) with a
+     deterministic state machine. Transitions happen only through the job queue.
+   - Each image gets its own state so reanalysis or deletion affects only that
+     item.
+
+3. **Structured Progress Events**
+   - Emit structured events such as `{caseId, photo, step, total, message}`.
+   - SSE clients consume these events for coherent progressive feedback.
+   - Logging the same events makes debugging and replaying issues easier.
+
+4. **Atomic Photo Operations**
+   - Adding or removing a photo enqueues an analysis job for just that image
+     and updates the case state. Existing jobs continue without conflict.
+   - Deleting an image aborts its queued job if it has not started yet.
+
+5. **Reusable Analysis Steps**
+   - Wrap `analyzeViolation` and `ocrPaperwork` into standalone steps that share
+     a common interface. Steps can be composed for full case analysis or for a
+     single photo.
+   - This allows reanalysis of individual photos without restarting the entire
+     workflow.
+
+6. **Improved Logging and Inspection**
+   - Persist job start/end times and outcomes in the database.
+   - Provide an API to list active and recent jobs for inspection.
+
+## Benefits
+- Users can create cases, add or remove photos, and reanalyze single images
+  without blocking other work.
+- Progressive events keep the UI informed of each step of processing.
+- Centralized job management prevents race conditions and makes failures easier
+  to debug.
+- The system retains all existing functionality while being faster and more
+  maintainable.
+

--- a/src/app/api/cases/[id]/photos/route.ts
+++ b/src/app/api/cases/[id]/photos/route.ts
@@ -1,4 +1,7 @@
-import { analyzeCaseInBackground } from "@/lib/caseAnalysis";
+import {
+  analyzePhotoInBackground,
+  removePhotoAnalysis,
+} from "@/lib/caseAnalysis";
 import {
   addCasePhoto,
   getCase,
@@ -18,15 +21,7 @@ export async function DELETE(
   if (!updated) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
-  const p = updateCase(updated.id, {
-    analysisStatus: "pending",
-    analysisProgress: {
-      stage: "upload",
-      index: 0,
-      total: updated.photos.length,
-    },
-  });
-  analyzeCaseInBackground(p || updated);
+  removePhotoAnalysis(id, photo);
   const layered = getCase(id);
   return NextResponse.json(layered);
 }
@@ -47,13 +42,9 @@ export async function POST(
   }
   const p = updateCase(updated.id, {
     analysisStatus: "pending",
-    analysisProgress: {
-      stage: "upload",
-      index: 0,
-      total: updated.photos.length,
-    },
+    analysisProgress: { stage: "upload", index: 0, total: 1 },
   });
-  analyzeCaseInBackground(p || updated);
+  analyzePhotoInBackground(p || updated, photo);
   const layered = getCase(id);
   return NextResponse.json(layered);
 }

--- a/src/jobs/analyzePhoto.ts
+++ b/src/jobs/analyzePhoto.ts
@@ -1,0 +1,14 @@
+import { parentPort, workerData } from "node:worker_threads";
+import { reanalyzePhoto } from "../lib/caseAnalysis";
+import type { Case } from "../lib/caseStore";
+import { migrationsReady } from "../lib/db";
+
+(async () => {
+  await migrationsReady;
+  const { caseData, photo } = workerData as { caseData: Case; photo: string };
+  await reanalyzePhoto(caseData, photo);
+  if (parentPort) parentPort.postMessage("done");
+})().catch((err) => {
+  console.error("analyzePhoto job failed", err);
+  if (parentPort) parentPort.postMessage("error");
+});

--- a/src/lib/analysisQueue.ts
+++ b/src/lib/analysisQueue.ts
@@ -1,0 +1,63 @@
+import crypto from "node:crypto";
+import type { Worker } from "node:worker_threads";
+
+interface Task {
+  id: string;
+  photo?: string;
+  run: () => Promise<void>;
+}
+
+interface Queue {
+  tasks: Task[];
+  active?: Task;
+  worker?: Worker;
+}
+
+const queues = new Map<string, Queue>();
+
+function process(caseId: string) {
+  const q = queues.get(caseId);
+  if (!q || q.active || q.tasks.length === 0) return;
+  const task = q.tasks.shift();
+  if (!task) return;
+  q.active = task;
+  task
+    .run()
+    .catch((err) => console.error("analysis task failed", err))
+    .finally(() => {
+      q.active = undefined;
+      process(caseId);
+    });
+}
+
+export function enqueueTask(
+  caseId: string,
+  task: Omit<Task, "id"> & { photo?: string },
+): string {
+  const id = crypto.randomUUID();
+  const q = queues.get(caseId) || { tasks: [] };
+  q.tasks.push({ ...task, id });
+  queues.set(caseId, q);
+  process(caseId);
+  return id;
+}
+
+export function removeQueuedPhoto(caseId: string, photo: string): boolean {
+  const q = queues.get(caseId);
+  if (!q) return false;
+  const idx = q.tasks.findIndex((t) => t.photo === photo);
+  if (idx !== -1) {
+    q.tasks.splice(idx, 1);
+    return true;
+  }
+  return false;
+}
+
+export function clearQueue(caseId: string): void {
+  queues.delete(caseId);
+}
+
+export function isProcessing(caseId: string): boolean {
+  const q = queues.get(caseId);
+  return Boolean(q?.active);
+}

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -90,8 +90,14 @@ describe("reanalysis", () => {
         { method: "POST" },
       );
       expect(re.status).toBe(200);
-      const data = await re.json();
-      expect(data.analysis.vehicle.licensePlateNumber).toBe("ABC123");
+      let final: Record<string, unknown> | undefined;
+      for (let i = 0; i < 10; i++) {
+        const check = await fetch(`${server.url}/api/cases/${caseId}`);
+        final = await check.json();
+        if (final.analysis?.vehicle?.licensePlateNumber) break;
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      expect(final?.analysis?.vehicle?.licensePlateNumber).toBe("ABC123");
       expect(stub.requests.length).toBe(2);
     }, 30000);
   });
@@ -149,9 +155,14 @@ describe("reanalysis", () => {
         { method: "POST" },
       );
       expect(re.status).toBe(200);
-      const data = await re.json();
-      console.log("DATA", JSON.stringify(data));
-      expect(data.analysis.vehicle.licensePlateNumber).toBe("ZZZ111");
+      let final: Record<string, unknown> | undefined;
+      for (let i = 0; i < 10; i++) {
+        const check = await fetch(`${server.url}/api/cases/${caseId}`);
+        final = await check.json();
+        if (final.analysis?.vehicle?.licensePlateNumber) break;
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      expect(final?.analysis?.vehicle?.licensePlateNumber).toBe("ZZZ111");
       expect(stub.requests.length).toBe(4);
     }, 30000);
   });


### PR DESCRIPTION
## Summary
- implement queued photo analysis jobs
- add photo worker and job queue
- remove sync logic from reanalyze-photo API
- analyze single photos when added
- update e2e tests for async analysis

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e124a0c10832b962247d82e060c6a