### PR TITLE
Add super admin env guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,8 @@ SMTP_PASS=
 SMTP_FROM=
 # Route all mail here instead of recipients
 MOCK_EMAIL_TO=
+# User promoted to super admin on first sign in
+SUPER_ADMIN_EMAIL=
 
 # JSON data file locations
 CASE_STORE_FILE=

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ npm run format
 
 Open [http://localhost:3000](http://localhost:3000) to view the app.
 
+## Authentication
+
+Copy `.env.example` to `.env` and set `SUPER_ADMIN_EMAIL` to automatically
+promote that user to the `superadmin` role on their first sign in. When the
+variable is omitted, the very first registered user becomes the super admin.
+
 ## Generating Zod Schemas
 
 When interfaces in `src/lib` change, update the runtime schemas and verify the output with:


### PR DESCRIPTION
## Summary
- document `SUPER_ADMIN_EMAIL` env in example file
- describe super admin promotion in new Authentication section of README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851dcf0abdc832ba99a054bf8af3c1b