### PR TITLE
Optimize CI with shared node_modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,19 +7,8 @@ on:
       - gh-pages
 
 jobs:
-  setup:
+  lint_typecheck:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: "npm"
-      - run: npm ci
-
-  lint:
-    runs-on: ubuntu-latest
-    needs: setup
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -28,29 +17,26 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run lint
-
-  typecheck:
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: "npm"
-      - run: npm ci
       - run: npm run typecheck
+      - name: Upload node modules
+        uses: actions/upload-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules
 
   test:
     runs-on: ubuntu-latest
-    needs: [lint, typecheck]
+    needs: lint_typecheck
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "npm"
-      - run: npm ci
+      - uses: actions/download-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules
       - run: npm test
 
   e2e:
@@ -62,7 +48,10 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
-      - run: npm ci
+      - uses: actions/download-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules
       - run: npm run e2e
 
   storybook:
@@ -76,7 +65,10 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
-      - run: npm ci
+      - uses: actions/download-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules
       - run: npm run build-storybook
       - name: Deploy Storybook to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
- remove setup job
- run lint and typecheck in a single job
- share `node_modules` across jobs using artifacts

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: process hung or timed out)*

------
https://chatgpt.com/codex/tasks/task_e_684ed6e2f14c832bb1b9d4b76e2285f6