### PR TITLE
Add concurrency only to deploy jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
     needs: e2e
     permissions:
       contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary
- limit concurrency to the jobs that deploy artifacts

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_684ef9016a20832b9d4b5338d94f76fb