### PR TITLE
Add case collaboration data model

### DIFF
--- a/migrations/0007_case_members.sql
+++ b/migrations/0007_case_members.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS case_members (
+  case_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  FOREIGN KEY(case_id) REFERENCES cases(id) ON DELETE CASCADE,
+  FOREIGN KEY(user_id) REFERENCES user(id) ON DELETE CASCADE,
+  CONSTRAINT case_members_pk PRIMARY KEY (case_id, user_id)
+);
+
+ALTER TABLE cases ADD COLUMN public INTEGER NOT NULL DEFAULT 0;

--- a/src/lib/caseMembers.ts
+++ b/src/lib/caseMembers.ts
@@ -1,0 +1,42 @@
+import { and, eq } from "drizzle-orm";
+import { orm } from "./orm";
+import { caseMembers } from "./schema";
+
+export type CaseMemberRole = "owner" | "collaborator";
+
+export function addCaseMember(
+  caseId: string,
+  userId: string,
+  role: CaseMemberRole,
+): void {
+  orm.insert(caseMembers).values({ caseId, userId, role }).run();
+}
+
+export function removeCaseMember(caseId: string, userId: string): void {
+  orm
+    .delete(caseMembers)
+    .where(and(eq(caseMembers.caseId, caseId), eq(caseMembers.userId, userId)))
+    .run();
+}
+
+export function listCaseMembers(caseId: string) {
+  return orm
+    .select()
+    .from(caseMembers)
+    .where(eq(caseMembers.caseId, caseId))
+    .all();
+}
+
+export function isCaseMember(
+  caseId: string,
+  userId: string,
+  role?: CaseMemberRole,
+): boolean {
+  const row = orm
+    .select()
+    .from(caseMembers)
+    .where(and(eq(caseMembers.caseId, caseId), eq(caseMembers.userId, userId)))
+    .get();
+  if (!row) return false;
+  return role ? row.role === role : true;
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -9,6 +9,7 @@ import {
 export const cases = sqliteTable("cases", {
   id: text("id").primaryKey(),
   data: text("data").notNull(),
+  public: integer("public", { mode: "boolean" }).notNull().default(false),
 });
 
 export const casePhotos = sqliteTable(
@@ -60,3 +61,15 @@ export const casbinRules = sqliteTable("casbin_rules", {
   v4: text("v4"),
   v5: text("v5"),
 });
+
+export const caseMembers = sqliteTable(
+  "case_members",
+  {
+    caseId: text("case_id").notNull(),
+    userId: text("user_id").notNull(),
+    role: text("role").notNull(),
+  },
+  (t) => ({
+    pk: primaryKey(t.caseId, t.userId),
+  }),
+);

--- a/test/caseMembers.test.ts
+++ b/test/caseMembers.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let dataDir: string;
+let caseStore: typeof import("../src/lib/caseStore");
+let members: typeof import("../src/lib/caseMembers");
+let orm: typeof import("../src/lib/orm").orm;
+let schema: typeof import("../src/lib/schema");
+
+beforeEach(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
+  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
+  vi.resetModules();
+  const db = await import("../src/lib/db");
+  await db.migrationsReady;
+  ({ orm } = await import("../src/lib/orm"));
+  schema = await import("../src/lib/schema");
+  orm.insert(schema.users).values({ id: "u1" }).run();
+  orm.insert(schema.users).values({ id: "u2" }).run();
+  caseStore = await import("../src/lib/caseStore");
+  members = await import("../src/lib/caseMembers");
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  vi.resetModules();
+  process.env.CASE_STORE_FILE = undefined;
+});
+
+describe("case members", () => {
+  it("assigns owner on create", () => {
+    const c = caseStore.createCase("/a.jpg", null, undefined, null, "u1");
+    expect(members.isCaseMember(c.id, "u1", "owner")).toBe(true);
+  });
+
+  it("adds and removes collaborator", () => {
+    const c = caseStore.createCase("/b.jpg", null, undefined, null, "u1");
+    members.addCaseMember(c.id, "u2", "collaborator");
+    let list = members.listCaseMembers(c.id);
+    expect(list).toHaveLength(2);
+    members.removeCaseMember(c.id, "u2");
+    list = members.listCaseMembers(c.id);
+    expect(list.some((m) => m.userId === "u2")).toBe(false);
+  });
+
+  it("stores public flag", () => {
+    const c = caseStore.createCase(
+      "/c.jpg",
+      null,
+      undefined,
+      null,
+      undefined,
+      true,
+    );
+    const loaded = caseStore.getCase(c.id);
+    expect(loaded?.public).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- implement migration for case_members table and public column on cases
- expose new tables in schema
- support collaborators in caseStore and new caseMembers helper
- cover case membership with unit tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68517089114c832bbe0f37ee4dd6ac5b