### PR TITLE
Fix TypeScript errors

### DIFF
--- a/src/app/admin/__tests__/AdminPage.test.tsx
+++ b/src/app/admin/__tests__/AdminPage.test.tsx
@@ -1,12 +1,12 @@
 import { getServerSession } from "next-auth/next";
-import { describe, expect, it, vi } from "vitest";
+import { expect, it, vi } from "vitest";
 import AdminPage from "../page";
 
 vi.mock("next-auth/next", () => ({
   getServerSession: vi.fn(),
 }));
 
-vi.mock("../api/auth/[...nextauth]/route", () => ({
+vi.mock("@/lib/authOptions", () => ({
   authOptions: {},
 }));
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,7 +1,7 @@
 import { getCasbinRules, listUsers } from "@/lib/adminStore";
+import { authOptions } from "@/lib/authOptions";
 import { withAuthorization } from "@/lib/authz";
 import { getServerSession } from "next-auth/next";
-import { authOptions } from "../api/auth/[...nextauth]/route";
 import AdminPageClient from "./AdminPageClient";
 
 export const dynamic = "force-dynamic";
@@ -26,6 +26,7 @@ const handler = withAuthorization(
 export default async function AdminPage() {
   const session = await getServerSession(authOptions);
   return handler(new Request("http://localhost"), {
+    params: Promise.resolve({}),
     session: session ?? undefined,
   });
 }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,51 +1,5 @@
-import { writeFile } from "node:fs/promises";
-import { authAdapter, seedSuperAdmin } from "@/lib/auth";
-import { sendEmail } from "@/lib/email";
-import NextAuth, {
-  type NextAuthOptions,
-  type Session,
-  type User,
-} from "next-auth";
-import type { Adapter } from "next-auth/adapters";
-import EmailProvider from "next-auth/providers/email";
-
-seedSuperAdmin().catch(() => {});
-
-export const authOptions: NextAuthOptions = {
-  adapter: authAdapter() as Adapter,
-  providers: [
-    EmailProvider({
-      async sendVerificationRequest({ identifier, url }) {
-        if (process.env.TEST_APIS) {
-          (global as Record<string, unknown>).verificationUrl = url;
-          await writeFile("/tmp/verification-url.txt", url);
-          return;
-        }
-        await sendEmail({ to: identifier, subject: "Sign in", body: url });
-      },
-      from: process.env.SMTP_FROM,
-    }),
-  ],
-  pages: { signIn: "/signin" },
-  session: { strategy: "database" as const },
-  callbacks: {
-    async session({
-      session,
-      user,
-    }: { session: Session; user: User & { role?: string } }) {
-      if (session.user) {
-        (session.user as User & { role?: string }).role = user.role;
-      }
-      return session;
-    },
-  },
-  events: {
-    async createUser({ user }) {
-      await seedSuperAdmin({ id: user.id, email: user.email ?? null });
-    },
-  },
-  secret: process.env.NEXTAUTH_SECRET,
-};
+import { authOptions } from "@/lib/authOptions";
+import NextAuth from "next-auth";
 
 const handler = NextAuth(authOptions);
 export { handler as GET, handler as POST };

--- a/src/app/api/casbin-rules/route.ts
+++ b/src/app/api/casbin-rules/route.ts
@@ -6,14 +6,28 @@ import {
 import { withAuthorization } from "@/lib/authz";
 import { NextResponse } from "next/server";
 
-export const GET = withAuthorization("admin", "read", async () =>
-  NextResponse.json(getCasbinRules()),
+export const GET = withAuthorization(
+  "admin",
+  "read",
+  async (
+    _req: Request,
+    _ctx: {
+      params: Promise<Record<string, string>>;
+      session?: { user?: { role?: string } };
+    },
+  ) => NextResponse.json(getCasbinRules()),
 );
 
 export const PUT = withAuthorization(
   "superadmin",
   "update",
-  async (req: Request) => {
+  async (
+    req: Request,
+    _ctx: {
+      params: Promise<Record<string, string>>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
     const rules = (await req.json()) as CasbinRule[];
     const updated = await replaceCasbinRules(rules);
     return NextResponse.json(updated);

--- a/src/app/api/cases/stream/route.ts
+++ b/src/app/api/cases/stream/route.ts
@@ -4,51 +4,62 @@ import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
 
-export const GET = withAuthorization("cases", "read", async (req: Request) => {
-  const encoder = new TextEncoder();
-  const stream = new ReadableStream({
-    start(controller) {
-      function send(chunk: string) {
-        try {
-          controller.enqueue(encoder.encode(chunk));
-        } catch {
-          cleanup();
+export const GET = withAuthorization(
+  "cases",
+  "read",
+  async (
+    req: Request,
+    _ctx: {
+      params: Promise<Record<string, string>>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        function send(chunk: string) {
+          try {
+            controller.enqueue(encoder.encode(chunk));
+          } catch {
+            cleanup();
+          }
         }
-      }
 
-      function onUpdate(data: unknown) {
-        const payload = `data: ${JSON.stringify(data)}\n\n`;
-        send(payload);
-      }
+        function onUpdate(data: unknown) {
+          const payload = `data: ${JSON.stringify(data)}\n\n`;
+          send(payload);
+        }
 
-      function cleanup() {
-        clearInterval(keepAlive);
-        caseEvents.off("update", onUpdate);
-      }
+        function cleanup() {
+          clearInterval(keepAlive);
+          caseEvents.off("update", onUpdate);
+        }
 
-      caseEvents.on("update", onUpdate);
+        caseEvents.on("update", onUpdate);
 
-      const keepAlive = setInterval(() => {
-        send(":\n\n");
-      }, 15000);
+        const keepAlive = setInterval(() => {
+          send(":\n\n");
+        }, 15000);
 
-      req.signal.addEventListener("abort", () => {
-        cleanup();
-        controller.close();
-      });
+        req.signal.addEventListener("abort", () => {
+          cleanup();
+          controller.close();
+        });
 
-      const ctrl = controller as ReadableStreamDefaultController<Uint8Array> & {
-        oncancel?: () => void;
-      };
-      ctrl.oncancel = cleanup;
-    },
-  });
+        const ctrl =
+          controller as ReadableStreamDefaultController<Uint8Array> & {
+            oncancel?: () => void;
+          };
+        ctrl.oncancel = cleanup;
+      },
+    });
 
-  return new NextResponse(stream, {
-    headers: {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
-      Connection: "keep-alive",
-    },
-  });
-});
+    return new NextResponse(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  },
+);

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -13,7 +13,13 @@ export const POST = withAuthorization(
   "create",
   async (
     req: Request,
-    { session }: { session?: { user?: { id?: string; role?: string } } },
+    {
+      session,
+      params,
+    }: {
+      params: Promise<Record<string, string>>;
+      session?: { user?: { id?: string; role?: string } };
+    },
   ) => {
     const form = await req.formData();
     const file = form.get("photo") as File | null;

--- a/src/app/api/users/invite/route.ts
+++ b/src/app/api/users/invite/route.ts
@@ -5,7 +5,13 @@ import { NextResponse } from "next/server";
 export const POST = withAuthorization(
   "admin",
   "create",
-  async (req: Request) => {
+  async (
+    req: Request,
+    _ctx: {
+      params: Promise<Record<string, string>>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
     const { email } = (await req.json()) as { email: string };
     const user = inviteUser(email);
     return NextResponse.json(user);

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -2,7 +2,17 @@ import { listUsers } from "@/lib/adminStore";
 import { withAuthorization } from "@/lib/authz";
 import { NextResponse } from "next/server";
 
-export const GET = withAuthorization("admin", "read", async () => {
-  const users = listUsers();
-  return NextResponse.json(users);
-});
+export const GET = withAuthorization(
+  "admin",
+  "read",
+  async (
+    _req: Request,
+    _ctx: {
+      params: Promise<Record<string, string>>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
+    const users = listUsers();
+    return NextResponse.json(users);
+  },
+);

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -1,0 +1,44 @@
+import { writeFile } from "node:fs/promises";
+import type { NextAuthOptions, Session, User } from "next-auth";
+import type { Adapter } from "next-auth/adapters";
+import EmailProvider from "next-auth/providers/email";
+import { authAdapter, seedSuperAdmin } from "./auth";
+import { sendEmail } from "./email";
+
+seedSuperAdmin().catch(() => {});
+
+export const authOptions: NextAuthOptions = {
+  adapter: authAdapter() as Adapter,
+  providers: [
+    EmailProvider({
+      async sendVerificationRequest({ identifier, url }) {
+        if (process.env.TEST_APIS) {
+          (global as Record<string, unknown>).verificationUrl = url;
+          await writeFile("/tmp/verification-url.txt", url);
+          return;
+        }
+        await sendEmail({ to: identifier, subject: "Sign in", body: url });
+      },
+      from: process.env.SMTP_FROM,
+    }),
+  ],
+  pages: { signIn: "/signin" },
+  session: { strategy: "database" as const },
+  callbacks: {
+    async session({
+      session,
+      user,
+    }: { session: Session; user: User & { role?: string } }) {
+      if (session.user) {
+        (session.user as User & { role?: string }).role = user.role;
+      }
+      return session;
+    },
+  },
+  events: {
+    async createUser({ user }) {
+      await seedSuperAdmin({ id: user.id, email: user.email ?? null });
+    },
+  },
+  secret: process.env.NEXTAUTH_SECRET,
+};

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -49,7 +49,10 @@ export async function authorize(
 }
 
 export function withAuthorization<
-  C extends { session?: { user?: { role?: string } } },
+  C extends {
+    params: Promise<Record<string, string>>;
+    session?: { user?: { role?: string } };
+  },
   R = Response,
 >(obj: string, act: string, handler: (req: Request, ctx: C) => Promise<R> | R) {
   return async (req: Request, ctx: C): Promise<R | Response> => {

--- a/test/casbinRulesRoute.test.ts
+++ b/test/casbinRulesRoute.test.ts
@@ -32,6 +32,7 @@ describe("casbin rules API", () => {
   it("allows admins to read", async () => {
     const mod = await import("../src/app/api/casbin-rules/route");
     const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({}),
       session: { user: { role: "admin" } },
     });
     expect(res.status).toBe(200);
@@ -40,6 +41,7 @@ describe("casbin rules API", () => {
   it("rejects regular users", async () => {
     const mod = await import("../src/app/api/casbin-rules/route");
     const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({}),
       session: { user: { role: "user" } },
     });
     expect(res.status).toBe(403);
@@ -52,10 +54,12 @@ describe("casbin rules API", () => {
       body: JSON.stringify([]),
     });
     const ok = await mod.PUT(req, {
+      params: Promise.resolve({}),
       session: { user: { role: "superadmin" } },
     });
     expect(ok.status).toBe(200);
     const fail = await mod.PUT(req, {
+      params: Promise.resolve({}),
       session: { user: { role: "admin" } },
     });
     expect(fail.status).toBe(403);
@@ -74,6 +78,7 @@ describe("casbin rules API", () => {
       ]),
     });
     const res = await mod.PUT(req, {
+      params: Promise.resolve({}),
       session: { user: { role: "superadmin" } },
     });
     expect(res.status).toBe(200);

--- a/test/protectedRoutes.test.ts
+++ b/test/protectedRoutes.test.ts
@@ -39,6 +39,7 @@ describe("protected routes", () => {
     form.append("photo", file);
     const req = new Request("http://test", { method: "POST", body: form });
     const res = await mod.POST(req as unknown as NextRequest, {
+      params: Promise.resolve({}),
       session: { user: { role: "guest" } },
     });
     expect(res.status).toBe(403);


### PR DESCRIPTION
## Summary
- clean up admin page imports
- export auth options from `src/lib/authOptions`
- handle context params in authorization helper
- update API handlers to accept context parameter
- adjust tests for new context

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852c1101900832b8aef2080d64b5c0e