### PR TITLE
Fix sharp missing libvips

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "generate:schemas": "ts-to-zod --skipValidation --all && npm run validate:generated",
     "validate:generated": "tsc --noEmit -p tsconfig.generated.json",
     "generate:migrations": "drizzle-kit generate:sqlite",
-    "website": "ts-node --transpile-only scripts/generateWebsiteImages.ts && eleventy",
+    "website": "LD_LIBRARY_PATH=$(pwd)/node_modules/@img/sharp-linux-x64/node_modules/@img/sharp-libvips-linux-x64/lib:$LD_LIBRARY_PATH ts-node --transpile-only scripts/generateWebsiteImages.ts && eleventy",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- set `LD_LIBRARY_PATH` in the `website` script so that sharp can load vendored libvips

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run website` *(fails to build images without OPENAI_API_KEY but sharp module loads)*

------
https://chatgpt.com/codex/tasks/task_e_6852bcf23494832b8d88e4ffe5ee9120