### PR TITLE
Add anonymous access tests

### DIFF
--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -10,15 +10,23 @@ export const GET = withAuthorization(
     req: Request,
     {
       params,
+      session,
     }: {
       params: Promise<{ id: string }>;
-      session?: { user?: { role?: string } };
+      session?: { user?: { id?: string; role?: string } };
     },
   ) => {
     const { id } = await params;
     const c = getCase(id);
     if (!c) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const userId = session?.user?.id;
+    const role = session?.user?.role ?? "user";
+    if (!c.public && role !== "admin" && role !== "superadmin") {
+      if (!userId || !isCaseMember(id, userId)) {
+        return new Response(null, { status: 403 });
+      }
     }
     return NextResponse.json(c);
   },

--- a/src/app/api/cases/stream/route.ts
+++ b/src/app/api/cases/stream/route.ts
@@ -9,11 +9,16 @@ export const GET = withAuthorization(
   "read",
   async (
     req: Request,
-    _ctx: {
+    {
+      session,
+    }: {
       params: Promise<Record<string, string>>;
       session?: { user?: { role?: string } };
     },
   ) => {
+    if (!session?.user) {
+      return new Response(null, { status: 403 });
+    }
     const encoder = new TextEncoder();
     const stream = new ReadableStream({
       start(controller) {

--- a/test/caseAuthorization.test.ts
+++ b/test/caseAuthorization.test.ts
@@ -67,4 +67,13 @@ describe("case authorization", () => {
     });
     expect(res.status).toBe(403);
   });
+
+  it("rejects private case read by anonymous user", async () => {
+    const c = caseStore.createCase("/d.jpg", null, undefined, null, "u1");
+    const { GET } = await import("../src/app/api/cases/[id]/route");
+    const res = await GET(new Request("http://test"), {
+      params: Promise.resolve({ id: c.id }),
+    });
+    expect(res.status).toBe(403);
+  });
 });

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type TestServer, startServer } from "./startServer";
+
+let server: TestServer;
+let cookie = "";
+
+async function api(path: string, opts: RequestInit = {}) {
+  const res = await fetch(`${server.url}${path}`, {
+    ...opts,
+    headers: { ...(opts.headers || {}), cookie },
+    redirect: "manual",
+  });
+  const set = res.headers.get("set-cookie");
+  if (set) cookie = set.split(";")[0];
+  return res;
+}
+
+async function signIn(email: string) {
+  const csrf = await api("/api/auth/csrf").then((r) => r.json());
+  await api("/api/auth/signin/email", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      csrfToken: csrf.csrfToken,
+      email,
+      callbackUrl: server.url,
+    }),
+  });
+  const ver = await api("/api/test/verification-url").then((r) => r.json());
+  await api(
+    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
+  );
+}
+
+async function signOut() {
+  const csrf = await api("/api/auth/csrf").then((r) => r.json());
+  await api("/api/auth/signout", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      csrfToken: csrf.csrfToken,
+      callbackUrl: server.url,
+    }),
+  });
+}
+
+async function createCase(): Promise<string> {
+  const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+  const form = new FormData();
+  form.append("photo", file);
+  const res = await api("/api/upload", { method: "POST", body: form });
+  const data = (await res.json()) as { caseId: string };
+  return data.caseId;
+}
+
+beforeAll(async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
+  server = await startServer(3021, {
+    NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
+    SMTP_FROM: "test@example.com",
+    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.close();
+}, 120000);
+
+describe("anonymous access", () => {
+  it("allows access to public case", async () => {
+    await signIn("user@example.com");
+    const id = await createCase();
+    await api(`/api/cases/${id}/public`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ public: true }),
+    });
+    await signOut();
+
+    const res = await api(`/api/cases/${id}`);
+    expect(res.status).toBe(200);
+  }, 30000);
+
+  it("rejects private case and stream", async () => {
+    await signIn("user@example.com");
+    const id = await createCase();
+    await signOut();
+
+    const caseRes = await api(`/api/cases/${id}`);
+    expect(caseRes.status).toBe(403);
+
+    const streamRes = await api("/api/cases/stream");
+    expect(streamRes.status).toBe(403);
+  }, 30000);
+
+  it("rejects non-member on private case", async () => {
+    await signIn("user@example.com");
+    const id = await createCase();
+    await signOut();
+    await signIn("other@example.com");
+
+    const res = await api(`/api/cases/${id}`);
+    expect(res.status).toBe(403);
+  }, 30000);
+});

--- a/test/protectedRoutes.test.ts
+++ b/test/protectedRoutes.test.ts
@@ -27,7 +27,7 @@ describe("protected routes", () => {
     const mod = await import("../src/app/api/cases/[id]/route");
     const res = await mod.GET(new Request("http://test"), {
       params: Promise.resolve({ id: c.id }),
-      session: { user: { role: "guest" } },
+      session: { user: { role: "anonymous" } },
     });
     expect(res.status).toBe(403);
   });
@@ -40,7 +40,7 @@ describe("protected routes", () => {
     const req = new Request("http://test", { method: "POST", body: form });
     const res = await mod.POST(req as unknown as NextRequest, {
       params: Promise.resolve({}),
-      session: { user: { role: "guest" } },
+      session: { user: { role: "anonymous" } },
     });
     expect(res.status).toBe(403);
   });


### PR DESCRIPTION
## Summary
- update case routes to block anonymous users on private cases and event streams
- test that anonymous users cannot access private cases
- verify protected routes use the new "anonymous" role
- add an end-to-end test for public and private case access

## Testing
- `npm test`
- `npm run e2e` *(fails: expected 403 to be 200)*

------
https://chatgpt.com/codex/tasks/task_e_6852c80a9658832b8d4bfe05e60b9827