### PR TITLE
Allow admin roles to read cases

### DIFF
--- a/migrations/0011_restore_cases_read.sql
+++ b/migrations/0011_restore_cases_read.sql
@@ -1,0 +1,2 @@
+INSERT INTO casbin_rules (ptype, v0, v1, v2)
+  VALUES ('p', 'user', 'cases', 'read');

--- a/test/caseAuthorization.test.ts
+++ b/test/caseAuthorization.test.ts
@@ -67,4 +67,19 @@ describe("case authorization", () => {
     });
     expect(res.status).toBe(403);
   });
+
+  it("allows superadmin to toggle visibility", async () => {
+    const c = caseStore.createCase("/d.jpg", null, undefined, null, "u1");
+    const { PUT } = await import("../src/app/api/cases/[id]/public/route");
+    const req = new Request("http://test", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ public: true }),
+    });
+    const res = await PUT(req, {
+      params: Promise.resolve({ id: c.id }),
+      session: { user: { id: "s1", role: "superadmin" } },
+    });
+    expect(res.status).toBe(200);
+  });
 });


### PR DESCRIPTION
## Summary
- restore `cases/read` policy so admins can update case visibility
- cover superadmin case visibility toggle in tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852cc5e9228832bad754035fac139ce