### PR TITLE
Fix TypeScript typecheck errors

### DIFF
--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
 import AdminPageClient from "../AdminPageClient";
 
 const users = [{ id: "1", email: "a@example.com", name: null, role: "admin" }];

--- a/src/app/api/users/[id]/disable/route.ts
+++ b/src/app/api/users/[id]/disable/route.ts
@@ -5,7 +5,15 @@ import { NextResponse } from "next/server";
 export const PUT = withAuthorization(
   "admin",
   "update",
-  async (_req: Request, { params }: { params: Promise<{ id: string }> }) => {
+  async (
+    _req: Request,
+    {
+      params,
+    }: {
+      params: Promise<{ id: string }>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
     const { id } = await params;
     disableUser(id);
     return NextResponse.json({ ok: true });

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -5,7 +5,15 @@ import { NextResponse } from "next/server";
 export const DELETE = withAuthorization(
   "admin",
   "delete",
-  async (_req: Request, { params }: { params: Promise<{ id: string }> }) => {
+  async (
+    _req: Request,
+    {
+      params,
+    }: {
+      params: Promise<{ id: string }>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
     const { id } = await params;
     deleteUser(id);
     return NextResponse.json({ ok: true });


### PR DESCRIPTION
## Summary
- import Vitest globals in AdminPageClient tests
- type API context to include session for user routes

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6852a5e560e0832ba4e2c3561452b70f