### PR TITLE
Add admin management features

### DIFF
--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -1,0 +1,109 @@
+"use client";
+import { apiFetch } from "@/apiClient";
+import { useState } from "react";
+
+export interface UserRecord {
+  id: string;
+  email: string | null;
+  name: string | null;
+  role: string;
+}
+
+export interface CasbinRule {
+  ptype: string;
+  v0?: string | null;
+  v1?: string | null;
+  v2?: string | null;
+  v3?: string | null;
+  v4?: string | null;
+  v5?: string | null;
+}
+
+export default function AdminPageClient({
+  initialUsers,
+  initialRules,
+}: {
+  initialUsers: UserRecord[];
+  initialRules: CasbinRule[];
+}) {
+  const [users, setUsers] = useState(initialUsers);
+  const [rules, setRules] = useState(initialRules);
+  const [inviteEmail, setInviteEmail] = useState("");
+
+  async function refreshUsers() {
+    const res = await apiFetch("/api/users");
+    if (res.ok) setUsers(await res.json());
+  }
+
+  async function invite() {
+    await apiFetch("/api/users/invite", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: inviteEmail }),
+    });
+    setInviteEmail("");
+    refreshUsers();
+  }
+
+  async function disable(id: string) {
+    await apiFetch(`/api/users/${id}/disable`, { method: "PUT" });
+    refreshUsers();
+  }
+
+  async function remove(id: string) {
+    await apiFetch(`/api/users/${id}`, { method: "DELETE" });
+    refreshUsers();
+  }
+
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">Users</h1>
+      <div className="mb-4 flex gap-2">
+        <input
+          type="email"
+          value={inviteEmail}
+          onChange={(e) => setInviteEmail(e.target.value)}
+          className="border rounded p-1 bg-white dark:bg-gray-900"
+        />
+        <button
+          type="button"
+          onClick={invite}
+          className="bg-blue-600 text-white px-2 py-1 rounded"
+        >
+          Invite
+        </button>
+      </div>
+      <ul className="grid gap-2">
+        {users.map((u) => (
+          <li key={u.id} className="flex items-center gap-2">
+            <span className="flex-1">{`${u.email ?? u.id} (${u.role})`}</span>
+            {u.role !== "disabled" && (
+              <button
+                type="button"
+                onClick={() => disable(u.id)}
+                className="bg-yellow-500 text-white px-2 py-1 rounded"
+              >
+                Disable
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => remove(u.id)}
+              className="bg-red-500 text-white px-2 py-1 rounded"
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+      <h1 className="text-xl font-bold my-4">Casbin Rules</h1>
+      <ul className="grid gap-1">
+        {rules.map((r) => (
+          <li key={`${r.ptype}-${r.v0}-${r.v1}-${r.v2}`}>
+            {r.ptype}, {r.v0 ?? ""}, {r.v1 ?? ""}, {r.v2 ?? ""}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import AdminPageClient from "../AdminPageClient";
+
+const users = [{ id: "1", email: "a@example.com", name: null, role: "admin" }];
+const rules = [{ ptype: "p", v0: "admin", v1: "users", v2: "read" }];
+
+describe("AdminPageClient", () => {
+  it("renders users and rules", () => {
+    render(<AdminPageClient initialUsers={users} initialRules={rules} />);
+    expect(screen.getByText("a@example.com (admin)")).toBeInTheDocument();
+    expect(screen.getByText(/p, admin, users/)).toBeInTheDocument();
+  });
+});

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,10 @@
+import { getCasbinRules, listUsers } from "@/lib/adminStore";
+import AdminPageClient from "./AdminPageClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminPage() {
+  const users = listUsers();
+  const rules = getCasbinRules();
+  return <AdminPageClient initialUsers={users} initialRules={rules} />;
+}

--- a/src/app/api/casbin-rules/route.ts
+++ b/src/app/api/casbin-rules/route.ts
@@ -1,0 +1,21 @@
+import {
+  type CasbinRule,
+  getCasbinRules,
+  replaceCasbinRules,
+} from "@/lib/adminStore";
+import { withAuthorization } from "@/lib/authz";
+import { NextResponse } from "next/server";
+
+export const GET = withAuthorization("admin", "read", async () =>
+  NextResponse.json(getCasbinRules()),
+);
+
+export const PUT = withAuthorization(
+  "admin",
+  "update",
+  async (req: Request) => {
+    const rules = (await req.json()) as CasbinRule[];
+    const updated = replaceCasbinRules(rules);
+    return NextResponse.json(updated);
+  },
+);

--- a/src/app/api/users/[id]/disable/route.ts
+++ b/src/app/api/users/[id]/disable/route.ts
@@ -1,0 +1,13 @@
+import { disableUser } from "@/lib/adminStore";
+import { withAuthorization } from "@/lib/authz";
+import { NextResponse } from "next/server";
+
+export const PUT = withAuthorization(
+  "admin",
+  "update",
+  async (_req: Request, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    disableUser(id);
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,0 +1,13 @@
+import { deleteUser } from "@/lib/adminStore";
+import { withAuthorization } from "@/lib/authz";
+import { NextResponse } from "next/server";
+
+export const DELETE = withAuthorization(
+  "admin",
+  "delete",
+  async (_req: Request, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    deleteUser(id);
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/users/invite/route.ts
+++ b/src/app/api/users/invite/route.ts
@@ -1,0 +1,13 @@
+import { inviteUser } from "@/lib/adminStore";
+import { withAuthorization } from "@/lib/authz";
+import { NextResponse } from "next/server";
+
+export const POST = withAuthorization(
+  "admin",
+  "create",
+  async (req: Request) => {
+    const { email } = (await req.json()) as { email: string };
+    const user = inviteUser(email);
+    return NextResponse.json(user);
+  },
+);

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,8 @@
+import { listUsers } from "@/lib/adminStore";
+import { withAuthorization } from "@/lib/authz";
+import { NextResponse } from "next/server";
+
+export const GET = withAuthorization("admin", "read", async () => {
+  const users = listUsers();
+  return NextResponse.json(users);
+});

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -62,6 +62,15 @@ export default function NavBar() {
         >
           Map View
         </Link>
+        {session?.user?.role === "admin" ||
+        session?.user?.role === "superadmin" ? (
+          <Link
+            href="/admin"
+            className="hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            Admin
+          </Link>
+        ) : null}
         <Link
           href="/settings"
           className="hover:text-gray-600 dark:hover:text-gray-300"

--- a/src/lib/adminStore.ts
+++ b/src/lib/adminStore.ts
@@ -1,0 +1,49 @@
+import crypto from "node:crypto";
+import { eq } from "drizzle-orm";
+import { orm } from "./orm";
+import { casbinRules, users } from "./schema";
+
+export interface UserRecord {
+  id: string;
+  name: string | null;
+  email: string | null;
+  role: string;
+}
+
+export function listUsers(): UserRecord[] {
+  return orm.select().from(users).all();
+}
+
+export function inviteUser(email: string, role = "user"): UserRecord {
+  const id = crypto.randomUUID();
+  orm.insert(users).values({ id, email, role }).run();
+  return { id, name: null, email, role };
+}
+
+export function disableUser(id: string): void {
+  orm.update(users).set({ role: "disabled" }).where(eq(users.id, id)).run();
+}
+
+export function deleteUser(id: string): void {
+  orm.delete(users).where(eq(users.id, id)).run();
+}
+
+export interface CasbinRule {
+  ptype: string;
+  v0?: string | null;
+  v1?: string | null;
+  v2?: string | null;
+  v3?: string | null;
+  v4?: string | null;
+  v5?: string | null;
+}
+
+export function getCasbinRules(): CasbinRule[] {
+  return orm.select().from(casbinRules).all();
+}
+
+export function replaceCasbinRules(rules: CasbinRule[]): CasbinRule[] {
+  orm.delete(casbinRules).run();
+  if (rules.length) orm.insert(casbinRules).values(rules).run();
+  return getCasbinRules();
+}


### PR DESCRIPTION
## Summary
- add simple admin store for users and casbin rules
- implement API routes for user and policy management
- scaffold admin page with client component
- link to Admin in NavBar
- test AdminPageClient component

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: Unexpected end of JSON input)*

------
https://chatgpt.com/codex/tasks/task_e_6851f9e85868832bbb180ab83a5f7636