### PR TITLE
Add landing stats from database

### DIFF
--- a/src/app/LoggedOutLanding.tsx
+++ b/src/app/LoggedOutLanding.tsx
@@ -1,0 +1,52 @@
+import { getLandingStats } from "@/lib/stats";
+
+function formatCount(n: number): string {
+  if (n < 10) return n.toString();
+  const digits = Math.floor(Math.log10(n));
+  const base = 10 ** digits;
+  return `>${Math.floor(n / base) * base}`;
+}
+
+export default async function LoggedOutLanding() {
+  const stats = getLandingStats();
+  return (
+    <main className="p-8 flex flex-col items-center text-center gap-6">
+      <h1 className="text-3xl font-bold">Photo To Citation</h1>
+      <p className="text-lg max-w-xl">
+        Snap a quick photo of blocked bike lanes or sidewalks and let the app
+        handle the paperwork.
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
+        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
+          <div className="text-2xl font-semibold">
+            {formatCount(stats.casesLastWeek)}
+          </div>
+          <div className="text-sm">cases created in the last week</div>
+        </div>
+        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
+          <div className="text-2xl font-semibold">
+            {formatCount(stats.authorityNotifications)}
+          </div>
+          <div className="text-sm">notifications sent to authorities</div>
+        </div>
+        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
+          <div className="text-2xl font-semibold">
+            {`<${Math.ceil(stats.avgDaysToNotification)} days`}
+          </div>
+          <div className="text-sm">average time to notify authorities</div>
+        </div>
+        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
+          <div className="text-2xl font-semibold">
+            {`>${Math.floor(stats.notificationSuccessRate * 100)}%`}
+          </div>
+          <div className="text-sm">cases with authority notification</div>
+        </div>
+      </div>
+      <p className="mt-4">
+        <a href="/signin" className="text-blue-600 underline">
+          Sign in to get started
+        </a>
+      </p>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,16 @@
 export { dynamic } from "./cases/page";
 import { withBasePath } from "@/basePath";
+import { authOptions } from "@/lib/authOptions";
+import { getServerSession } from "next-auth/next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import LoggedOutLanding from "./LoggedOutLanding";
 
 export default async function Home() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return <LoggedOutLanding />;
+  }
   const ua = (await headers()).get("user-agent") ?? "";
   const isMobile = /Mobile|Android|iPhone|iPad/i.test(ua);
   redirect(withBasePath(isMobile ? "/point" : "/cases"));

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,0 +1,86 @@
+export interface LandingStats {
+  casesLastWeek: number;
+  authorityNotifications: number;
+  avgDaysToNotification: number;
+  notificationSuccessRate: number;
+}
+
+import { getCases } from "./caseStore";
+import { reportModules } from "./reportModules";
+import { getSentMails } from "./snailMailStore";
+
+function addressKey(address: {
+  address1: string;
+  address2?: string | null;
+  city: string;
+  state: string;
+  postalCode: string;
+}): string {
+  return [
+    address.address1.trim(),
+    address.address2?.trim() || "",
+    address.city.trim(),
+    address.state.trim(),
+    address.postalCode.trim(),
+  ]
+    .join("|")
+    .toLowerCase();
+}
+
+function parseAuthorityAddress(text?: string | null) {
+  if (!text) return null;
+  const [first, second] = text.split("\n");
+  if (!first || !second) return null;
+  const [cityPart, stateZip] = second.split(",");
+  if (!stateZip) return null;
+  const [state, postalCode] = stateZip.trim().split(/\s+/);
+  return {
+    address1: first.trim(),
+    city: cityPart.trim(),
+    state: state.trim(),
+    postalCode: postalCode.trim(),
+  };
+}
+
+export function getLandingStats(): LandingStats {
+  const cases = getCases();
+  const weekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  const module = reportModules["oak-park"];
+  const authorityEmail = module.authorityEmail;
+  const authorityAddress = parseAuthorityAddress(module.authorityAddress);
+
+  let casesLastWeek = 0;
+  let authorityNotifications = 0;
+  let delayTotal = 0;
+  let casesWithNotification = 0;
+
+  for (const c of cases) {
+    const created = new Date(c.createdAt).getTime();
+    if (created >= weekAgo) casesLastWeek++;
+    const emails = (c.sentEmails || []).filter((m) => m.to === authorityEmail);
+    if (emails.length > 0) {
+      authorityNotifications += emails.length;
+      delayTotal += new Date(emails[0].sentAt).getTime() - created;
+      casesWithNotification++;
+    }
+  }
+
+  if (authorityAddress) {
+    const key = addressKey(authorityAddress);
+    const snailMails = getSentMails().filter((m) => addressKey(m.to) === key);
+    authorityNotifications += snailMails.length;
+  }
+
+  const avgDays =
+    casesWithNotification > 0
+      ? delayTotal / casesWithNotification / (1000 * 60 * 60 * 24)
+      : 0;
+  const success = cases.length > 0 ? casesWithNotification / cases.length : 0;
+
+  return {
+    casesLastWeek,
+    authorityNotifications,
+    avgDaysToNotification: avgDays,
+    notificationSuccessRate: success,
+  };
+}

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -16,6 +16,6 @@ describe("end-to-end", () => {
     const res = await fetch(`${server.url}/`);
     expect(res.status).toBe(200);
     const text = await res.text();
-    expect(text).toContain("Cases");
+    expect(text).toContain("Photo To Citation");
   }, 30000);
 });


### PR DESCRIPTION
## Summary
- compute dynamic stats using database cases and snail mail
- display those stats on the logged-out landing page

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852f32b5104832ba05aad5270ca9e70