### PR TITLE
Fix TypeScript errors

### DIFF
--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -1,8 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import type { useSession as useSessionFn } from "../../useSession";
 
 vi.mock("../../useSession", () => ({
-  useSession: vi.fn(() => ({ data: { user: { role: "admin" } } })),
+  useSession: vi.fn(
+    () =>
+      ({
+        data: { user: { role: "admin" }, expires: "0" },
+      }) as unknown as ReturnType<typeof useSessionFn>,
+  ),
 }));
 
 import { useSession } from "../../useSession";
@@ -22,7 +28,9 @@ describe("AdminPageClient", () => {
   });
 
   it("enables saving for superadmins", async () => {
-    useSession.mockReturnValueOnce({ data: { user: { role: "superadmin" } } });
+    vi.mocked(useSession).mockReturnValueOnce({
+      data: { user: { role: "superadmin" }, expires: "0" },
+    } as unknown as ReturnType<typeof useSessionFn>);
     render(<AdminPageClient initialUsers={users} initialRules={rules} />);
     expect(
       screen.getByRole("button", { name: /save rules/i }),

--- a/src/app/admin/__tests__/changeRoleRoute.test.ts
+++ b/src/app/admin/__tests__/changeRoleRoute.test.ts
@@ -50,7 +50,7 @@ describe("change role route", () => {
       .from(schema.users)
       .where(eq(schema.users.id, "u1"))
       .get();
-    expect(row.role).toBe("admin");
+    expect(row?.role).toBe("admin");
   });
 
   it("rejects non-superadmins", async () => {
@@ -72,6 +72,6 @@ describe("change role route", () => {
       .from(schema.users)
       .where(eq(schema.users.id, "u1"))
       .get();
-    expect(row.role).toBe("user");
+    expect(row?.role).toBe("user");
   });
 });

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -25,5 +25,7 @@ const handler = withAuthorization(
 
 export default async function AdminPage() {
   const session = await getServerSession(authOptions);
-  return handler(new Request("http://localhost"), { session });
+  return handler(new Request("http://localhost"), {
+    session: session ?? undefined,
+  });
 }

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -13,7 +13,7 @@ export const POST = withAuthorization(
   "create",
   async (
     req: Request,
-    { session }: { session?: { user?: { id?: string } } },
+    { session }: { session?: { user?: { id?: string; role?: string } } },
   ) => {
     const form = await req.formData();
     const file = form.get("photo") as File | null;


### PR DESCRIPTION
## Summary
- clean up tests to use mocked useSession typings
- avoid non-null assertions in tests
- pass session as optional when calling admin handler
- widen auth context for upload API

## Testing
- `npm run lint`
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6852ad8ae910832b9e2218f50039bb76