### PR TITLE
Split CI workflow into parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,67 @@ on:
       - gh-pages
 
 jobs:
-  build:
+  setup:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+      - run: npm run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+      - run: npm run typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+      - run: npm test
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+      - run: npm run e2e
+
+  storybook:
+    runs-on: ubuntu-latest
+    needs: e2e
     permissions:
       contents: write
     steps:
@@ -16,12 +75,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: "npm"
       - run: npm ci
-      - run: npm run typecheck
-      - run: npm run lint
-      - run: npm test
-      - run: npm run e2e
       - run: npm run build-storybook
       - name: Deploy Storybook to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
- run lint and typecheck in parallel
- gate tests, e2e and storybook on earlier jobs

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: manual interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684ebb3593b0832b821f0d025d66161e