### PR TITLE
Fix unused import

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,10 +1,4 @@
-import {
-  integer,
-  primaryKey,
-  real,
-  sqliteTable,
-  text,
-} from "drizzle-orm/sqlite-core";
+import { primaryKey, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 export const cases = sqliteTable("cases", {
   id: text("id").primaryKey(),


### PR DESCRIPTION
## Summary
- remove unused `integer` import from `schema.ts`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f1829078c832b9aca8c99c50cff76