### PR TITLE
Fix TypeScript errors

### DIFF
--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -1,10 +1,11 @@
 "use client";
-import L from "leaflet";
+import * as L from "leaflet";
 import type { DivIcon, TooltipOptions } from "leaflet";
 import "leaflet/dist/leaflet.css";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
+import type React from "react";
 import {
   MapContainer,
   Marker,
@@ -12,6 +13,16 @@ import {
   Tooltip,
   useMap,
 } from "react-leaflet";
+
+const MapContainerAny = MapContainer as unknown as React.ComponentType<
+  Record<string, unknown>
+>;
+const MarkerAny = Marker as unknown as React.ComponentType<
+  Record<string, unknown>
+>;
+const TooltipAny = Tooltip as unknown as React.ComponentType<
+  Record<string, unknown>
+>;
 
 import "../globals.css";
 
@@ -54,8 +65,7 @@ function FitBounds({ cases }: { cases: MapCase[] }) {
 export default function MapPageClient({ cases }: { cases: MapCase[] }) {
   const router = useRouter();
   return (
-    // @ts-expect-error leaflet props
-    <MapContainer
+    <MapContainerAny
       style={{ height: "calc(100vh - 4rem)", width: "100%" }}
       center={[0, 0] as [number, number]}
       zoom={2}
@@ -64,15 +74,13 @@ export default function MapPageClient({ cases }: { cases: MapCase[] }) {
       <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
       <FitBounds cases={cases} />
       {cases.map((c) => (
-        // @ts-expect-error leaflet props
-        <Marker
+        <MarkerAny
           key={c.id}
           position={[c.gps.lat, c.gps.lon] as [number, number]}
-          icon={markerIcon as DivIcon}
+          icon={markerIcon}
           eventHandlers={{ click: () => router.push(`/cases/${c.id}`) }}
         >
-          {/* @ts-expect-error leaflet props */}
-          <Tooltip {...({ direction: "top" } as TooltipOptions)}>
+          <TooltipAny direction="top">
             <a
               href={`/cases/${c.id}`}
               className="w-40 cursor-pointer block"
@@ -90,9 +98,9 @@ export default function MapPageClient({ cases }: { cases: MapCase[] }) {
               />
               <div>Case {c.id}</div>
             </a>
-          </Tooltip>
-        </Marker>
+          </TooltipAny>
+        </MarkerAny>
       ))}
-    </MapContainer>
+    </MapContainerAny>
   );
 }

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-type Database = unknown;
+import type Database from "better-sqlite3";
 
 export function runMigrations(db: Database.Database): void {
   const anyDb = db as {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "jsx": "preserve",
     "incremental": true,
     "allowImportingTsExtensions": true,
-    "typeRoots": ["./types", "./node_modules/@types"],
+    "typeRoots": ["./types", "./node_modules/@types", "./node_modules/vitest"],
     "plugins": [
       {
         "name": "next"

--- a/types/better-sqlite3.d.ts
+++ b/types/better-sqlite3.d.ts
@@ -8,6 +8,7 @@ declare module "better-sqlite3" {
   interface DB {
     prepare<T = unknown>(sql: string): Statement<T>;
     exec(sql: string): this;
+    close(): void;
   }
 
   interface DatabaseConstructor {
@@ -20,9 +21,7 @@ declare module "better-sqlite3" {
 
   namespace Database {
     export type Database = DB;
-    export type Statement<T = unknown> = import(
-      "./better-sqlite3",
-    ).Statement<T>;
+    export type Statement<T = unknown> = import("better-sqlite3").Statement<T>;
   }
 
   export = Database;

--- a/types/vitest.d.ts
+++ b/types/vitest.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vitest" />


### PR DESCRIPTION
## Summary
- add vitest type reference so tsc can find vitest globals
- improve better-sqlite3 typings and use them in migrations
- relax Leaflet component typing to compile cleanly
- update typeRoots in tsconfig

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f20261e78832b8a140cbc201e6e9c