### PR TITLE
feat: manage case collaborators

### DIFF
--- a/src/app/api/cases/[id]/members/route.ts
+++ b/src/app/api/cases/[id]/members/route.ts
@@ -1,0 +1,17 @@
+import { withAuthorization } from "@/lib/authz";
+import { listCaseMembers } from "@/lib/caseMembers";
+import { getCase } from "@/lib/caseStore";
+import { NextResponse } from "next/server";
+
+export const GET = withAuthorization(
+  "cases",
+  "read",
+  async (_req: Request, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const c = getCase(id);
+    if (!c) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    return NextResponse.json(listCaseMembers(id));
+  },
+);

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -72,6 +72,10 @@ export default function ClientCasePage({
   const [vin, setVin] = useState<string>(
     initialCase ? getCaseVin(initialCase) || "" : "",
   );
+  const [members, setMembers] = useState<
+    Array<{ userId: string; role: string }>
+  >([]);
+  const [inviteUserId, setInviteUserId] = useState("");
   const { data: session } = useSession();
   const isAdmin =
     session?.user?.role === "admin" || session?.user?.role === "superadmin";
@@ -93,6 +97,9 @@ export default function ClientCasePage({
         const data = (await res.json()) as Case;
         setCaseData(data);
       }
+    });
+    apiFetch(`/api/cases/${caseId}/members`).then(async (res) => {
+      if (res.ok) setMembers(await res.json());
     });
     const es = apiEventSource("/api/cases/stream");
     es.onmessage = (e) => {
@@ -269,6 +276,37 @@ export default function ClientCasePage({
     router.refresh();
   }
 
+  async function refreshMembers() {
+    const res = await apiFetch(`/api/cases/${caseId}/members`);
+    if (res.ok) setMembers(await res.json());
+  }
+
+  async function inviteMember() {
+    if (!inviteUserId) return;
+    const res = await apiFetch(`/api/cases/${caseId}/invite`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userId: inviteUserId }),
+    });
+    if (!res.ok) {
+      alert("Failed to invite collaborator.");
+      return;
+    }
+    setInviteUserId("");
+    await refreshMembers();
+  }
+
+  async function removeMember(uid: string) {
+    const res = await apiFetch(`/api/cases/${caseId}/members/${uid}`, {
+      method: "DELETE",
+    });
+    if (!res.ok) {
+      alert("Failed to remove collaborator.");
+      return;
+    }
+    await refreshMembers();
+  }
+
   if (!caseData) {
     return (
       <div className="p-8 flex flex-col gap-4">
@@ -293,6 +331,10 @@ export default function ClientCasePage({
   const plateStateOverridden =
     caseData.analysisOverrides?.vehicle?.licensePlateState !== undefined;
   const ownerContact = getCaseOwnerContact(caseData);
+  const isOwner = members.some(
+    (m) => m.userId === session?.user?.id && m.role === "owner",
+  );
+  const canManageMembers = isAdmin || isOwner;
 
   const progress =
     caseData.analysisStatus === "pending" && caseData.analysisProgress
@@ -451,6 +493,45 @@ export default function ClientCasePage({
                     placeholder="VIN"
                   />
                 </p>
+                <div>
+                  <span className="font-semibold">Members:</span>
+                  <ul className="ml-2 mt-1 flex flex-col gap-1">
+                    {members.map((m) => (
+                      <li key={m.userId} className="flex items-center gap-2">
+                        <span className="flex-1">
+                          {m.userId} ({m.role})
+                        </span>
+                        {canManageMembers && m.role !== "owner" ? (
+                          <button
+                            type="button"
+                            onClick={() => removeMember(m.userId)}
+                            className="text-red-600"
+                          >
+                            Remove
+                          </button>
+                        ) : null}
+                      </li>
+                    ))}
+                  </ul>
+                  {canManageMembers ? (
+                    <div className="flex gap-2 mt-2">
+                      <input
+                        type="text"
+                        value={inviteUserId}
+                        onChange={(e) => setInviteUserId(e.target.value)}
+                        placeholder="User ID"
+                        className="border rounded p-1 flex-1 bg-white dark:bg-gray-900"
+                      />
+                      <button
+                        type="button"
+                        onClick={inviteMember}
+                        className="bg-blue-600 text-white px-2 py-1 rounded"
+                      >
+                        Invite
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
               </div>
             </DebugWrapper>
             {selectedPhoto ? (

--- a/test/e2e/members.test.ts
+++ b/test/e2e/members.test.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type TestServer, startServer } from "./startServer";
+
+let server: TestServer;
+let cookie = "";
+
+async function api(path: string, opts: RequestInit = {}) {
+  const res = await fetch(`${server.url}${path}`, {
+    ...opts,
+    headers: { ...(opts.headers || {}), cookie },
+    redirect: "manual",
+  });
+  const set = res.headers.get("set-cookie");
+  if (set) cookie = set.split(";")[0];
+  return res;
+}
+
+async function signIn(email: string) {
+  const csrf = await api("/api/auth/csrf").then((r) => r.json());
+  await api("/api/auth/signin/email", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      csrfToken: csrf.csrfToken,
+      email,
+      callbackUrl: server.url,
+    }),
+  });
+  const ver = await api("/api/test/verification-url").then((r) => r.json());
+  await api(
+    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
+  );
+}
+
+async function signOut() {
+  const csrf = await api("/api/auth/csrf").then((r) => r.json());
+  await api("/api/auth/signout", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      csrfToken: csrf.csrfToken,
+      callbackUrl: server.url,
+    }),
+  });
+}
+
+async function createCase(): Promise<string> {
+  const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+  const form = new FormData();
+  form.append("photo", file);
+  const res = await api("/api/upload", { method: "POST", body: form });
+  const data = (await res.json()) as { caseId: string };
+  return data.caseId;
+}
+
+beforeAll(async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
+  server = await startServer(3012, {
+    NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
+    SMTP_FROM: "test@example.com",
+    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.close();
+}, 120000);
+
+describe("case members e2e", () => {
+  it("invites and removes collaborators", async () => {
+    await signIn("admin@example.com");
+    await signOut();
+    await signIn("owner@example.com");
+    const id = await createCase();
+
+    let members = await api(`/api/cases/${id}/members`).then(
+      (r) => r.json() as Promise<{ userId: string; role: string }[]>,
+    );
+    expect(members).toHaveLength(1);
+
+    const invite = await api(`/api/cases/${id}/invite`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userId: "collab" }),
+    });
+    expect(invite.status).toBe(200);
+
+    members = await api(`/api/cases/${id}/members`).then(
+      (r) => r.json() as Promise<{ userId: string; role: string }[]>,
+    );
+    expect(members.some((m) => m.userId === "collab")).toBe(true);
+
+    const del = await api(`/api/cases/${id}/members/collab`, {
+      method: "DELETE",
+    });
+    expect(del.status).toBe(200);
+
+    members = await api(`/api/cases/${id}/members`).then(
+      (r) => r.json() as Promise<{ userId: string; role: string }[]>,
+    );
+    expect(members.some((m) => m.userId === "collab")).toBe(false);
+  }, 30000);
+});


### PR DESCRIPTION
## Summary
- add `/api/cases/[id]/members` endpoint
- fetch and update members on client case page
- allow owners/admins to invite/remove collaborators
- test invite and removal flow end-to-end

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852bf75b630832b80d778263e33c8b5