### PR TITLE
Update casbin rules API authorization

### DIFF
--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -1,5 +1,12 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../useSession", () => ({
+  useSession: vi.fn(() => ({ data: { user: { role: "admin" } } })),
+}));
+
+import { useSession } from "../../useSession";
+
 import AdminPageClient from "../AdminPageClient";
 
 const users = [{ id: "1", email: "a@example.com", name: null, role: "admin" }];
@@ -10,5 +17,14 @@ describe("AdminPageClient", () => {
     render(<AdminPageClient initialUsers={users} initialRules={rules} />);
     expect(screen.getByText("a@example.com (admin)")).toBeInTheDocument();
     expect(screen.getByText(/p, admin, users/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save rules/i })).toBeDisabled();
+  });
+
+  it("enables saving for superadmins", async () => {
+    useSession.mockReturnValueOnce({ data: { user: { role: "superadmin" } } });
+    render(<AdminPageClient initialUsers={users} initialRules={rules} />);
+    expect(
+      screen.getByRole("button", { name: /save rules/i }),
+    ).not.toBeDisabled();
   });
 });

--- a/src/app/api/casbin-rules/route.ts
+++ b/src/app/api/casbin-rules/route.ts
@@ -11,7 +11,7 @@ export const GET = withAuthorization("admin", "read", async () =>
 );
 
 export const PUT = withAuthorization(
-  "admin",
+  "superadmin",
   "update",
   async (req: Request) => {
     const rules = (await req.json()) as CasbinRule[];

--- a/test/casbinRulesRoute.test.ts
+++ b/test/casbinRulesRoute.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let dataDir: string;
+
+beforeEach(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
+  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
+  vi.resetModules();
+  const db = await import("../src/lib/db");
+  await db.migrationsReady;
+  const { orm } = await import("../src/lib/orm");
+  const { casbinRules } = await import("../src/lib/schema");
+  orm
+    .insert(casbinRules)
+    .values([
+      { ptype: "p", v0: "admin", v1: "admin", v2: "read" },
+      { ptype: "p", v0: "superadmin", v1: "superadmin", v2: "update" },
+    ])
+    .run();
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  vi.resetModules();
+  process.env.CASE_STORE_FILE = undefined;
+});
+
+describe("casbin rules API", () => {
+  it("allows admins to read", async () => {
+    const mod = await import("../src/app/api/casbin-rules/route");
+    const res = await mod.GET(new Request("http://test"), {
+      session: { user: { role: "admin" } },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects regular users", async () => {
+    const mod = await import("../src/app/api/casbin-rules/route");
+    const res = await mod.GET(new Request("http://test"), {
+      session: { user: { role: "user" } },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("allows only superadmin to update", async () => {
+    const mod = await import("../src/app/api/casbin-rules/route");
+    const req = new Request("http://test", {
+      method: "PUT",
+      body: JSON.stringify([]),
+    });
+    const ok = await mod.PUT(req, {
+      session: { user: { role: "superadmin" } },
+    });
+    expect(ok.status).toBe(200);
+    const fail = await mod.PUT(req, {
+      session: { user: { role: "admin" } },
+    });
+    expect(fail.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- restrict rules updates to superadmin role
- provide a basic rule editor on the admin page
- add casbin rules route tests
- ensure editor button behaviour is tested

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852a885de68832b9cefcf0481179ac9