### PR TITLE
Fix TypeScript issues

### DIFF
--- a/src/app/api/cases/[id]/followup/route.ts
+++ b/src/app/api/cases/[id]/followup/route.ts
@@ -1,4 +1,4 @@
-import { withCaseAuthorization } from "@/lib/authz";
+import { withAuthorization, withCaseAuthorization } from "@/lib/authz";
 import { draftFollowUp } from "@/lib/caseReport";
 import type { Case, SentEmail } from "@/lib/caseStore";
 import { addCaseEmail, getCase } from "@/lib/caseStore";

--- a/src/app/api/cases/[id]/notify-owner/route.ts
+++ b/src/app/api/cases/[id]/notify-owner/route.ts
@@ -1,4 +1,4 @@
-import { withCaseAuthorization } from "@/lib/authz";
+import { withAuthorization, withCaseAuthorization } from "@/lib/authz";
 import { draftOwnerNotification } from "@/lib/caseReport";
 import { addCaseEmail, getCase } from "@/lib/caseStore";
 import { getCaseOwnerContactInfo } from "@/lib/caseUtils";

--- a/src/app/api/cases/[id]/report/route.ts
+++ b/src/app/api/cases/[id]/report/route.ts
@@ -1,4 +1,4 @@
-import { withCaseAuthorization } from "@/lib/authz";
+import { withAuthorization, withCaseAuthorization } from "@/lib/authz";
 import { draftEmail } from "@/lib/caseReport";
 import { addCaseEmail, getCase } from "@/lib/caseStore";
 import { sendSnailMail } from "@/lib/contactMethods";

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -1,4 +1,5 @@
 import { withAuthorization, withCaseAuthorization } from "@/lib/authz";
+import { isCaseMember } from "@/lib/caseMembers";
 import { deleteCase, getCase } from "@/lib/caseStore";
 import { NextResponse } from "next/server";
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,11 +1,14 @@
-import { DrizzleAdapter } from "@auth/drizzle-adapter";
+import {
+  SQLiteDrizzleAdapter,
+  defineTables,
+} from "@auth/drizzle-adapter/lib/sqlite.js";
 import { eq, sql } from "drizzle-orm";
 import { migrationsReady } from "./db";
 import { orm } from "./orm";
 import { users } from "./schema";
 
 export function authAdapter() {
-  return DrizzleAdapter(orm, { usersTable: users });
+  return SQLiteDrizzleAdapter(orm, defineTables({ usersTable: users }));
 }
 
 export async function seedSuperAdmin(newUser?: {

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -31,6 +31,7 @@ export const authOptions: NextAuthOptions = {
     }: { session: Session; user: User & { role?: string } }) {
       if (session.user) {
         (session.user as User & { role?: string }).role = user.role;
+        (session.user as User & { id: string }).id = user.id;
       }
       return session;
     },

--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -120,7 +120,7 @@ describe("admin actions", () => {
     await signIn("super2@example.com");
     const rules = (await api("/api/casbin-rules").then((r) =>
       r.json(),
-    )) as Array<{ v2?: string }>;
+    )) as Array<import("@/lib/adminStore").CasbinRule>;
     rules.push({ ptype: "p", v0: "user", v1: "cases", v2: "extra" });
     const res = await api("/api/casbin-rules", {
       method: "PUT",

--- a/test/snailMailProviders.test.ts
+++ b/test/snailMailProviders.test.ts
@@ -54,6 +54,7 @@ describe("snail mail provider API authorization", () => {
   it("rejects listing without admin role", async () => {
     const mod = await import("../src/app/api/snail-mail-providers/route");
     const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({}) as Promise<Record<string, string>>,
       session: { user: { role: "user" } },
     });
     expect(res.status).toBe(403);
@@ -63,7 +64,7 @@ describe("snail mail provider API authorization", () => {
     const mod = await import("../src/app/api/snail-mail-providers/[id]/route");
     const req = new Request("http://test", { method: "PUT" });
     const res = await mod.PUT(req, {
-      params: Promise.resolve({ id: "mock" }),
+      params: Promise.resolve({ id: "mock" }) as Promise<{ id: string }>,
       session: { user: { role: "user" } },
     });
     expect(res.status).toBe(403);

--- a/test/vinSources.test.ts
+++ b/test/vinSources.test.ts
@@ -45,6 +45,7 @@ describe("vin source API authorization", () => {
   it("rejects listing without admin role", async () => {
     const mod = await import("../src/app/api/vin-sources/route");
     const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({}) as Promise<Record<string, string>>,
       session: { user: { role: "user" } },
     });
     expect(res.status).toBe(403);
@@ -58,7 +59,7 @@ describe("vin source API authorization", () => {
       body: JSON.stringify({ enabled: false }),
     });
     const res = await mod.PUT(req, {
-      params: Promise.resolve({ id: "edmunds" }),
+      params: Promise.resolve({ id: "edmunds" }) as Promise<{ id: string }>,
       session: { user: { role: "user" } },
     });
     expect(res.status).toBe(403);

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -2,10 +2,11 @@ import type { DefaultSession } from "next-auth";
 
 declare module "next-auth" {
   interface Session {
-    user?: DefaultSession["user"] & { role: string };
+    user?: DefaultSession["user"] & { id: string; role: string };
   }
 
   interface User {
+    id: string;
     role: string;
   }
 }


### PR DESCRIPTION
## Summary
- add authorization import in case API routes
- load default auth tables for the adapter
- expose `id` in NextAuth session
- cast admin rule editing to `CasbinRule`
- adjust API test helpers to satisfy types

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68530ced9488832b8cb66923cc136cf2