### PR TITLE
Add usersTable option to DrizzleAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Copy `.env.example` to `.env` and set `SUPER_ADMIN_EMAIL` to automatically
 promote that user to the `superadmin` role on their first sign in. When the
 variable is omitted, the very first registered user becomes the super admin.
 
+NextAuth now integrates with Drizzle using a custom adapter that points to the
+`users` table so the user's role appears in the session object.
+
 ## Generating Zod Schemas
 
 When interfaces in `src/lib` change, update the runtime schemas and verify the output with:

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,7 +5,7 @@ import { orm } from "./orm";
 import { users } from "./schema";
 
 export function authAdapter() {
-  return DrizzleAdapter(orm);
+  return DrizzleAdapter(orm, { usersTable: users });
 }
 
 export async function seedSuperAdmin(newUser?: {


### PR DESCRIPTION
## Summary
- expose user roles in session by pointing DrizzleAdapter to the users table
- note the custom auth adapter in the README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: expected 403 to be 200)*

------
https://chatgpt.com/codex/tasks/task_e_6852c8c99074832bba5a165b31517cf1