### PR TITLE
Fix ESLint issues in MapPageClient and Point page

### DIFF
--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -1,6 +1,5 @@
 "use client";
 import * as L from "leaflet";
-import type { DivIcon, TooltipOptions } from "leaflet";
 import "leaflet/dist/leaflet.css";
 import Image from "next/image";
 import { useRouter } from "next/navigation";

--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -40,8 +40,8 @@ export default function PointAndShootPage() {
       }
     }
     startCamera();
+    const v = videoRef.current;
     return () => {
-      const v = videoRef.current;
       if (v?.srcObject) {
         for (const t of (v.srcObject as MediaStream).getTracks()) {
           t.stop();


### PR DESCRIPTION
## Summary
- remove unused imports
- capture `videoRef.current` in a variable before cleanup to avoid React hook warning

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f33190964832bbb9ba4a428018ebf