### PR TITLE
Add marketing screenshots

### DIFF
--- a/scripts/generateWebsiteImages.ts
+++ b/scripts/generateWebsiteImages.ts
@@ -77,6 +77,21 @@ specs.push({
   width: 180,
 });
 
+const screenshotPrompts = [
+  "dark mode app screenshot showing a list of violation cases with thumbnail photos, status icons and blue highlights, sleek mobile UI",
+  "mobile camera interface screenshot with live preview and large 'Take Picture' button over a car blocking a bike lane",
+  "case detail screen screenshot with big photo marked up with bounding boxes, sidebar with address and license plate fields, map preview and dark UI",
+  "map view screenshot with open street map tiles, blue location pins containing thumbnail images and navigation header",
+];
+
+for (let i = 0; i < screenshotPrompts.length; i++) {
+  specs.push({
+    file: `images/screenshots/${i + 1}.png`,
+    prompt: screenshotPrompts[i],
+    width: 800,
+  });
+}
+
 function fetchRemote(file: string): Buffer | null {
   const paths = [`website/${file}`, `website/dist/${file}`];
   for (const p of paths) {

--- a/website/index.md
+++ b/website/index.md
@@ -18,3 +18,10 @@ Welcome to **Photo To Citation**, a tool for cyclists and pedestrians who feel p
   <img src="{{ '/images/library/4.png' | url }}" alt="Citation example" />
   <img src="{{ '/images/owners.png' | url }}" alt="Violator paying fine" />
 </div>
+
+<div class="screenshots">
+  <img src="{{ '/images/screenshots/1.png' | url }}" alt="Case list" />
+  <img src="{{ '/images/screenshots/2.png' | url }}" alt="Camera interface" />
+  <img src="{{ '/images/screenshots/3.png' | url }}" alt="Case detail" />
+  <img src="{{ '/images/screenshots/4.png' | url }}" alt="Map view" />
+</div>

--- a/website/style.css
+++ b/website/style.css
@@ -85,3 +85,18 @@ main {
   height: auto;
   border-radius: 4px;
 }
+
+.screenshots {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  margin-top: 2rem;
+}
+
+.screenshots img {
+  width: 100%;
+  max-width: 800px;
+  border-radius: 4px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.6);
+}


### PR DESCRIPTION
## Summary
- generate screenshot images using OpenAI
- display screenshots on the home page
- style screenshot gallery

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f2003f074832b83af3e97e1469f06