### PR TITLE
Add automated marketing image generation

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,6 @@
 module.exports = (eleventyConfig) => {
   eleventyConfig.addPassthroughCopy("website/style.css");
+  eleventyConfig.addPassthroughCopy("website/images");
   return {
     pathPrefix: process.env.PATH_PREFIX || "/",
     dir: {

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -20,6 +20,7 @@ jobs:
       - run: npm run website
         env:
           PATH_PREFIX: /photo-to-citation/website/
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       - name: Deploy Website to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/README.md
+++ b/README.md
@@ -312,5 +312,7 @@ npm run website
 
 The output is written to `website/dist`.
 
+The build step uses OpenAI to generate marketing images when they are missing in the `gh-pages` branch. Set an `OPENAI_API_KEY` secret in your repository so the GitHub Action can access the API.
+
 ## Browser Debugging
 Set `NEXT_PUBLIC_BROWSER_DEBUG` to `true` in your `.env` to enable a JSON overlay. Hold the Option key while hovering over case images or details to reveal the tooltip. The tooltip remains visible while you move the cursor over it so you can easily copy the JSON.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "generate:schemas": "ts-to-zod --skipValidation --all && npm run validate:generated",
     "validate:generated": "tsc --noEmit -p tsconfig.generated.json",
     "generate:migrations": "drizzle-kit generate:sqlite",
-    "website": "eleventy",
+    "website": "ts-node --transpile-only scripts/generateWebsiteImages.ts && eleventy",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/scripts/generateWebsiteImages.ts
+++ b/scripts/generateWebsiteImages.ts
@@ -1,0 +1,112 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import dotenv from "dotenv";
+import OpenAI from "openai";
+
+dotenv.config();
+
+const openai = new OpenAI();
+
+interface ImageSpec {
+  file: string;
+  prompt: string;
+  size?: string;
+}
+
+const specs: ImageSpec[] = [
+  {
+    file: "images/logo.png",
+    prompt:
+      "minimal logo reading 'Photo To Citation' with camera and ticket icon, dark background",
+    size: "512x512",
+  },
+  {
+    file: "images/hero.png",
+    prompt:
+      "cyclist snapping a photo of a car blocking the bike lane using a phone app",
+  },
+];
+
+const featurePrompts = [
+  "camera icon for quick one-handed capture",
+  "envelope icon for creating cases from email",
+  "magnifying glass over car for automatic AI analysis",
+  "map pin icon for reverse geocoding",
+  "document icon for generating reports",
+  "bell icon for multi-channel notifications",
+  "clipboard icon for citation tracking",
+  "group of cyclists helping each other",
+];
+
+for (let i = 0; i < featurePrompts.length; i++) {
+  specs.push({
+    file: `images/features/${i + 1}.png`,
+    prompt: featurePrompts[i],
+    size: "512x512",
+  });
+}
+
+const libraryPrompts = [
+  "car blocking bike lane while cyclist takes a photo",
+  "sidewalk blocked by vehicle, pedestrian photographing",
+  "cyclist using phone app to report violation",
+  "car receiving citation from community program",
+];
+
+for (let i = 0; i < libraryPrompts.length; i++) {
+  specs.push({
+    file: `images/library/${i + 1}.png`,
+    prompt: libraryPrompts[i],
+  });
+}
+
+specs.push({
+  file: "images/owners.png",
+  prompt: "vehicle owner looking sorry while paying fine for parking violation",
+});
+
+function fetchRemote(file: string): Buffer | null {
+  try {
+    const data = execSync(`git show origin/gh-pages:website/${file}`, {
+      encoding: "buffer",
+    });
+    return Buffer.from(data);
+  } catch {
+    return null;
+  }
+}
+
+async function generate(spec: ImageSpec): Promise<void> {
+  const localPath = path.join("website", spec.file);
+  if (fs.existsSync(localPath)) return;
+  const data = fetchRemote(spec.file);
+  if (data) {
+    fs.mkdirSync(path.dirname(localPath), { recursive: true });
+    fs.writeFileSync(localPath, data);
+    return;
+  }
+  const res = await openai.images.generate({
+    model: "dall-e-3",
+    prompt: spec.prompt,
+    n: 1,
+    size: spec.size || "1024x1024",
+  });
+  const url = res.data[0]?.url;
+  if (!url) throw new Error("Image generation failed");
+  const imgRes = await fetch(url);
+  const buf = Buffer.from(await imgRes.arrayBuffer());
+  fs.mkdirSync(path.dirname(localPath), { recursive: true });
+  fs.writeFileSync(localPath, buf);
+}
+
+(async () => {
+  try {
+    execSync("git fetch origin gh-pages", { stdio: "ignore" });
+  } catch {
+    // ignore
+  }
+  for (const spec of specs) {
+    await generate(spec);
+  }
+})();

--- a/website/_includes/layout.njk
+++ b/website/_includes/layout.njk
@@ -7,6 +7,7 @@
   </head>
   <body>
     <header>
+      <img class="logo" src="{{ '/images/logo.png' | url }}" alt="Photo To Citation logo" />
       <nav>
         <a href="{{ '/' | url }}">Home</a>
         <a href="{{ '/features/' | url }}">Features</a>

--- a/website/features.md
+++ b/website/features.md
@@ -7,13 +7,14 @@ layout: layout.njk
 
 Photo To Citation automates every step of reporting blocked bike lanes and sidewalks so you don’t have to.
 
-- **One-handed capture** — snap a photo and submit it from your phone while you wait at the light or pause your walk.
-- **Create cases from inbound email** — forward pictures directly to your dedicated address when you get home.
-- **Automatic AI analysis** — language models pull out license plates, location clues and violation type.
-- **Reverse geocoding** — GPS data from your photos instantly turns into street addresses.
-- **Generate reports** — the app assembles everything into a clear PDF or email for the authorities.
-- **Multi-channel notifications** — get updates via email, SMS or even snail mail.
-- **Citation tracking** — built-in modules keep tabs on the status of each citation so you know it’s moving forward.
-
-- **Community assistance** — empower municipalities that need residents to help keep paths clear for biking and walking.
+<ul class="features">
+  <li><img class="feature-icon" src="{{ '/images/features/1.png' | url }}" alt="One-handed capture" /> <strong>One-handed capture</strong> — snap a photo and submit it from your phone while you wait at the light or pause your walk.</li>
+  <li><img class="feature-icon" src="{{ '/images/features/2.png' | url }}" alt="Email cases" /> <strong>Create cases from inbound email</strong> — forward pictures directly to your dedicated address when you get home.</li>
+  <li><img class="feature-icon" src="{{ '/images/features/3.png' | url }}" alt="AI analysis" /> <strong>Automatic AI analysis</strong> — language models pull out license plates, location clues and violation type.</li>
+  <li><img class="feature-icon" src="{{ '/images/features/4.png' | url }}" alt="Reverse geocoding" /> <strong>Reverse geocoding</strong> — GPS data from your photos instantly turns into street addresses.</li>
+  <li><img class="feature-icon" src="{{ '/images/features/5.png' | url }}" alt="Generate reports" /> <strong>Generate reports</strong> — the app assembles everything into a clear PDF or email for the authorities.</li>
+  <li><img class="feature-icon" src="{{ '/images/features/6.png' | url }}" alt="Notifications" /> <strong>Multi-channel notifications</strong> — get updates via email, SMS or even snail mail.</li>
+  <li><img class="feature-icon" src="{{ '/images/features/7.png' | url }}" alt="Citation tracking" /> <strong>Citation tracking</strong> — built-in modules keep tabs on the status of each citation so you know it’s moving forward.</li>
+  <li><img class="feature-icon" src="{{ '/images/features/8.png' | url }}" alt="Community assistance" /> <strong>Community assistance</strong> — empower municipalities that need residents to help keep paths clear for biking and walking.</li>
+</ul>
 

--- a/website/index.md
+++ b/website/index.md
@@ -5,7 +5,16 @@ layout: layout.njk
 
 <div class="hero">
   <h1>Photo To Citation</h1>
+  <img src="{{ '/images/hero.png' | url }}" alt="Cyclist using the app" />
   <p>Stop dodging cars in the bike lane or on the sidewalk—let one photo clear the path.</p>
 </div>
 
 Welcome to **Photo To Citation**, a tool for cyclists and pedestrians who feel powerless when vehicles clog their space. If your city needs help keeping streets usable for bikes and walkers, just grab your phone, snap a photo and keep moving. We handle the paperwork while the citation heads to the authorities. This isn’t for drivers—it’s for everyone who relies on safe alternatives to cars.
+
+<div class="gallery">
+  <img src="{{ '/images/library/1.png' | url }}" alt="Violation example" />
+  <img src="{{ '/images/library/2.png' | url }}" alt="Sidewalk violation" />
+  <img src="{{ '/images/library/3.png' | url }}" alt="Reporting with phone" />
+  <img src="{{ '/images/library/4.png' | url }}" alt="Citation example" />
+  <img src="{{ '/images/owners.png' | url }}" alt="Violator paying fine" />
+</div>

--- a/website/style.css
+++ b/website/style.css
@@ -12,6 +12,12 @@ header {
   text-align: center;
 }
 
+header .logo {
+  height: 40px;
+  vertical-align: middle;
+  margin-right: 1rem;
+}
+
 header a {
   color: #eee;
   margin: 0 1rem;
@@ -34,6 +40,12 @@ main {
   padding: 3rem 0;
 }
 
+.hero img {
+  max-width: 100%;
+  height: auto;
+  margin-bottom: 1rem;
+}
+
 .hero h1 {
   font-size: 3rem;
   margin-bottom: 1rem;
@@ -42,4 +54,34 @@ main {
 .hero p {
   font-size: 1.2rem;
   color: #ccc;
+}
+
+.features {
+  list-style: none;
+  padding: 0;
+}
+
+.features li {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.feature-icon {
+  width: 64px;
+  height: 64px;
+  margin-right: 1rem;
+}
+
+.gallery {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.gallery img {
+  max-width: 180px;
+  height: auto;
+  border-radius: 4px;
 }


### PR DESCRIPTION
## Summary
- generate marketing images with OpenAI when building website
- display logo, hero picture and feature icons
- add gallery of example photos on home page
- update Eleventy config to copy images
- document OPENAI_API_KEY secret and expose it in workflow

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ee5910ecc832b8a809ef8589a6bd8