### PR TITLE
Fix TypeScript errors in tests

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -1,5 +1,5 @@
 import { headers } from "next/headers";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { type Mock, beforeAll, describe, expect, it, vi } from "vitest";
 import Home from "../page";
 
 vi.mock("next/headers", () => ({
@@ -18,7 +18,7 @@ describe("Home page", () => {
   });
 
   it("redirects mobile users to /point", async () => {
-    (headers as vi.Mock).mockReturnValueOnce(
+    (headers as Mock).mockReturnValueOnce(
       Promise.resolve(
         new Headers({
           "user-agent":
@@ -36,7 +36,7 @@ describe("Home page", () => {
   });
 
   it("redirects desktop users to /cases", async () => {
-    (headers as vi.Mock).mockReturnValueOnce(
+    (headers as Mock).mockReturnValueOnce(
       Promise.resolve(
         new Headers({ "user-agent": "Mozilla/5.0 (X11; Linux x86_64)" }),
       ),

--- a/src/app/__tests__/point.test.tsx
+++ b/src/app/__tests__/point.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import PointAndShootPage from "../point/page";
 
 vi.mock("next/navigation", () => ({

--- a/src/app/components/__tests__/NavBar.test.tsx
+++ b/src/app/components/__tests__/NavBar.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const mockedUsePathname = vi.fn();
 vi.mock("next/navigation", () => ({

--- a/test/better-sqlite3.d.ts
+++ b/test/better-sqlite3.d.ts
@@ -1,0 +1,1 @@
+declare module "better-sqlite3";

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -34,7 +34,7 @@ describe("caseStore", () => {
     );
     expect(c.photos).toEqual(["/foo.jpg"]);
     expect(c.gps).toEqual({ lat: 10, lon: 20 });
-    expect(c.photoGps["/foo.jpg"]).toEqual({ lat: 10, lon: 20 });
+    expect(c.photoGps?.["/foo.jpg"]).toEqual({ lat: 10, lon: 20 });
     expect(c.streetAddress).toBeNull();
     expect(c.intersection).toBeNull();
     expect(getCase(c.id)).toEqual(c);
@@ -117,7 +117,7 @@ describe("caseStore", () => {
     expect(updated?.analysisStatus).toBe("pending");
     const stored = getCase(c.id);
     expect(stored?.photos).toEqual(["/bar.jpg"]);
-    expect(stored?.photoGps["/foo.jpg"]).toBeUndefined();
+    expect(stored?.photoGps?.["/foo.jpg"]).toBeUndefined();
   });
 
   it("deletes a case", () => {

--- a/test/e2e/analysisQueue.test.ts
+++ b/test/e2e/analysisQueue.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Case } from "../../src/lib/caseStore";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
 
@@ -32,14 +33,14 @@ async function createPhoto(name: string): Promise<File> {
   return new File([Buffer.from(name)], `${name}.jpg`, { type: "image/jpeg" });
 }
 
-async function fetchCase(id: string): Promise<Record<string, unknown>> {
+async function fetchCase(id: string): Promise<Case> {
   for (let i = 0; i < 20; i++) {
     const res = await fetch(`${server.url}/api/cases/${id}`);
-    if (res.status === 200) return res.json();
+    if (res.status === 200) return (await res.json()) as Case;
     await new Promise((r) => setTimeout(r, 500));
   }
   const res = await fetch(`${server.url}/api/cases/${id}`);
-  return res.json();
+  return (await res.json()) as Case;
 }
 
 beforeAll(async () => {
@@ -107,7 +108,7 @@ describe("analysis queue", () => {
     const { caseId } = (await res.json()) as { caseId: string };
 
     let data = await fetchCase(caseId);
-    const photo = data.photos[0] as string;
+    const photo = data.photos[0];
 
     const second = await createPhoto("d");
     const add = new FormData();

--- a/test/e2e/openaiStub.ts
+++ b/test/e2e/openaiStub.ts
@@ -58,11 +58,11 @@ export async function startOpenAIStub(
       }
     });
   });
-  await new Promise((resolve) => server.listen(0, resolve));
+  await new Promise<void>((resolve) => server.listen(0, () => resolve()));
   const { port } = server.address() as AddressInfo;
   return {
     url: `http://127.0.0.1:${port}`,
     requests,
-    close: () => new Promise((resolve) => server.close(() => resolve())),
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
   };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["vitest"]
   },
   "ts-node": {
     "compilerOptions": {


### PR DESCRIPTION
## Summary
- add vitest type definitions in tsconfig
- fix imports and types in various test files
- type the E2E fetch helper and adjust openAI stub
- declare `better-sqlite3` for tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ed31e2360832b9054e27842f57aae