### PR TITLE
Update docker-compose for external Traefik

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ docker compose up -d
 The compose file sets `platform: \"linux/amd64\"` so builds use an architecture
 with prebuilt Node.js binaries.
 
-Traefik will serve the application at `https://730op.synology.me/photo-citation` using the labels defined in `docker-compose.yml`.
+Run Traefik separately and it will use the labels in `docker-compose.yml` to route traffic to `https://730op.synology.me/photo-citation`.
 
 ## Marketing Website
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,26 +19,6 @@ services:
     networks:
       - web
 
-  traefik:
-    image: traefik:v3.0
-    command:
-      - --providers.docker=true
-      - --providers.docker.exposedbydefault=false
-      - --entrypoints.http.address=:80
-      - --entrypoints.https.address=:443
-      - --certificatesresolvers.myresolver.acme.tlschallenge=true
-      - --certificatesresolvers.myresolver.acme.email=you@example.com
-      - --certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./letsencrypt:/letsencrypt
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    networks:
-      - web
-    restart: unless-stopped
-
 networks:
   web:
-    external: false
+    external: true


### PR DESCRIPTION
## Summary
- remove the Traefik service from `docker-compose.yml`
- mark the `web` network as external
- update README about running Traefik separately

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f26c5be94832bb069c1baed76344a