### PR TITLE
Fix tests using verification URL

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,4 @@
+import { writeFile } from "node:fs/promises";
 import { authAdapter, seedSuperAdmin } from "@/lib/auth";
 import { sendEmail } from "@/lib/email";
 import NextAuth, {
@@ -15,8 +16,9 @@ const authOptions: NextAuthOptions = {
   providers: [
     EmailProvider({
       async sendVerificationRequest({ identifier, url }) {
-        if (process.env.NODE_ENV === "test") {
+        if (process.env.TEST_APIS) {
           (global as Record<string, unknown>).verificationUrl = url;
+          await writeFile("/tmp/verification-url.txt", url);
           return;
         }
         await sendEmail({ to: identifier, subject: "Sign in", body: url });

--- a/src/app/api/test/verification-url/route.ts
+++ b/src/app/api/test/verification-url/route.ts
@@ -1,9 +1,13 @@
+import { readFile } from "node:fs/promises";
 import { NextResponse } from "next/server";
 
 export async function GET() {
-  if (process.env.NODE_ENV !== "test") {
+  if (!process.env.TEST_APIS) {
     return new NextResponse(null, { status: 404 });
   }
-  const url = (global as Record<string, unknown>).verificationUrl;
+  let url: string | undefined;
+  try {
+    url = await readFile("/tmp/verification-url.txt", "utf8");
+  } catch {}
   return NextResponse.json({ url });
 }

--- a/test/e2e/startServer.ts
+++ b/test/e2e/startServer.ts
@@ -24,7 +24,13 @@ export async function startServer(
 ): Promise<TestServer> {
   const nextBin = path.join("node_modules", ".bin", "next");
   const proc = spawn(nextBin, ["dev", "-p", String(port)], {
-    env: { ...process.env, NEXT_TELEMETRY_DISABLED: "1", ...env, CI: "1" },
+    env: {
+      ...process.env,
+      NEXT_TELEMETRY_DISABLED: "1",
+      TEST_APIS: "1",
+      ...env,
+      CI: "1",
+    },
     stdio: ["ignore", "pipe", "pipe"],
   });
   let output = "";


### PR DESCRIPTION
## Summary
- expose test API flag when starting the dev server
- persist verification URL in a temp file during tests
- read verification URL from the file in the test-only endpoint

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: Cannot read property 'url' of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6851ff57d10c832b8cc4905718ee8da4