### PR TITLE
Fix assets when deploying to subpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ The `docker-build-photo-citation.yml` workflow publishes a second image tagged
 
 Run Traefik separately and it will use the labels in `docker-compose.example.yaml` to route traffic to `https://730op.synology.me/photo-citation`.
 
-Set `NEXT_PUBLIC_BASE_PATH=/photo-citation` in your `.env` (or container environment) and remove the Traefik `stripprefix` middleware so the app serves correctly at that subpath.
+Set `NEXT_PUBLIC_BASE_PATH=/photo-citation` in your `.env` (or container environment) and remove the Traefik `stripprefix` middleware so the app serves correctly at that subpath. The `next.config.ts` file applies this base path to both `basePath` and `assetPrefix` so that the runtime bundle and assets load from `/photo-citation` as well.
 
 ## Marketing Website
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,11 @@
 import type { NextConfig } from "next";
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+const assetPrefix = basePath ? `${basePath}/` : undefined;
 
 const nextConfig: NextConfig = {
   basePath,
+  assetPrefix,
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary
- ensure Next.js serves bundles from subpath
- document assetPrefix behavior in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68500cc72620832b9cb09fa6a2b92425