### PR TITLE
Add type checking to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
+      - run: npm run typecheck
       - run: npm run lint
       - run: npm test
       - run: npm run e2e

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "storybook:screenshot": "npm run build-storybook && storycap http://localhost:6006 --serverCmd \"http-server storybook-static -p 6006\" --out storybook-screenshots",
     "generate:schemas": "ts-to-zod --skipValidation --all",
     "generate:migrations": "drizzle-kit generate:sqlite",
-    "website": "eleventy"
+    "website": "eleventy",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@faker-js/faker": "^8.4.1",


### PR DESCRIPTION
## Summary
- run TypeScript compiler in CI
- expose a `typecheck` npm script

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eb8c9afec832ba1db8fe49b3c5dff