### PR TITLE
feat: toggle case public/private

### DIFF
--- a/src/app/api/cases/[id]/public/route.ts
+++ b/src/app/api/cases/[id]/public/route.ts
@@ -1,0 +1,37 @@
+import { withAuthorization } from "@/lib/authz";
+import { isCaseMember } from "@/lib/caseMembers";
+import { getCase, setCasePublic } from "@/lib/caseStore";
+import { NextResponse } from "next/server";
+
+export const PUT = withAuthorization(
+  "cases",
+  "read",
+  async (
+    req: Request,
+    {
+      params,
+      session,
+    }: {
+      params: Promise<{ id: string }>;
+      session?: { user?: { id?: string; role?: string } };
+    },
+  ) => {
+    const { id } = await params;
+    const userId = session?.user?.id;
+    const role = session?.user?.role ?? "user";
+    if (
+      role !== "admin" &&
+      role !== "superadmin" &&
+      (!userId || !isCaseMember(id, userId))
+    ) {
+      return new Response(null, { status: 403 });
+    }
+    const { public: isPublic } = (await req.json()) as { public: boolean };
+    const updated = setCasePublic(id, isPublic);
+    if (!updated) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const layered = getCase(id);
+    return NextResponse.json(layered);
+  },
+);

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -230,6 +230,19 @@ export default function ClientCasePage({
     await refreshCase();
   }
 
+  async function togglePublic() {
+    const res = await apiFetch(`/api/cases/${caseId}/public`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ public: !(caseData?.public ?? false) }),
+    });
+    if (!res.ok) {
+      alert("Failed to update visibility.");
+      return;
+    }
+    await refreshCase();
+  }
+
   async function reanalyzePhoto(
     photo: string,
     detailsEl?: HTMLDetailsElement | null,
@@ -416,6 +429,19 @@ export default function ClientCasePage({
                 <p>
                   <span className="font-semibold">Created:</span>{" "}
                   {new Date(caseData.createdAt).toLocaleString()}
+                </p>
+                <p>
+                  <span className="font-semibold">Visibility:</span>{" "}
+                  {caseData.public ? "Public" : "Private"}
+                  {(isAdmin || session?.user) && (
+                    <button
+                      type="button"
+                      onClick={togglePublic}
+                      className="ml-2 text-blue-500 underline"
+                    >
+                      Make {caseData.public ? "Private" : "Public"}
+                    </button>
+                  )}
                 </p>
                 {caseData.streetAddress ? (
                   <p>

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -396,6 +396,10 @@ export function addOwnershipRequest(
   return current;
 }
 
+export function setCasePublic(id: string, isPublic: boolean): Case | undefined {
+  return updateCase(id, { public: isPublic });
+}
+
 export function deleteCase(id: string): boolean {
   const current = getCaseRow(id);
   if (!current) return false;

--- a/test/caseAuthorization.test.ts
+++ b/test/caseAuthorization.test.ts
@@ -52,4 +52,19 @@ describe("case authorization", () => {
     });
     expect(res.status).toBe(403);
   });
+
+  it("rejects public toggle by non-member", async () => {
+    const c = caseStore.createCase("/c.jpg", null, undefined, null, "u1");
+    const { PUT } = await import("../src/app/api/cases/[id]/public/route");
+    const req = new Request("http://test", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ public: true }),
+    });
+    const res = await PUT(req, {
+      params: Promise.resolve({ id: c.id }),
+      session: { user: { id: "u2", role: "user" } },
+    });
+    expect(res.status).toBe(403);
+  });
 });

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -146,4 +146,14 @@ describe("caseStore", () => {
     const c = createCase("/own.jpg", null, undefined, null, "u1");
     expect(members.isCaseMember(c.id, "u1", "owner")).toBe(true);
   });
+
+  it("toggles public flag", () => {
+    const { createCase, setCasePublic, getCase } = caseStore;
+    const c = createCase("/pub.jpg", null);
+    expect(c.public).toBe(false);
+    const updated = setCasePublic(c.id, true);
+    expect(updated?.public).toBe(true);
+    const stored = getCase(c.id);
+    expect(stored?.public).toBe(true);
+  });
 });

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type TestServer, startServer } from "./startServer";
+
+let server: TestServer;
+let cookie = "";
+
+async function api(path: string, opts: RequestInit = {}) {
+  const res = await fetch(`${server.url}${path}`, {
+    ...opts,
+    headers: { ...(opts.headers || {}), cookie },
+    redirect: "manual",
+  });
+  const set = res.headers.get("set-cookie");
+  if (set) cookie = set.split(";")[0];
+  return res;
+}
+
+async function signIn(email: string) {
+  const csrf = await api("/api/auth/csrf").then((r) => r.json());
+  await api("/api/auth/signin/email", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      csrfToken: csrf.csrfToken,
+      email,
+      callbackUrl: server.url,
+    }),
+  });
+  const ver = await api("/api/test/verification-url").then((r) => r.json());
+  await api(
+    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
+  );
+}
+
+beforeAll(async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
+  server = await startServer(3020, {
+    NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
+    SMTP_FROM: "test@example.com",
+    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.close();
+}, 120000);
+
+describe("case visibility", () => {
+  it("shows toggle for admins", async () => {
+    await signIn("admin@example.com");
+    const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+    const form = new FormData();
+    form.append("photo", file);
+    const upload = await api("/api/upload", { method: "POST", body: form });
+    const { caseId } = (await upload.json()) as { caseId: string };
+
+    const page = await api(`/cases/${caseId}`).then((r) => r.text());
+    expect(page).toContain("Make Public");
+  }, 30000);
+});


### PR DESCRIPTION
## Summary
- add `setCasePublic` to modify case visibility
- expose new API route `PUT /api/cases/[id]/public`
- allow toggling case visibility from the case page
- test the new store function, API route, and page behaviour

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: expected 403 to be 200)*

------
https://chatgpt.com/codex/tasks/task_e_6852bf03745c832bb4a6e106d2170026