### PR TITLE
Fix map preview alias in ClientCasesPage

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -1,4 +1,5 @@
 "use client";
+import MapPreview from "@/app/components/MapPreview";
 import Image from "next/image";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -9,7 +10,6 @@ import {
 } from "../../lib/caseUtils";
 import { distanceBetween } from "../../lib/distance";
 import AnalysisInfo from "../components/AnalysisInfo";
-import MapPreview from "../components/MapPreview";
 import useNewCaseFromFiles from "../useNewCaseFromFiles";
 import useDragReset from "./useDragReset";
 

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -1,4 +1,5 @@
 "use client";
+import MapPreview from "@/app/components/MapPreview";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -19,7 +20,6 @@ import CaseProgressGraph from "../../components/CaseProgressGraph";
 import CaseToolbar from "../../components/CaseToolbar";
 import EditableText from "../../components/EditableText";
 import ImageHighlights from "../../components/ImageHighlights";
-import MapPreview from "../../components/MapPreview";
 import useCloseOnOutsideClick from "../../useCloseOnOutsideClick";
 import useDragReset from "../useDragReset";
 


### PR DESCRIPTION
## Summary
- import MapPreview via alias in client case pages so Storybook uses the stub

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684eb643797c832b88b2a592b39fd2a0