### PR TITLE
Implement user role updates for superadmins

### DIFF
--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -50,6 +50,15 @@ export default function AdminPageClient({
     refreshUsers();
   }
 
+  async function changeRole(id: string, role: string) {
+    await apiFetch(`/api/users/${id}/role`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role }),
+    });
+    refreshUsers();
+  }
+
   async function remove(id: string) {
     await apiFetch(`/api/users/${id}`, { method: "DELETE" });
     refreshUsers();
@@ -76,7 +85,17 @@ export default function AdminPageClient({
       <ul className="grid gap-2">
         {users.map((u) => (
           <li key={u.id} className="flex items-center gap-2">
-            <span className="flex-1">{`${u.email ?? u.id} (${u.role})`}</span>
+            <span className="flex-1">{u.email ?? u.id}</span>
+            <select
+              value={u.role}
+              onChange={(e) => changeRole(u.id, e.target.value)}
+              className="border rounded p-1 bg-white dark:bg-gray-900"
+            >
+              <option value="user">user</option>
+              <option value="admin">admin</option>
+              <option value="superadmin">superadmin</option>
+              <option value="disabled">disabled</option>
+            </select>
             {u.role !== "disabled" && (
               <button
                 type="button"

--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -8,7 +8,8 @@ const rules = [{ ptype: "p", v0: "admin", v1: "users", v2: "read" }];
 describe("AdminPageClient", () => {
   it("renders users and rules", () => {
     render(<AdminPageClient initialUsers={users} initialRules={rules} />);
-    expect(screen.getByText("a@example.com (admin)")).toBeInTheDocument();
+    expect(screen.getByText("a@example.com")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("admin")).toBeInTheDocument();
     expect(screen.getByText(/p, admin, users/)).toBeInTheDocument();
   });
 });

--- a/src/app/admin/__tests__/changeRoleRoute.test.ts
+++ b/src/app/admin/__tests__/changeRoleRoute.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let dataDir: string;
+let orm: typeof import("@/lib/orm").orm;
+let schema: typeof import("@/lib/schema");
+let eq: typeof import("drizzle-orm").eq;
+
+beforeEach(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
+  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
+  vi.resetModules();
+  const db = await import("@/lib/db");
+  await db.migrationsReady;
+  ({ orm } = await import("@/lib/orm"));
+  schema = await import("@/lib/schema");
+  ({ eq } = await import("drizzle-orm"));
+  orm.insert(schema.users).values({ id: "u1" }).run();
+  orm
+    .insert(schema.casbinRules)
+    .values({ ptype: "p", v0: "superadmin", v1: "admin", v2: "update" })
+    .run();
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  vi.resetModules();
+  process.env.CASE_STORE_FILE = undefined;
+});
+
+describe("change role route", () => {
+  it("allows superadmins", async () => {
+    const { PUT } = await import("../../api/users/[id]/role/route");
+    const res = await PUT(
+      new Request("http://test", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: "admin" }),
+      }),
+      {
+        params: Promise.resolve({ id: "u1" }),
+        session: { user: { role: "superadmin" } },
+      },
+    );
+    expect(res.status).toBe(200);
+    const row = orm
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, "u1"))
+      .get();
+    expect(row.role).toBe("admin");
+  });
+
+  it("rejects non-superadmins", async () => {
+    const { PUT } = await import("../../api/users/[id]/role/route");
+    const res = await PUT(
+      new Request("http://test", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: "admin" }),
+      }),
+      {
+        params: Promise.resolve({ id: "u1" }),
+        session: { user: { role: "admin" } },
+      },
+    );
+    expect(res.status).toBe(403);
+    const row = orm
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, "u1"))
+      .get();
+    expect(row.role).toBe("user");
+  });
+});

--- a/src/app/api/users/[id]/role/route.ts
+++ b/src/app/api/users/[id]/role/route.ts
@@ -1,0 +1,26 @@
+import { updateUserRole } from "@/lib/adminStore";
+import { withAuthorization } from "@/lib/authz";
+import { NextResponse } from "next/server";
+
+export const PUT = withAuthorization(
+  "admin",
+  "update",
+  async (
+    req: Request,
+    {
+      params,
+      session,
+    }: {
+      params: Promise<{ id: string }>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
+    if (session?.user?.role !== "superadmin") {
+      return new Response(null, { status: 403 });
+    }
+    const { id } = await params;
+    const { role } = (await req.json()) as { role: string };
+    updateUserRole(id, role);
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/lib/adminStore.ts
+++ b/src/lib/adminStore.ts
@@ -24,6 +24,10 @@ export function disableUser(id: string): void {
   orm.update(users).set({ role: "disabled" }).where(eq(users.id, id)).run();
 }
 
+export function updateUserRole(id: string, role: string): void {
+  orm.update(users).set({ role }).where(eq(users.id, id)).run();
+}
+
 export function deleteUser(id: string): void {
   orm.delete(users).where(eq(users.id, id)).run();
 }


### PR DESCRIPTION
## Summary
- enable admins to change a user's role via `updateUserRole`
- API endpoint `/api/users/[id]/role` with superadmin guard
- allow role changes in Admin page client
- adjust admin client test for new UI
- test that only superadmins can change roles

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852a8801a74832bbeb9ba29027a7287