### PR TITLE
Fix build-time type errors

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -4,7 +4,7 @@ import { DrizzleAdapter } from "@auth/drizzle-adapter";
 import NextAuth from "next-auth";
 import EmailProvider from "next-auth/providers/email";
 
-export const authOptions = {
+const authOptions = {
   adapter: DrizzleAdapter(orm),
   providers: [
     EmailProvider({
@@ -19,7 +19,7 @@ export const authOptions = {
     }),
   ],
   pages: { signIn: "/signin" },
-  session: { strategy: "database" },
+  session: { strategy: "database" as const },
   secret: process.env.NEXTAUTH_SECRET,
 };
 


### PR DESCRIPTION
## Summary
- remove extraneous export from NextAuth route file
- specify literal type for session strategy

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685163e7b0d8832b844330937d3a5773