### PR TITLE
Add role-based UI controls

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -23,6 +23,7 @@ import DebugWrapper from "../../components/DebugWrapper";
 import EditableText from "../../components/EditableText";
 import ImageHighlights from "../../components/ImageHighlights";
 import useCloseOnOutsideClick from "../../useCloseOnOutsideClick";
+import { useSession } from "../../useSession";
 import useDragReset from "../useDragReset";
 
 function buildThreads(c: Case): SentEmail[] {
@@ -71,6 +72,9 @@ export default function ClientCasePage({
   const [vin, setVin] = useState<string>(
     initialCase ? getCaseVin(initialCase) || "" : "",
   );
+  const { data: session } = useSession();
+  const isAdmin =
+    session?.user?.role === "admin" || session?.user?.role === "superadmin";
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [dragging, setDragging] = useState(false);
@@ -394,6 +398,7 @@ export default function ClientCasePage({
               disabled={!violationIdentified}
               hasOwner={Boolean(ownerContact)}
               progress={progress}
+              canDelete={isAdmin}
             />
           </div>
         }

--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -6,6 +6,7 @@ import type { ReportModule } from "@/lib/reportModules";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import { useSession } from "../../../useSession";
 
 export default function DraftEditor({
   initialDraft,
@@ -34,6 +35,9 @@ export default function DraftEditor({
   >({});
   const [threadUrl, setThreadUrl] = useState<string | null>(null);
   const router = useRouter();
+  const { data: session } = useSession();
+  const isAdmin =
+    session?.user?.role === "admin" || session?.user?.role === "superadmin";
 
   useEffect(() => {
     if (initialDraft) {
@@ -175,7 +179,7 @@ export default function DraftEditor({
       <button
         type="button"
         onClick={sendEmail}
-        disabled={sending}
+        disabled={!isAdmin || sending}
         className="bg-blue-500 text-white px-2 py-1 rounded disabled:opacity-50"
       >
         {sending ? "Sending..." : "Send"}

--- a/src/app/cases/__tests__/dragOverlayPosition.test.tsx
+++ b/src/app/cases/__tests__/dragOverlayPosition.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { Case } from "../../../lib/caseStore";
 import ClientCasesPage from "../ClientCasesPage";
 import ClientCasePage from "../[id]/ClientCasePage";
+vi.mock("../../useSession", () => ({ useSession: () => ({ data: null }) }));
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({}),

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -12,11 +12,13 @@ export default function CaseToolbar({
   disabled = false,
   hasOwner = false,
   progress,
+  canDelete = false,
 }: {
   caseId: string;
   disabled?: boolean;
   hasOwner?: boolean;
   progress?: LlmProgress | null;
+  canDelete?: boolean;
 }) {
   const reqText = progress
     ? progress.stage === "upload"
@@ -121,24 +123,26 @@ export default function CaseToolbar({
                 ) : null}
               </>
             )}
-            <button
-              type="button"
-              onClick={async () => {
-                const code = Math.random().toString(36).slice(2, 6);
-                const input = prompt(
-                  `Type '${code}' to confirm deleting this case.`,
-                );
-                if (input === code) {
-                  await apiFetch(`/api/cases/${caseId}`, {
-                    method: "DELETE",
-                  });
-                  window.location.href = withBasePath("/cases");
-                }
-              }}
-              className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
-            >
-              Delete Case
-            </button>
+            {canDelete ? (
+              <button
+                type="button"
+                onClick={async () => {
+                  const code = Math.random().toString(36).slice(2, 6);
+                  const input = prompt(
+                    `Type '${code}' to confirm deleting this case.`,
+                  );
+                  if (input === code) {
+                    await apiFetch(`/api/cases/${caseId}`, {
+                      method: "DELETE",
+                    });
+                    window.location.href = withBasePath("/cases");
+                  }
+                }}
+                className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+              >
+                Delete Case
+              </button>
+            ) : null}
           </div>
         </details>
       </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { apiFetch } from "@/apiClient";
 import { useEffect, useState } from "react";
+import { useSession } from "../useSession";
 
 interface VinSourceStatus {
   id: string;
@@ -19,6 +20,9 @@ export default function SettingsPage() {
   const [mailProviders, setMailProviders] = useState<SnailMailProviderStatus[]>(
     [],
   );
+  const { data: session } = useSession();
+  const isAdmin =
+    session?.user?.role === "admin" || session?.user?.role === "superadmin";
 
   useEffect(() => {
     apiFetch("/api/vin-sources")
@@ -59,6 +63,7 @@ export default function SettingsPage() {
             <button
               type="button"
               onClick={() => toggle(s.id, !s.enabled)}
+              disabled={!isAdmin}
               className={
                 s.enabled
                   ? "bg-green-500 text-white px-2 py-1 rounded"
@@ -85,6 +90,7 @@ export default function SettingsPage() {
               <button
                 type="button"
                 onClick={() => activateProvider(p.id)}
+                disabled={!isAdmin}
                 className="bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
               >
                 Activate

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type TestServer, startServer } from "./startServer";
+
+let server: TestServer;
+let cookie = "";
+
+async function api(path: string, opts: RequestInit = {}) {
+  const res = await fetch(`${server.url}${path}`, {
+    ...opts,
+    headers: { ...(opts.headers || {}), cookie },
+    redirect: "manual",
+  });
+  const set = res.headers.get("set-cookie");
+  if (set) cookie = set.split(";")[0];
+  return res;
+}
+
+async function signIn(email: string) {
+  const csrf = await api("/api/auth/csrf").then((r) => r.json());
+  await api("/api/auth/signin/email", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      csrfToken: csrf.csrfToken,
+      email,
+      callbackUrl: server.url,
+    }),
+  });
+  const ver = await api("/api/test/verification-url").then((r) => r.json());
+  await api(
+    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
+  );
+}
+
+async function signOut() {
+  const csrf = await api("/api/auth/csrf").then((r) => r.json());
+  await api("/api/auth/signout", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      csrfToken: csrf.csrfToken,
+      callbackUrl: server.url,
+    }),
+  });
+}
+
+async function createCase(): Promise<string> {
+  const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+  const form = new FormData();
+  form.append("photo", file);
+  const res = await api("/api/upload", { method: "POST", body: form });
+  const data = (await res.json()) as { caseId: string };
+  return data.caseId;
+}
+
+beforeAll(async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
+  server = await startServer(3011, {
+    NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
+    SMTP_FROM: "test@example.com",
+    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.close();
+}, 120000);
+
+describe("permissions", () => {
+  it("hides admin actions for regular users", async () => {
+    await signIn("admin@example.com");
+    await signOut();
+    await signIn("user@example.com");
+
+    const id = await createCase();
+    const casePage = await api(`/cases/${id}`).then((r) => r.text());
+    expect(casePage).not.toContain("Delete Case");
+    const draft = await api(`/cases/${id}/draft`).then((r) => r.text());
+    expect(draft).toMatch(/disabled/);
+  }, 30000);
+
+  it("shows admin actions for admins", async () => {
+    cookie = "";
+    await signIn("admin@example.com");
+    const id = await createCase();
+    const casePage = await api(`/cases/${id}`).then((r) => r.text());
+    expect(casePage).toContain("Delete Case");
+    const draft = await api(`/cases/${id}/draft`).then((r) => r.text());
+    expect(draft).not.toMatch(/disabled/);
+  }, 30000);
+});


### PR DESCRIPTION
## Summary
- check user role in case and settings pages
- hide delete case option and disable sending when user lacks permission
- disable settings updates for regular users
- add integration test verifying UI for admin vs regular user

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: Unexpected end of JSON input)*

------
https://chatgpt.com/codex/tasks/task_e_6851f9ecadbc832bb603c07f189b6f25