### PR TITLE
Add Terraform for Twilio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ storybook-screenshots
 *.tsbuildinfo
 public/uploads
 
+.terraform/
+terraform.tfstate*

--- a/README.md
+++ b/README.md
@@ -175,6 +175,15 @@ TWILIO_AUTH_TOKEN=your_auth_token
 TWILIO_FROM_NUMBER=+15551234567
 ```
 
+A Terraform module under `terraform/twilio` can create this phone number and output the values above.
+
+```bash
+cd terraform/twilio
+terraform init
+terraform apply
+```
+
+Copy the outputs into `.env.local`.
 If these variables are not set, phone notifications are skipped.
 
 ## Inbox Scanning

--- a/terraform/twilio/README.md
+++ b/terraform/twilio/README.md
@@ -1,0 +1,19 @@
+# Twilio Configuration
+
+This directory contains Terraform code for provisioning the Twilio resources used by the app.
+
+The configuration expects your existing Twilio account credentials and will
+ensure the configured phone number exists. Outputs can be copied into `.env`.
+
+```bash
+terraform init
+terraform apply
+```
+
+Pass variables on the command line or in a `terraform.tfvars` file:
+
+```hcl
+account_sid   = "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+auth_token    = "your_auth_token"
+from_number   = "+15551234567"
+```

--- a/terraform/twilio/main.tf
+++ b/terraform/twilio/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.2"
+  required_providers {
+    twilio = {
+      source  = "twilio/twilio"
+      version = "~> 0.18"
+    }
+  }
+}
+
+provider "twilio" {
+  account_sid = var.account_sid
+  auth_token  = var.auth_token
+}
+
+resource "twilio_api_accounts_incoming_phone_numbers" "sms" {
+  phone_number  = var.from_number
+  friendly_name = var.friendly_name
+}

--- a/terraform/twilio/outputs.tf
+++ b/terraform/twilio/outputs.tf
@@ -1,0 +1,11 @@
+output "twilio_account_sid" {
+  value = var.account_sid
+}
+
+output "twilio_from_number" {
+  value = twilio_api_accounts_incoming_phone_numbers.sms.phone_number
+}
+
+output "twilio_phone_sid" {
+  value = twilio_api_accounts_incoming_phone_numbers.sms.sid
+}

--- a/terraform/twilio/variables.tf
+++ b/terraform/twilio/variables.tf
@@ -1,0 +1,21 @@
+variable "account_sid" {
+  type        = string
+  description = "Twilio account SID"
+}
+
+variable "auth_token" {
+  type        = string
+  description = "Twilio auth token"
+  sensitive   = true
+}
+
+variable "from_number" {
+  type        = string
+  description = "Phone number used to send messages"
+}
+
+variable "friendly_name" {
+  type        = string
+  description = "Label for the phone number"
+  default     = "photo-to-citation"
+}


### PR DESCRIPTION
## Summary
- configure a Terraform module to provision Twilio resources
- document how to run the module in the README
- ignore Terraform state files

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f4cccb28c832b904067bf1c82a6c4