### PR TITLE
Add public cases API

### DIFF
--- a/migrations/0009_anonymous_public_cases.sql
+++ b/migrations/0009_anonymous_public_cases.sql
@@ -1,0 +1,2 @@
+INSERT INTO casbin_rules (ptype, v0, v1, v2) VALUES
+  ('p', 'anonymous', 'public_cases', 'read');

--- a/src/app/api/public/cases/[id]/route.ts
+++ b/src/app/api/public/cases/[id]/route.ts
@@ -1,0 +1,21 @@
+import { authorize } from "@/lib/authz";
+import { getCase } from "@/lib/caseStore";
+import { NextResponse } from "next/server";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!(await authorize("anonymous", "public_cases", "read"))) {
+    return new Response(null, { status: 403 });
+  }
+  const { id } = await params;
+  const c = getCase(id);
+  if (!c) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (!c.public) {
+    return new Response(null, { status: 403 });
+  }
+  return NextResponse.json(c);
+}

--- a/test/publicCases.test.ts
+++ b/test/publicCases.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let dataDir: string;
+let caseStore: typeof import("../src/lib/caseStore");
+
+beforeEach(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
+  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
+  vi.resetModules();
+  const db = await import("../src/lib/db");
+  await db.migrationsReady;
+  caseStore = await import("../src/lib/caseStore");
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  vi.resetModules();
+  process.env.CASE_STORE_FILE = undefined;
+});
+
+describe("public cases API", () => {
+  it("returns a public case", async () => {
+    const c = caseStore.createCase(
+      "/a.jpg",
+      null,
+      undefined,
+      null,
+      undefined,
+      true,
+    );
+    const mod = await import("../src/app/api/public/cases/[id]/route");
+    const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({ id: c.id }),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.id).toBe(c.id);
+  });
+
+  it("rejects private cases", async () => {
+    const c = caseStore.createCase("/b.jpg", null);
+    const mod = await import("../src/app/api/public/cases/[id]/route");
+    const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({ id: c.id }),
+    });
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- expose `/api/public/cases/[id]` for unauthenticated reads
- migrate in a new Casbin rule for anonymous read access
- test that only public cases are returned

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851f9dc8d08832bb66cd16db7ba4906