### PR TITLE
Add app configuration tab and user settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,8 @@ enabled and how many times it has failed consecutively.
 
 Successful lookups reset the failure count. Failures increment the count; after
 more than three consecutive failures the module is automatically disabled. The
-settings page (`/settings`) shows each module's failure count and allows
-manually enabling or disabling modules.
+App Configuration tab on the admin page (`/admin`) shows each module's failure
+count and allows manually enabling or disabling modules.
 
 ### Adding a New Module
 
@@ -265,8 +265,8 @@ manually enabling or disabling modules.
    where to find the VIN.
 2. Run the app once (or create the `data/vinSources.json` file) to generate a
    status entry for the new module.
-3. Visit `/settings` to verify the module appears and enable or disable it as
-   desired.
+3. Visit `/admin` and open the App Configuration tab to verify the module
+   appears and enable or disable it as desired.
 
 ## Citation Status Modules
 

--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -2,6 +2,7 @@
 import { apiFetch } from "@/apiClient";
 import { useEffect, useState } from "react";
 import { useSession } from "../useSession";
+import AppConfigurationTab from "./AppConfigurationTab";
 
 export interface UserRecord {
   id: string;
@@ -29,6 +30,7 @@ export default function AdminPageClient({
 }) {
   const [users, setUsers] = useState(initialUsers);
   const [rules, setRules] = useState(initialRules);
+  const [tab, setTab] = useState<"users" | "config">("users");
   const [inviteEmail, setInviteEmail] = useState("");
   const [rulesText, setRulesText] = useState(
     JSON.stringify(initialRules, null, 2),
@@ -91,77 +93,98 @@ export default function AdminPageClient({
 
   return (
     <div className="p-8">
-      <h1 className="text-xl font-bold mb-4">Users</h1>
-      <div className="mb-4 flex gap-2">
-        <input
-          type="email"
-          value={inviteEmail}
-          onChange={(e) => setInviteEmail(e.target.value)}
-          className="border rounded p-1 bg-white dark:bg-gray-900"
-        />
+      <div className="flex gap-4 mb-4">
         <button
           type="button"
-          onClick={invite}
-          className="bg-blue-600 text-white px-2 py-1 rounded"
+          onClick={() => setTab("users")}
+          className={tab === "users" ? "font-bold underline" : ""}
         >
-          Invite
+          User Management
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab("config")}
+          className={tab === "config" ? "font-bold underline" : ""}
+        >
+          App Configuration
         </button>
       </div>
-      <ul className="grid gap-2">
-        {users.map((u) => (
-          <li key={u.id} className="flex items-center gap-2">
-            <span className="flex-1">{u.email ?? u.id}</span>
-            <select
-              value={u.role}
-              onChange={(e) => changeRole(u.id, e.target.value)}
+      {tab === "users" && (
+        <>
+          <h1 className="text-xl font-bold mb-4">Users</h1>
+          <div className="mb-4 flex gap-2">
+            <input
+              type="email"
+              value={inviteEmail}
+              onChange={(e) => setInviteEmail(e.target.value)}
               className="border rounded p-1 bg-white dark:bg-gray-900"
-            >
-              <option value="user">user</option>
-              <option value="admin">admin</option>
-              <option value="superadmin">superadmin</option>
-              <option value="disabled">disabled</option>
-            </select>
-            {u.role !== "disabled" && (
-              <button
-                type="button"
-                onClick={() => disable(u.id)}
-                className="bg-yellow-500 text-white px-2 py-1 rounded"
-              >
-                Disable
-              </button>
-            )}
+            />
             <button
               type="button"
-              onClick={() => remove(u.id)}
-              className="bg-red-500 text-white px-2 py-1 rounded"
+              onClick={invite}
+              className="bg-blue-600 text-white px-2 py-1 rounded"
             >
-              Delete
+              Invite
             </button>
-          </li>
-        ))}
-      </ul>
-      <h1 className="text-xl font-bold my-4">Casbin Rules</h1>
-      <ul className="grid gap-1">
-        {rules.map((r) => (
-          <li key={`${r.ptype}-${r.v0}-${r.v1}-${r.v2}`}>
-            {r.ptype}, {r.v0 ?? ""}, {r.v1 ?? ""}, {r.v2 ?? ""}
-          </li>
-        ))}
-      </ul>
-      <textarea
-        value={rulesText}
-        onChange={(e) => setRulesText(e.target.value)}
-        rows={10}
-        className="border p-1 w-full my-2 bg-white dark:bg-gray-900"
-      />
-      <button
-        type="button"
-        onClick={saveRules}
-        disabled={!isSuperadmin}
-        className="bg-blue-600 text-white px-2 py-1 rounded disabled:opacity-50"
-      >
-        Save Rules
-      </button>
+          </div>
+          <ul className="grid gap-2">
+            {users.map((u) => (
+              <li key={u.id} className="flex items-center gap-2">
+                <span className="flex-1">{u.email ?? u.id}</span>
+                <select
+                  value={u.role}
+                  onChange={(e) => changeRole(u.id, e.target.value)}
+                  className="border rounded p-1 bg-white dark:bg-gray-900"
+                >
+                  <option value="user">user</option>
+                  <option value="admin">admin</option>
+                  <option value="superadmin">superadmin</option>
+                  <option value="disabled">disabled</option>
+                </select>
+                {u.role !== "disabled" && (
+                  <button
+                    type="button"
+                    onClick={() => disable(u.id)}
+                    className="bg-yellow-500 text-white px-2 py-1 rounded"
+                  >
+                    Disable
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => remove(u.id)}
+                  className="bg-red-500 text-white px-2 py-1 rounded"
+                >
+                  Delete
+                </button>
+              </li>
+            ))}
+          </ul>
+          <h1 className="text-xl font-bold my-4">Casbin Rules</h1>
+          <ul className="grid gap-1">
+            {rules.map((r) => (
+              <li key={`${r.ptype}-${r.v0}-${r.v1}-${r.v2}`}>
+                {r.ptype}, {r.v0 ?? ""}, {r.v1 ?? ""}, {r.v2 ?? ""}
+              </li>
+            ))}
+          </ul>
+          <textarea
+            value={rulesText}
+            onChange={(e) => setRulesText(e.target.value)}
+            rows={10}
+            className="border p-1 w-full my-2 bg-white dark:bg-gray-900"
+          />
+          <button
+            type="button"
+            onClick={saveRules}
+            disabled={!isSuperadmin}
+            className="bg-blue-600 text-white px-2 py-1 rounded disabled:opacity-50"
+          >
+            Save Rules
+          </button>
+        </>
+      )}
+      {tab === "config" && <AppConfigurationTab />}
     </div>
   );
 }

--- a/src/app/admin/AppConfigurationTab.tsx
+++ b/src/app/admin/AppConfigurationTab.tsx
@@ -1,0 +1,104 @@
+"use client";
+import { apiFetch } from "@/apiClient";
+import { useEffect, useState } from "react";
+import { useSession } from "../useSession";
+
+interface VinSourceStatus {
+  id: string;
+  enabled: boolean;
+  failureCount: number;
+}
+
+interface SnailMailProviderStatus {
+  id: string;
+  active: boolean;
+  failureCount: number;
+}
+
+export default function AppConfigurationTab() {
+  const [sources, setSources] = useState<VinSourceStatus[]>([]);
+  const [mailProviders, setMailProviders] = useState<SnailMailProviderStatus[]>(
+    [],
+  );
+  const { data: session } = useSession();
+  const isAdmin =
+    session?.user?.role === "admin" || session?.user?.role === "superadmin";
+
+  useEffect(() => {
+    apiFetch("/api/vin-sources")
+      .then((res) => res.json())
+      .then((data) => setSources(data));
+    apiFetch("/api/snail-mail-providers")
+      .then((res) => res.json())
+      .then((data) => setMailProviders(data));
+  }, []);
+
+  async function toggle(id: string, enabled: boolean) {
+    await apiFetch(`/api/vin-sources/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled }),
+    });
+    const res = await apiFetch("/api/vin-sources");
+    if (res.ok) setSources(await res.json());
+  }
+
+  async function activateProvider(id: string) {
+    await apiFetch(`/api/snail-mail-providers/${id}`, {
+      method: "PUT",
+    });
+    const res = await apiFetch("/api/snail-mail-providers");
+    if (res.ok) setMailProviders(await res.json());
+  }
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">VIN Lookup Modules</h1>
+      <ul className="grid gap-2">
+        {sources.map((s) => (
+          <li key={s.id} className="flex items-center gap-4">
+            <span className="flex-1">
+              {s.id} (failures: {s.failureCount})
+            </span>
+            <button
+              type="button"
+              onClick={() => toggle(s.id, !s.enabled)}
+              disabled={!isAdmin}
+              className={
+                s.enabled
+                  ? "bg-green-500 text-white px-2 py-1 rounded"
+                  : "bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
+              }
+            >
+              {s.enabled ? "Disable" : "Enable"}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <h1 className="text-xl font-bold my-4">Snail Mail Providers</h1>
+      <ul className="grid gap-2">
+        {mailProviders.map((p) => (
+          <li key={p.id} className="flex items-center gap-4">
+            <span className="flex-1">
+              {p.id} (failures: {p.failureCount})
+            </span>
+            {p.active ? (
+              <span className="px-2 py-1 bg-green-500 text-white rounded">
+                Active
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => activateProvider(p.id)}
+                disabled={!isAdmin}
+                className="bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
+              >
+                Activate
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -75,7 +75,7 @@ export default function NavBar() {
           href="/settings"
           className="hover:text-gray-600 dark:hover:text-gray-300"
         >
-          Settings
+          User Settings
         </Link>
         {session ? (
           <button

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,104 +1,18 @@
 "use client";
-import { apiFetch } from "@/apiClient";
-import { useEffect, useState } from "react";
 import { useSession } from "../useSession";
 
-interface VinSourceStatus {
-  id: string;
-  enabled: boolean;
-  failureCount: number;
-}
-
-interface SnailMailProviderStatus {
-  id: string;
-  active: boolean;
-  failureCount: number;
-}
-
-export default function SettingsPage() {
-  const [sources, setSources] = useState<VinSourceStatus[]>([]);
-  const [mailProviders, setMailProviders] = useState<SnailMailProviderStatus[]>(
-    [],
-  );
+export default function UserSettingsPage() {
   const { data: session } = useSession();
-  const isAdmin =
-    session?.user?.role === "admin" || session?.user?.role === "superadmin";
 
-  useEffect(() => {
-    apiFetch("/api/vin-sources")
-      .then((res) => res.json())
-      .then((data) => setSources(data));
-    apiFetch("/api/snail-mail-providers")
-      .then((res) => res.json())
-      .then((data) => setMailProviders(data));
-  }, []);
-
-  async function toggle(id: string, enabled: boolean) {
-    await apiFetch(`/api/vin-sources/${id}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ enabled }),
-    });
-    const res = await apiFetch("/api/vin-sources");
-    if (res.ok) setSources(await res.json());
-  }
-
-  async function activateProvider(id: string) {
-    await apiFetch(`/api/snail-mail-providers/${id}`, {
-      method: "PUT",
-    });
-    const res = await apiFetch("/api/snail-mail-providers");
-    if (res.ok) setMailProviders(await res.json());
+  if (!session) {
+    return <div className="p-8">You are not logged in.</div>;
   }
 
   return (
     <div className="p-8">
-      <h1 className="text-xl font-bold mb-4">VIN Lookup Modules</h1>
-      <ul className="grid gap-2">
-        {sources.map((s) => (
-          <li key={s.id} className="flex items-center gap-4">
-            <span className="flex-1">
-              {s.id} (failures: {s.failureCount})
-            </span>
-            <button
-              type="button"
-              onClick={() => toggle(s.id, !s.enabled)}
-              disabled={!isAdmin}
-              className={
-                s.enabled
-                  ? "bg-green-500 text-white px-2 py-1 rounded"
-                  : "bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
-              }
-            >
-              {s.enabled ? "Disable" : "Enable"}
-            </button>
-          </li>
-        ))}
-      </ul>
-      <h1 className="text-xl font-bold my-4">Snail Mail Providers</h1>
-      <ul className="grid gap-2">
-        {mailProviders.map((p) => (
-          <li key={p.id} className="flex items-center gap-4">
-            <span className="flex-1">
-              {p.id} (failures: {p.failureCount})
-            </span>
-            {p.active ? (
-              <span className="px-2 py-1 bg-green-500 text-white rounded">
-                Active
-              </span>
-            ) : (
-              <button
-                type="button"
-                onClick={() => activateProvider(p.id)}
-                disabled={!isAdmin}
-                className="bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
-              >
-                Activate
-              </button>
-            )}
-          </li>
-        ))}
-      </ul>
+      <h1 className="text-xl font-bold mb-4">User Settings</h1>
+      <p>Email: {session.user?.email ?? session.user?.name ?? "Unknown"}</p>
+      <p>Role: {session.user?.role}</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- move settings page into admin as "App Configuration" tab
- create new user settings page
- update navigation link text
- update docs for new admin tab

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852af155fe4832bb0770eb0def6d28c