### PR TITLE
Add watchtower service

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ docker compose up -d
 The compose file sets `platform: \"linux/amd64\"` so builds use an architecture
 with prebuilt Node.js binaries.
 
-Run Traefik separately and it will use the labels in `docker-compose.yml` to route traffic to `https://730op.synology.me/photo-citation`.
+Run Traefik separately and it will use the labels in `docker-compose.example.yaml` to route traffic to `https://730op.synology.me/photo-citation`.
 
 ## Marketing Website
 

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -16,8 +16,16 @@ services:
       - "traefik.http.services.photo-citation.loadbalancer.server.port=3000"
       - "traefik.http.middlewares.photo-citation-stripprefix.stripprefix.prefixes=/photo-citation"
       - "traefik.http.routers.photo-citation.middlewares=photo-citation-stripprefix"
+      - "com.centurylinklabs.watchtower.enable=true"
     networks:
       - web
+
+  watchtower:
+    image: containrrr/watchtower
+    command: --interval 300 --cleanup --label-enable
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
 
 networks:
   web:

--- a/docs/feature-outline.md
+++ b/docs/feature-outline.md
@@ -37,7 +37,7 @@ to various services. Follow these basic steps to get a local copy running:
    `http://localhost:3000` to see the app.
 
 These steps give you a working development environment. The server reloads when
-files change, so you can iterate quickly. Review the `docker-compose.yml` file
+files change, so you can iterate quickly. Review the `docker-compose.example.yaml` file
 if you want to spin up supporting services with Docker.
 
 ### 2.1 Environment Variables


### PR DESCRIPTION
## Summary
- add watchtower container to automatically update the app
- rename docker-compose.yml to docker-compose.example.yaml

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f24da2bc4832b83e8aa58e0f76360