### PR TITLE
Fix TypeScript issues in tests

### DIFF
--- a/test/e2e/startServer.ts
+++ b/test/e2e/startServer.ts
@@ -20,7 +20,7 @@ function waitForServer(port: number): Promise<void> {
 
 export async function startServer(
   port = 3002,
-  env: NodeJS.ProcessEnv = {},
+  env: Partial<NodeJS.ProcessEnv> = {},
 ): Promise<TestServer> {
   const nextBin = path.join("node_modules", ".bin", "next");
   const proc = spawn(nextBin, ["dev", "-p", String(port)], {

--- a/test/e2e/stream.test.ts
+++ b/test/e2e/stream.test.ts
@@ -18,6 +18,8 @@ describe("case events", () => {
     const res = await fetch(`${server.url}/api/cases/stream`);
     expect(res.status).toBe(200);
     const reader = res.body?.getReader();
+    expect(reader).toBeDefined();
+    if (!reader) throw new Error("no reader");
     const decoder = new TextDecoder();
 
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });

--- a/test/vinLookup.test.ts
+++ b/test/vinLookup.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Case } from "../src/lib/caseStore";
 
 let dataDir: string;
 
@@ -77,7 +78,7 @@ describe("vinLookup", () => {
       },
     });
     const current = caseStore.getCase(c.id);
-    await fetchCaseVin(current as caseStore.Case);
+    await fetchCaseVin(current as Case);
     expect(logSpy).toHaveBeenCalledWith(
       "VIN fetch successful",
       "1HGCM82633A004352",

--- a/test/vinSources.test.ts
+++ b/test/vinSources.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 let dataDir: string;
 

--- a/test/violationUtils.test.ts
+++ b/test/violationUtils.test.ts
@@ -6,6 +6,8 @@ describe("hasViolation", () => {
     expect(
       hasViolation({
         violationType: "",
+        details: "",
+        vehicle: {},
         images: { a: { representationScore: 1, violation: true } },
       }),
     ).toBe(true);
@@ -15,14 +17,20 @@ describe("hasViolation", () => {
     expect(
       hasViolation({
         violationType: "",
+        details: "",
+        vehicle: {},
         images: { a: { representationScore: 1, violation: false } },
       }),
     ).toBe(false);
   });
 
   it("falls back to violationType when flags missing", () => {
-    expect(hasViolation({ violationType: "parking" })).toBe(true);
-    expect(hasViolation({ violationType: "" })).toBe(false);
+    expect(
+      hasViolation({ violationType: "parking", details: "", vehicle: {} }),
+    ).toBe(true);
+    expect(hasViolation({ violationType: "", details: "", vehicle: {} })).toBe(
+      false,
+    );
   });
 });
 

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
     include: ["test/e2e/*.test.ts"],
     testTimeout: 30000,
     hookTimeout: 30000,
-    threads: false,
     maxConcurrency: 1,
     isolate: false,
     sequence: { concurrent: false },

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -70,8 +70,9 @@ afterEach((context) => {
     if (originalGetUserMedia) {
       navigator.mediaDevices.getUserMedia = originalGetUserMedia;
     } else if (navigator.mediaDevices) {
-      (navigator.mediaDevices as Record<string, unknown>).getUserMedia =
-        undefined;
+      (
+        navigator.mediaDevices as unknown as Record<string, unknown>
+      ).getUserMedia = undefined;
     }
   }
 


### PR DESCRIPTION
## Summary
- update `startServer` to accept partial env vars
- guard `reader` in stream tests
- import `vi` in vinSources tests
- type cast Case in vinLookup tests
- include required fields in violationUtils tests
- adjust Vitest setup and E2E config

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run typecheck` *(fails: see log)*

------
https://chatgpt.com/codex/tasks/task_e_684ec5da0d90832b94001c8bc9761c03