### PR TITLE
Add GHCR photo-citation image build

### DIFF
--- a/.github/workflows/docker-build-photo-citation.yml
+++ b/.github/workflows/docker-build-photo-citation.yml
@@ -1,0 +1,25 @@
+name: Build Photo-Citation Docker Image
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          build-args: |
+            NEXT_PUBLIC_BASE_PATH=/photo-citation
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/photo-to-citation:photo-citation

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ FROM node:20-bookworm AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+ARG NEXT_PUBLIC_BASE_PATH=""
+ENV NEXT_PUBLIC_BASE_PATH=$NEXT_PUBLIC_BASE_PATH
 RUN npm run build && npm prune --production
 
 # Runtime image

--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ with prebuilt Node.js binaries.
 When commits land on `main`, the `docker-build.yml` workflow pushes the image to
 GitHub Container Registry as `ghcr.io/<OWNER>/photo-to-citation:latest`. Point
 Watchtower at this tag so your Synology NAS automatically pulls updates and redeploys.
+The `docker-build-photo-citation.yml` workflow publishes a second image tagged
+`photo-citation` for NAS deployments requiring `NEXT_PUBLIC_BASE_PATH=/photo-citation`.
 
 Run Traefik separately and it will use the labels in `docker-compose.example.yaml` to route traffic to `https://730op.synology.me/photo-citation`.
 

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   app:
     platform: "linux/amd64"
-    build: .
+    image: ghcr.io/<OWNER>/photo-to-citation:photo-citation
     env_file:
       - .env
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- build Dockerfile with configurable `NEXT_PUBLIC_BASE_PATH`
- publish a dedicated `photo-citation` tag
- document usage of the tag for NAS setups
- reference the registry image in docker-compose example

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684febf75478832bb8ce900121c4b939