### PR TITLE
Update docs and admin tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ npm run generate:migrations
 
 Migrations are stored as SQL files under the `migrations` folder and applied at runtime. The default SQLite database is `data/cases.sqlite`. Per-photo analysis results now live in the `case_photo_analysis` table instead of the JSON `analysis.images` field.
 
+## Administration
+
+Visit `/admin` to manage users and Casbin policies. Admins can invite collaborators by entering an email address. The app creates the user with the `user` role and sends an invitation link. Super admins may edit the Casbin rule list directly in the UI. After saving, the server reloads the policy set so changes take effect immediately.
+
 ## OpenAI Integration
 
 Copy `.env.example` to `.env` and add your API key:

--- a/docs/auth-plan.md
+++ b/docs/auth-plan.md
@@ -16,9 +16,10 @@ This document proposes an approach for user login, role management, and access c
 - user (default)
 - admin
 - superadmin
+- anonymous
 ```
 
-Roles are stored on the `User` record. The super admin can promote other users to admin or superadmin.
+Roles are stored on the `User` record. The `anonymous` role represents unauthenticated visitors. The super admin can promote other users to admin or superadmin.
 
 ## 3. Access Control
 
@@ -28,7 +29,8 @@ Roles are stored on the `User` record. The super admin can promote other users t
   - `collaborator` can comment on a case they have been invited to.
   - `admin` can manage any case and manage users.
   - `superadmin` can modify the policy matrix itself.
-- Contextual checks (such as ownership) use Casbin's ABAC support.
+- Contextual checks use Casbin's ABAC support so membership in a `CaseMember`
+  record is enforced even if the policy is broad.
 
 ## 4. Case Collaboration
 

--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { useSession as useSessionFn } from "../../useSession";
 
@@ -13,6 +13,11 @@ vi.mock("../../useSession", () => ({
 
 import { useSession } from "../../useSession";
 
+vi.mock("@/apiClient", () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from "@/apiClient";
 import AdminPageClient from "../AdminPageClient";
 
 const users = [{ id: "1", email: "a@example.com", name: null, role: "admin" }];
@@ -35,5 +40,47 @@ describe("AdminPageClient", () => {
     expect(
       screen.getByRole("button", { name: /save rules/i }),
     ).not.toBeDisabled();
+  });
+
+  it("updates user role without reload", async () => {
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(apiFetch).mockResolvedValueOnce(
+      new Response(null, { status: 200 }),
+    );
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { id: "1", email: "a@example.com", name: null, role: "user" },
+      ],
+    } as Response);
+    render(<AdminPageClient initialUsers={users} initialRules={rules} />);
+    fireEvent.change(screen.getByDisplayValue("admin"), {
+      target: { value: "user" },
+    });
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("user")).toBeInTheDocument(),
+    );
+  });
+
+  it("reloads policies after save", async () => {
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(useSession).mockReturnValueOnce({
+      data: { user: { role: "superadmin" }, expires: "0" },
+    } as unknown as ReturnType<typeof useSessionFn>);
+    const newRules = [{ ptype: "p", v0: "user", v1: "cases", v2: "read" }];
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => newRules,
+    } as Response);
+    render(<AdminPageClient initialUsers={users} initialRules={rules} />);
+    fireEvent.change(screen.getAllByRole("textbox")[1], {
+      target: { value: JSON.stringify(newRules, null, 2) },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save rules/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByText((t) => t.includes("user") && t.includes("cases")),
+      ).toBeInTheDocument(),
+    );
   });
 });

--- a/test/authz.test.ts
+++ b/test/authz.test.ts
@@ -17,6 +17,10 @@ beforeEach(async () => {
     .insert(casbinRules)
     .values({ ptype: "p", v0: "superadmin", v1: "cases", v2: "delete" })
     .run();
+  orm
+    .insert(casbinRules)
+    .values({ ptype: "p", v0: "user", v1: "cases", v2: "read" })
+    .run();
   orm.insert(users).values({ id: "u1" }).run();
   orm.insert(users).values({ id: "u2" }).run();
 });

--- a/test/caseMembers.test.ts
+++ b/test/caseMembers.test.ts
@@ -17,6 +17,10 @@ beforeEach(async () => {
   await db.migrationsReady;
   ({ orm } = await import("../src/lib/orm"));
   schema = await import("../src/lib/schema");
+  orm
+    .insert(schema.casbinRules)
+    .values({ ptype: "p", v0: "user", v1: "cases", v2: "read" })
+    .run();
   orm.insert(schema.users).values({ id: "u1" }).run();
   orm.insert(schema.users).values({ id: "u2" }).run();
   orm.insert(schema.users).values({ id: "u3", role: "admin" }).run();


### PR DESCRIPTION
## Summary
- mention anonymous role and ABAC enforcement in auth plan
- document admin policy editing and collaborator invites in README
- test admin client updates without reload
- fix unit tests by seeding read policy

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852cb92b620832b9d24fb6d18bd14a3