### PR TITLE
Fix TypeScript issues in tests

### DIFF
--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -69,16 +69,24 @@ describe("reanalysis", () => {
       expect(res.status).toBe(200);
       const { caseId } = (await res.json()) as { caseId: string };
 
-      let json: Record<string, unknown> | undefined;
+      type CaseData = {
+        photos: string[];
+        analysis?: {
+          vehicle?: { licensePlateNumber?: string; licensePlateState?: string };
+          images?: Record<string, unknown>;
+        };
+      };
+      let json: CaseData | undefined;
       for (let i = 0; i < 10; i++) {
         const check = await fetch(`${server.url}/api/cases/${caseId}`);
         if (check.status === 200) {
-          json = await check.json();
+          json = (await check.json()) as CaseData;
           break;
         }
-        await new Promise((r) => setTimeout(r, 500));
+        await new Promise((r) => setTimeout(() => r(undefined), 500));
       }
       expect(json).toBeDefined();
+      if (!json) throw new Error("case data not found");
       const photo = json.photos[0] as string;
       photoName = path.basename(photo);
       expect(json.analysis?.vehicle?.licensePlateNumber).toBeUndefined();
@@ -93,7 +101,7 @@ describe("reanalysis", () => {
       for (let i = 0; i < 10; i++) {
         const check = await fetch(`${server.url}/api/cases/${caseId}`);
         if (check.status === 200) break;
-        await new Promise((r) => setTimeout(r, 500));
+        await new Promise((r) => setTimeout(() => r(undefined), 500));
       }
       expect(stub.requests.length).toBeGreaterThanOrEqual(1);
     }, 30000);
@@ -131,16 +139,23 @@ describe("reanalysis", () => {
       expect(res.status).toBe(200);
       const { caseId } = (await res.json()) as { caseId: string };
 
-      let json: Record<string, unknown> | undefined;
+      type CaseData = {
+        photos: string[];
+        analysis?: {
+          images?: Record<string, unknown>;
+        };
+      };
+      let json: CaseData | undefined;
       for (let i = 0; i < 10; i++) {
         const check = await fetch(`${server.url}/api/cases/${caseId}`);
         if (check.status === 200) {
-          json = await check.json();
+          json = (await check.json()) as CaseData;
           break;
         }
-        await new Promise((r) => setTimeout(r, 500));
+        await new Promise((r) => setTimeout(() => r(undefined), 500));
       }
       expect(json).toBeDefined();
+      if (!json) throw new Error("case data not found");
       const photo = json.photos[0] as string;
       photoName = path.basename(photo);
       expect(json.analysis?.images?.[photoName]).toBeUndefined();
@@ -155,7 +170,7 @@ describe("reanalysis", () => {
       for (let i = 0; i < 10; i++) {
         const check = await fetch(`${server.url}/api/cases/${caseId}`);
         if (check.status === 200) break;
-        await new Promise((r) => setTimeout(r, 500));
+        await new Promise((r) => setTimeout(() => r(undefined), 500));
       }
       expect(stub.requests.length).toBeGreaterThanOrEqual(1);
     }, 30000);

--- a/test/e2e/snailmail.test.ts
+++ b/test/e2e/snailmail.test.ts
@@ -17,7 +17,17 @@ beforeAll(async () => {
     images: {},
   });
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-snail-"));
-  const env = {
+  const env: NodeJS.ProcessEnv & {
+    CASE_STORE_FILE: string;
+    VIN_SOURCE_FILE: string;
+    OPENAI_BASE_URL: string;
+    SNAIL_MAIL_PROVIDER_FILE: string;
+    SNAIL_MAIL_FILE: string;
+    SNAIL_MAIL_OUT_DIR: string;
+    RETURN_ADDRESS: string;
+    SNAIL_MAIL_PROVIDER: string;
+    NODE_ENV: string;
+  } = {
     CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
     VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
     OPENAI_BASE_URL: stub.url,
@@ -26,7 +36,8 @@ beforeAll(async () => {
     SNAIL_MAIL_OUT_DIR: path.join(tmpDir, "out"),
     RETURN_ADDRESS: "Me\n1 A St\nTown, ST 12345",
     SNAIL_MAIL_PROVIDER: "file",
-  } as NodeJS.ProcessEnv;
+    NODE_ENV: "test",
+  };
   fs.writeFileSync(
     env.VIN_SOURCE_FILE,
     JSON.stringify(

--- a/test/violationUtils.test.ts
+++ b/test/violationUtils.test.ts
@@ -26,11 +26,16 @@ describe("hasViolation", () => {
 
   it("falls back to violationType when flags missing", () => {
     expect(
-      hasViolation({ violationType: "parking", details: "", vehicle: {} }),
+      hasViolation({
+        violationType: "parking",
+        details: "",
+        vehicle: {},
+        images: {},
+      }),
     ).toBe(true);
-    expect(hasViolation({ violationType: "", details: "", vehicle: {} })).toBe(
-      false,
-    );
+    expect(
+      hasViolation({ violationType: "", details: "", vehicle: {}, images: {} }),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- fix type usage in snail mail e2e test
- add missing images field in violation utils test
- improve types in reanalysis e2e test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ece2a2590832baae574f0b0a1dde4