### PR TITLE
Fix artifact download path for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: node-modules
-          path: node_modules
+          path: .
       - run: npm test
 
   e2e:
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: node-modules
-          path: node_modules
+          path: .
       - run: npm run e2e
 
   storybook:
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: node-modules
-          path: node_modules
+          path: .
       - run: npm run build-storybook
       - name: Deploy Storybook to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
- fix artifact download path so node_modules installs properly on GitHub Actions

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684eea644028832b922e51e02d97c59c