### PR TITLE
fix: use map preview stub in storybook

### DIFF
--- a/.storybook/MapPreviewStub.tsx
+++ b/.storybook/MapPreviewStub.tsx
@@ -1,0 +1,21 @@
+import Image from "next/image";
+
+export default function MapPreviewStub({
+  width,
+  height,
+  className,
+}: { width: number; height: number; className?: string }) {
+  return (
+    <div
+      className={className ?? ""}
+      style={{ aspectRatio: `${width} / ${height}` }}
+    >
+      <Image
+        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='150'%3E%3Crect width='100%25' height='100%25' fill='%23ddd'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23666' font-family='sans-serif' font-size='20'%3EMap Preview%3C/text%3E%3C/svg%3E"
+        alt="Map preview placeholder"
+        width={width}
+        height={height}
+      />
+    </div>
+  );
+}

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -14,6 +14,11 @@ const config: StorybookConfig = {
     config.resolve.alias = {
       ...(config.resolve.alias ?? {}),
       "@": path.resolve(process.cwd(), "src"),
+      "@/app/components/MapPreview": path.resolve(
+        process.cwd(),
+        ".storybook",
+        "MapPreviewStub.tsx",
+      ),
     };
     return config;
   },


### PR DESCRIPTION
## Summary
- add a `MapPreviewStub` to show a placeholder image for Storybook
- alias `MapPreview` to the stub when building Storybook so broken maps don't appear

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684eacef7cac832ba266bc2d65614a55