### PR TITLE
Protect admin page access

### DIFF
--- a/src/app/admin/__tests__/AdminPage.test.tsx
+++ b/src/app/admin/__tests__/AdminPage.test.tsx
@@ -1,0 +1,25 @@
+import { getServerSession } from "next-auth/next";
+import { describe, expect, it, vi } from "vitest";
+import AdminPage from "../page";
+
+vi.mock("next-auth/next", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("../api/auth/[...nextauth]/route", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/authz", () => ({
+  withAuthorization: (_o: string, _a: string, h: unknown) => h,
+}));
+
+it("returns 403 for non-admin", async () => {
+  (
+    getServerSession as unknown as { mockResolvedValue: (v: unknown) => void }
+  ).mockResolvedValue({
+    user: { role: "user" },
+  });
+  const res = (await AdminPage()) as Response;
+  expect(res.status).toBe(403);
+});

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,10 +1,29 @@
 import { getCasbinRules, listUsers } from "@/lib/adminStore";
+import { withAuthorization } from "@/lib/authz";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../api/auth/[...nextauth]/route";
 import AdminPageClient from "./AdminPageClient";
 
 export const dynamic = "force-dynamic";
 
+const handler = withAuthorization(
+  "admin",
+  "read",
+  async (
+    _req: Request,
+    { session }: { session?: { user?: { role?: string } } },
+  ) => {
+    const s = session ?? (await getServerSession(authOptions));
+    if (s?.user?.role !== "admin" && s?.user?.role !== "superadmin") {
+      return new Response(null, { status: 403 });
+    }
+    const users = listUsers();
+    const rules = getCasbinRules();
+    return <AdminPageClient initialUsers={users} initialRules={rules} />;
+  },
+);
+
 export default async function AdminPage() {
-  const users = listUsers();
-  const rules = getCasbinRules();
-  return <AdminPageClient initialUsers={users} initialRules={rules} />;
+  const session = await getServerSession(authOptions);
+  return handler(new Request("http://localhost"), { session });
 }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -11,7 +11,7 @@ import EmailProvider from "next-auth/providers/email";
 
 seedSuperAdmin().catch(() => {});
 
-const authOptions: NextAuthOptions = {
+export const authOptions: NextAuthOptions = {
   adapter: authAdapter() as Adapter,
   providers: [
     EmailProvider({

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -45,12 +45,9 @@ export async function authorize(
 
 export function withAuthorization<
   C extends { session?: { user?: { role?: string } } },
->(
-  obj: string,
-  act: string,
-  handler: (req: Request, ctx: C) => Promise<Response> | Response,
-) {
-  return async (req: Request, ctx: C) => {
+  R = Response,
+>(obj: string, act: string, handler: (req: Request, ctx: C) => Promise<R> | R) {
+  return async (req: Request, ctx: C): Promise<R | Response> => {
     const role = ctx.session?.user?.role ?? "user";
     if (!(await authorize(role, obj, act))) {
       return new Response(null, { status: 403 });


### PR DESCRIPTION
## Summary
- export `authOptions` for server session usage
- allow `withAuthorization` to wrap any return type
- gate admin page behind session role checks and authorization
- test admin page access control

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852a878e6fc832bb44a40c261fd463a