### PR TITLE
feat: publish docker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,9 +11,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v5
         with:
           context: .
-          push: false
-          tags: photo-to-citation:latest
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/photo-to-citation:latest
 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,12 @@ docker compose up -d
 The compose file sets `platform: \"linux/amd64\"` so builds use an architecture
 with prebuilt Node.js binaries.
 
+### Publishing to GHCR
+
+When commits land on `main`, the `docker-build.yml` workflow pushes the image to
+GitHub Container Registry as `ghcr.io/<OWNER>/photo-to-citation:latest`. Point
+Watchtower at this tag so your Synology NAS automatically pulls updates and redeploys.
+
 Run Traefik separately and it will use the labels in `docker-compose.yml` to route traffic to `https://730op.synology.me/photo-citation`.
 
 ## Marketing Website


### PR DESCRIPTION
## Summary
- push built Docker image to GHCR so Watchtower can deploy updates
- document Docker image publishing in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f36feb0ec832b84c726d1c63957a3