### PR TITLE
Fix hero image regeneration

### DIFF
--- a/scripts/generateWebsiteImages.ts
+++ b/scripts/generateWebsiteImages.ts
@@ -78,14 +78,18 @@ specs.push({
 });
 
 function fetchRemote(file: string): Buffer | null {
-  try {
-    const data = execSync(`git show origin/gh-pages:website/${file}`, {
-      encoding: "buffer",
-    });
-    return Buffer.from(data);
-  } catch {
-    return null;
+  const paths = [`website/${file}`, `website/dist/${file}`];
+  for (const p of paths) {
+    try {
+      const data = execSync(`git show origin/gh-pages:${p}`, {
+        encoding: "buffer",
+      });
+      return Buffer.from(data);
+    } catch {
+      // try next path
+    }
   }
+  return null;
 }
 
 async function saveResized(


### PR DESCRIPTION
## Summary
- handle gh-pages image paths under `website/dist`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f0d0c6fd0832b8ba6ed9e26519a91