### PR TITLE
Restrict case modifications to members

### DIFF
--- a/migrations/0008_seed_casbin_rules.sql
+++ b/migrations/0008_seed_casbin_rules.sql
@@ -1,7 +1,5 @@
 INSERT INTO casbin_rules (ptype, v0, v1, v2) VALUES
   ('p', 'user', 'cases', 'read'),
-  ('p', 'user', 'cases', 'update'),
-  ('p', 'user', 'cases', 'delete'),
   ('p', 'user', 'upload', 'create'),
   ('g', 'admin', 'user', NULL),
   ('g', 'superadmin', 'admin', NULL);

--- a/src/app/api/cases/[id]/cancel-analysis/route.ts
+++ b/src/app/api/cases/[id]/cancel-analysis/route.ts
@@ -1,21 +1,32 @@
 import { withAuthorization } from "@/lib/authz";
 import { cancelCaseAnalysis } from "@/lib/caseAnalysis";
+import { isCaseMember } from "@/lib/caseMembers";
 import { getCase } from "@/lib/caseStore";
 import { NextResponse } from "next/server";
 
 export const POST = withAuthorization(
   "cases",
-  "update",
+  "read",
   async (
     _req: Request,
     {
       params,
+      session,
     }: {
       params: Promise<{ id: string }>;
-      session?: { user?: { role?: string } };
+      session?: { user?: { id?: string; role?: string } };
     },
   ) => {
     const { id } = await params;
+    const userId = session?.user?.id;
+    const role = session?.user?.role ?? "user";
+    if (
+      role !== "admin" &&
+      role !== "superadmin" &&
+      (!userId || !isCaseMember(id, userId))
+    ) {
+      return new Response(null, { status: 403 });
+    }
     const ok = cancelCaseAnalysis(id);
     const c = getCase(id);
     if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/src/app/api/cases/[id]/invite/route.ts
+++ b/src/app/api/cases/[id]/invite/route.ts
@@ -5,7 +5,7 @@ import { NextResponse } from "next/server";
 
 export const POST = withAuthorization(
   "cases",
-  "update",
+  "read",
   async (
     req: Request,
     {

--- a/src/app/api/cases/[id]/members/[uid]/route.ts
+++ b/src/app/api/cases/[id]/members/[uid]/route.ts
@@ -5,7 +5,7 @@ import { NextResponse } from "next/server";
 
 export const DELETE = withAuthorization(
   "cases",
-  "update",
+  "read",
   async (
     _req: Request,
     {

--- a/src/app/api/cases/[id]/override/route.ts
+++ b/src/app/api/cases/[id]/override/route.ts
@@ -1,20 +1,31 @@
 import { withAuthorization } from "@/lib/authz";
+import { isCaseMember } from "@/lib/caseMembers";
 import { getCase, setCaseAnalysisOverrides } from "@/lib/caseStore";
 import { NextResponse } from "next/server";
 
 export const PUT = withAuthorization(
   "cases",
-  "update",
+  "read",
   async (
     req: Request,
     {
       params,
+      session,
     }: {
       params: Promise<{ id: string }>;
-      session?: { user?: { role?: string } };
+      session?: { user?: { id?: string; role?: string } };
     },
   ) => {
     const { id } = await params;
+    const userId = session?.user?.id;
+    const role = session?.user?.role ?? "user";
+    if (
+      role !== "admin" &&
+      role !== "superadmin" &&
+      (!userId || !isCaseMember(id, userId))
+    ) {
+      return new Response(null, { status: 403 });
+    }
     const overrides = (await req.json()) as Record<string, unknown>;
     const updated = setCaseAnalysisOverrides(id, overrides);
     if (!updated) {
@@ -27,17 +38,27 @@ export const PUT = withAuthorization(
 
 export const DELETE = withAuthorization(
   "cases",
-  "update",
+  "read",
   async (
     _req: Request,
     {
       params,
+      session,
     }: {
       params: Promise<{ id: string }>;
-      session?: { user?: { role?: string } };
+      session?: { user?: { id?: string; role?: string } };
     },
   ) => {
     const { id } = await params;
+    const userId = session?.user?.id;
+    const role = session?.user?.role ?? "user";
+    if (
+      role !== "admin" &&
+      role !== "superadmin" &&
+      (!userId || !isCaseMember(id, userId))
+    ) {
+      return new Response(null, { status: 403 });
+    }
     const updated = setCaseAnalysisOverrides(id, null);
     if (!updated) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/src/app/api/cases/[id]/reanalyze/route.ts
+++ b/src/app/api/cases/[id]/reanalyze/route.ts
@@ -3,22 +3,33 @@ import {
   analyzeCaseInBackground,
   cancelCaseAnalysis,
 } from "@/lib/caseAnalysis";
+import { isCaseMember } from "@/lib/caseMembers";
 import { getCase, updateCase } from "@/lib/caseStore";
 import { NextResponse } from "next/server";
 
 export const POST = withAuthorization(
   "cases",
-  "update",
+  "read",
   async (
     _req: Request,
     {
       params,
+      session,
     }: {
       params: Promise<{ id: string }>;
-      session?: { user?: { role?: string } };
+      session?: { user?: { id?: string; role?: string } };
     },
   ) => {
     const { id } = await params;
+    const userId = session?.user?.id;
+    const role = session?.user?.role ?? "user";
+    if (
+      role !== "admin" &&
+      role !== "superadmin" &&
+      (!userId || !isCaseMember(id, userId))
+    ) {
+      return new Response(null, { status: 403 });
+    }
     const c = getCase(id);
     if (!c) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/src/app/api/cases/[id]/report/route.ts
+++ b/src/app/api/cases/[id]/report/route.ts
@@ -1,4 +1,5 @@
 import { withAuthorization } from "@/lib/authz";
+import { isCaseMember } from "@/lib/caseMembers";
 import { draftEmail } from "@/lib/caseReport";
 import { addCaseEmail, getCase } from "@/lib/caseStore";
 import { sendSnailMail } from "@/lib/contactMethods";
@@ -13,12 +14,22 @@ export const GET = withAuthorization(
     _req: Request,
     {
       params,
+      session,
     }: {
       params: Promise<{ id: string }>;
-      session?: { user?: { role?: string } };
+      session?: { user?: { id?: string; role?: string } };
     },
   ) => {
     const { id } = await params;
+    const userId = session?.user?.id;
+    const role = session?.user?.role ?? "user";
+    if (
+      role !== "admin" &&
+      role !== "superadmin" &&
+      (!userId || !isCaseMember(id, userId))
+    ) {
+      return new Response(null, { status: 403 });
+    }
     const c = getCase(id);
     if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
     const reportModule = reportModules["oak-park"];
@@ -33,7 +44,7 @@ export const GET = withAuthorization(
 
 export const POST = withAuthorization(
   "cases",
-  "update",
+  "read",
   async (
     req: Request,
     {

--- a/src/app/api/cases/[id]/thread-images/route.ts
+++ b/src/app/api/cases/[id]/thread-images/route.ts
@@ -2,23 +2,34 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { withAuthorization } from "@/lib/authz";
+import { isCaseMember } from "@/lib/caseMembers";
 import { addCaseThreadImage, getCase } from "@/lib/caseStore";
 import { ocrPaperwork } from "@/lib/openai";
 import { NextResponse } from "next/server";
 
 export const POST = withAuthorization(
   "cases",
-  "update",
+  "read",
   async (
     req: Request,
     {
       params,
+      session,
     }: {
       params: Promise<{ id: string }>;
-      session?: { user?: { role?: string } };
+      session?: { user?: { id?: string; role?: string } };
     },
   ) => {
     const { id } = await params;
+    const userId = session?.user?.id;
+    const role = session?.user?.role ?? "user";
+    if (
+      role !== "admin" &&
+      role !== "superadmin" &&
+      (!userId || !isCaseMember(id, userId))
+    ) {
+      return new Response(null, { status: 403 });
+    }
     const form = await req.formData();
     const file = form.get("photo") as File | null;
     const parent = form.get("replyTo") as string | null;

--- a/src/app/api/cases/[id]/vin/route.ts
+++ b/src/app/api/cases/[id]/vin/route.ts
@@ -1,20 +1,31 @@
 import { withAuthorization } from "@/lib/authz";
+import { isCaseMember } from "@/lib/caseMembers";
 import { getCase, setCaseVinOverride } from "@/lib/caseStore";
 import { NextResponse } from "next/server";
 
 export const PUT = withAuthorization(
   "cases",
-  "update",
+  "read",
   async (
     req: Request,
     {
       params,
+      session,
     }: {
       params: Promise<{ id: string }>;
-      session?: { user?: { role?: string } };
+      session?: { user?: { id?: string; role?: string } };
     },
   ) => {
     const { id } = await params;
+    const userId = session?.user?.id;
+    const role = session?.user?.role ?? "user";
+    if (
+      role !== "admin" &&
+      role !== "superadmin" &&
+      (!userId || !isCaseMember(id, userId))
+    ) {
+      return new Response(null, { status: 403 });
+    }
     const { vin } = (await req.json()) as { vin: string | null };
     const updated = setCaseVinOverride(id, vin);
     if (!updated) {
@@ -27,17 +38,27 @@ export const PUT = withAuthorization(
 
 export const DELETE = withAuthorization(
   "cases",
-  "update",
+  "read",
   async (
     _req: Request,
     {
       params,
+      session,
     }: {
       params: Promise<{ id: string }>;
-      session?: { user?: { role?: string } };
+      session?: { user?: { id?: string; role?: string } };
     },
   ) => {
     const { id } = await params;
+    const userId = session?.user?.id;
+    const role = session?.user?.role ?? "user";
+    if (
+      role !== "admin" &&
+      role !== "superadmin" &&
+      (!userId || !isCaseMember(id, userId))
+    ) {
+      return new Response(null, { status: 403 });
+    }
     const updated = setCaseVinOverride(id, null);
     if (!updated) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/test/authz.test.ts
+++ b/test/authz.test.ts
@@ -29,6 +29,6 @@ describe("casbin", () => {
   it("authorizes based on db rules", async () => {
     const { authorize } = await import("../src/lib/authz");
     expect(await authorize("superadmin", "cases", "delete")).toBe(true);
-    expect(await authorize("user", "cases", "delete")).toBe(true);
+    expect(await authorize("user", "cases", "delete")).toBe(false);
   });
 });

--- a/test/caseAuthorization.test.ts
+++ b/test/caseAuthorization.test.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let dataDir: string;
+let caseStore: typeof import("../src/lib/caseStore");
+
+beforeEach(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
+  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
+  vi.resetModules();
+  const db = await import("../src/lib/db");
+  await db.migrationsReady;
+  caseStore = await import("../src/lib/caseStore");
+  const { orm } = await import("../src/lib/orm");
+  const { users } = await import("../src/lib/schema");
+  orm
+    .insert(users)
+    .values([{ id: "u1" }, { id: "u2" }])
+    .run();
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  vi.resetModules();
+  process.env.CASE_STORE_FILE = undefined;
+});
+
+describe("case authorization", () => {
+  it("rejects deletion by non-member", async () => {
+    const c = caseStore.createCase("/a.jpg", null, undefined, null, "u1");
+    const { DELETE } = await import("../src/app/api/cases/[id]/route");
+    const res = await DELETE(new Request("http://test", { method: "DELETE" }), {
+      params: Promise.resolve({ id: c.id }),
+      session: { user: { id: "u2", role: "user" } },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects update by non-member", async () => {
+    const c = caseStore.createCase("/b.jpg", null, undefined, null, "u1");
+    const { PUT } = await import("../src/app/api/cases/[id]/vin/route");
+    const req = new Request("http://test", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ vin: "1" }),
+    });
+    const res = await PUT(req, {
+      params: Promise.resolve({ id: c.id }),
+      session: { user: { id: "u2", role: "user" } },
+    });
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- seed user role without global update/delete permissions
- gate case update and delete endpoints on case membership
- add regression tests for unauthorized case actions
- update authz test expectations

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852ad0730ec832baf3bf12b3e06610f