### PR TITLE
Fix admin link when app served under base path

### DIFF
--- a/src/app/auth-provider.tsx
+++ b/src/app/auth-provider.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { BASE_PATH } from "@/basePath";
 import type { Session } from "next-auth";
 import { SessionProvider } from "next-auth/react";
 
@@ -9,5 +10,10 @@ export default function AuthProvider({
   children: React.ReactNode;
   session?: Session | null;
 }) {
-  return <SessionProvider session={session}>{children}</SessionProvider>;
+  const authPath = BASE_PATH ? `${BASE_PATH}/api/auth` : "/api/auth";
+  return (
+    <SessionProvider session={session} basePath={authPath}>
+      {children}
+    </SessionProvider>
+  );
 }


### PR DESCRIPTION
## Summary
- supply NextAuth `SessionProvider` with the correct API path

When `NEXT_PUBLIC_BASE_PATH` was set, the session fetch went to `/api/auth/session` instead of the base path prefix. That meant `useSession` never received data and the admin link stayed hidden for superadmins. Passing `basePath` ensures the client hits the correct endpoint.

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852ae8654d0832b99eaf71a3cae7f1f