### PR TITLE
Update authorization defaults and policy

### DIFF
--- a/migrations/0008_seed_casbin_rules.sql
+++ b/migrations/0008_seed_casbin_rules.sql
@@ -1,5 +1,4 @@
 INSERT INTO casbin_rules (ptype, v0, v1, v2) VALUES
-  ('p', 'user', 'cases', 'read'),
   ('p', 'user', 'upload', 'create'),
   ('g', 'admin', 'user', NULL),
   ('g', 'superadmin', 'admin', NULL);

--- a/migrations/0010_update_cases_policy.sql
+++ b/migrations/0010_update_cases_policy.sql
@@ -1,0 +1,3 @@
+DELETE FROM casbin_rules WHERE ptype='p' AND v0='user' AND v1='cases' AND v2='read';
+INSERT INTO casbin_rules (ptype, v0, v1, v2)
+  VALUES ('p', 'anonymous', 'public_cases', 'read');

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -56,7 +56,7 @@ export function withAuthorization<
   R = Response,
 >(obj: string, act: string, handler: (req: Request, ctx: C) => Promise<R> | R) {
   return async (req: Request, ctx: C): Promise<R | Response> => {
-    const role = ctx.session?.user?.role ?? "user";
+    const role = ctx.session?.user?.role ?? "anonymous";
     if (!(await authorize(role, obj, act))) {
       return new Response(null, { status: 403 });
     }


### PR DESCRIPTION
## Summary
- default anonymous sessions to `"anonymous"` instead of `"user"`
- seed initial Casbin policies without the old user read rule
- migrate to remove the old rule and grant anonymous read access to public cases

## Testing
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c8155be4832b910626291cd20f2b