### PR TITLE
Fix camera permissions errors

### DIFF
--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -13,6 +13,16 @@ export default function PointAndShootPage() {
 
   useEffect(() => {
     async function startCamera() {
+      if (!navigator.mediaDevices?.getUserMedia) {
+        setCameraError(
+          "Camera API not available. Use HTTPS and a compatible browser.",
+        );
+        return;
+      }
+      if (location.protocol !== "https:" && location.hostname !== "localhost") {
+        setCameraError("Camera requires a secure connection (HTTPS).");
+        return;
+      }
       try {
         const constraints = {
           audio: false,


### PR DESCRIPTION
## Summary
- detect when browser lacks camera support
- warn when connection isn't secure before starting the camera

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852f3b77a64832ba36b6a4df20e5192