### PR TITLE
Fix type errors in API route handlers

### DIFF
--- a/src/app/api/cases/[id]/override/route.ts
+++ b/src/app/api/cases/[id]/override/route.ts
@@ -1,13 +1,12 @@
 import { withAuthorization } from "@/lib/authz";
 import { getCase, setCaseAnalysisOverrides } from "@/lib/caseStore";
-import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 export const PUT = withAuthorization(
   "cases",
   "update",
   async (
-    req: NextRequest,
+    req: Request,
     {
       params,
     }: {
@@ -30,7 +29,7 @@ export const DELETE = withAuthorization(
   "cases",
   "update",
   async (
-    _req: NextRequest,
+    _req: Request,
     {
       params,
     }: {

--- a/src/app/api/cases/[id]/photos/route.ts
+++ b/src/app/api/cases/[id]/photos/route.ts
@@ -9,14 +9,13 @@ import {
   removeCasePhoto,
   updateCase,
 } from "@/lib/caseStore";
-import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 export const DELETE = withAuthorization(
   "cases",
   "update",
   async (
-    req: NextRequest,
+    req: Request,
     {
       params,
     }: {
@@ -40,7 +39,7 @@ export const POST = withAuthorization(
   "cases",
   "update",
   async (
-    req: NextRequest,
+    req: Request,
     {
       params,
     }: {

--- a/src/app/api/cases/[id]/thread-images/route.ts
+++ b/src/app/api/cases/[id]/thread-images/route.ts
@@ -4,14 +4,13 @@ import path from "node:path";
 import { withAuthorization } from "@/lib/authz";
 import { addCaseThreadImage, getCase } from "@/lib/caseStore";
 import { ocrPaperwork } from "@/lib/openai";
-import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 export const POST = withAuthorization(
   "cases",
   "update",
   async (
-    req: NextRequest,
+    req: Request,
     {
       params,
     }: {

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -6,12 +6,12 @@ import { analyzeCaseInBackground } from "@/lib/caseAnalysis";
 import { fetchCaseLocationInBackground } from "@/lib/caseLocation";
 import { addCasePhoto, createCase, getCase, updateCase } from "@/lib/caseStore";
 import { extractGps, extractTimestamp } from "@/lib/exif";
-import { type NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
 export const POST = withAuthorization(
   "upload",
   "create",
-  async (req: NextRequest) => {
+  async (req: Request) => {
     const form = await req.formData();
     const file = form.get("photo") as File | null;
     const clientId = form.get("caseId") as string | null;


### PR DESCRIPTION
## Summary
- use the global `Request` type for API handler parameters

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6851f6ba972c832bae0bb6de68412362