### PR TITLE
Fix TypeScript compile errors

### DIFF
--- a/src/app/api/cases/[id]/followup/route.ts
+++ b/src/app/api/cases/[id]/followup/route.ts
@@ -1,4 +1,4 @@
-import { withCaseAuthorization } from "@/lib/authz";
+import { withAuthorization, withCaseAuthorization } from "@/lib/authz";
 import { draftFollowUp } from "@/lib/caseReport";
 import type { Case, SentEmail } from "@/lib/caseStore";
 import { addCaseEmail, getCase } from "@/lib/caseStore";

--- a/src/app/api/cases/[id]/notify-owner/route.ts
+++ b/src/app/api/cases/[id]/notify-owner/route.ts
@@ -1,4 +1,4 @@
-import { withCaseAuthorization } from "@/lib/authz";
+import { withAuthorization, withCaseAuthorization } from "@/lib/authz";
 import { draftOwnerNotification } from "@/lib/caseReport";
 import { addCaseEmail, getCase } from "@/lib/caseStore";
 import { getCaseOwnerContactInfo } from "@/lib/caseUtils";

--- a/src/app/api/cases/[id]/report/route.ts
+++ b/src/app/api/cases/[id]/report/route.ts
@@ -1,4 +1,4 @@
-import { withCaseAuthorization } from "@/lib/authz";
+import { withAuthorization, withCaseAuthorization } from "@/lib/authz";
 import { draftEmail } from "@/lib/caseReport";
 import { addCaseEmail, getCase } from "@/lib/caseStore";
 import { sendSnailMail } from "@/lib/contactMethods";

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -1,4 +1,5 @@
 import { withAuthorization, withCaseAuthorization } from "@/lib/authz";
+import { isCaseMember } from "@/lib/caseMembers";
 import { deleteCase, getCase } from "@/lib/caseStore";
 import { NextResponse } from "next/server";
 

--- a/src/app/api/snail-mail-providers/[id]/route.ts
+++ b/src/app/api/snail-mail-providers/[id]/route.ts
@@ -8,7 +8,15 @@ import { NextResponse } from "next/server";
 export const PUT = withAuthorization(
   "admin",
   "update",
-  async (_req: Request, { params }: { params: Promise<{ id: string }> }) => {
+  async (
+    _req: Request,
+    {
+      params,
+    }: {
+      params: Promise<{ id: string }>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
     const { id } = await params;
     const result = setActiveSnailMailProvider(id);
     if (!result) {

--- a/src/app/api/vin-sources/[id]/route.ts
+++ b/src/app/api/vin-sources/[id]/route.ts
@@ -5,7 +5,15 @@ import { NextResponse } from "next/server";
 export const PUT = withAuthorization(
   "admin",
   "update",
-  async (req: Request, { params }: { params: Promise<{ id: string }> }) => {
+  async (
+    req: Request,
+    {
+      params,
+    }: {
+      params: Promise<{ id: string }>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
     const { id } = await params;
     const { enabled } = (await req.json()) as { enabled: boolean };
     const result = setVinSourceEnabled(id, enabled);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,7 +5,10 @@ import { orm } from "./orm";
 import { users } from "./schema";
 
 export function authAdapter() {
-  return DrizzleAdapter(orm, { usersTable: users });
+  return DrizzleAdapter(orm, { usersTable: users } as unknown as Record<
+    string,
+    unknown
+  >);
 }
 
 export async function seedSuperAdmin(newUser?: {

--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { CasbinRule } from "@/lib/adminStore";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { type TestServer, startServer } from "./startServer";
 
@@ -120,7 +121,7 @@ describe("admin actions", () => {
     await signIn("super2@example.com");
     const rules = (await api("/api/casbin-rules").then((r) =>
       r.json(),
-    )) as Array<{ v2?: string }>;
+    )) as CasbinRule[];
     rules.push({ ptype: "p", v0: "user", v1: "cases", v2: "extra" });
     const res = await api("/api/casbin-rules", {
       method: "PUT",
@@ -128,7 +129,7 @@ describe("admin actions", () => {
       body: JSON.stringify(rules),
     });
     expect(res.status).toBe(200);
-    const updated = (await res.json()) as Array<{ v2?: string }>;
+    const updated = (await res.json()) as CasbinRule[];
     expect(updated.some((r) => r.v2 === "extra")).toBe(true);
   }, 30000);
 

--- a/test/snailMailProviders.test.ts
+++ b/test/snailMailProviders.test.ts
@@ -54,6 +54,7 @@ describe("snail mail provider API authorization", () => {
   it("rejects listing without admin role", async () => {
     const mod = await import("../src/app/api/snail-mail-providers/route");
     const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({}),
       session: { user: { role: "user" } },
     });
     expect(res.status).toBe(403);

--- a/test/vinSources.test.ts
+++ b/test/vinSources.test.ts
@@ -45,6 +45,7 @@ describe("vin source API authorization", () => {
   it("rejects listing without admin role", async () => {
     const mod = await import("../src/app/api/vin-sources/route");
     const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({}),
       session: { user: { role: "user" } },
     });
     expect(res.status).toBe(403);

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -2,10 +2,11 @@ import type { DefaultSession } from "next-auth";
 
 declare module "next-auth" {
   interface Session {
-    user?: DefaultSession["user"] & { role: string };
+    user?: DefaultSession["user"] & { id: string; role: string };
   }
 
   interface User {
+    id: string;
     role: string;
   }
 }


### PR DESCRIPTION
## Summary
- add missing authorization imports
- include session context in admin routes
- expand NextAuth types to include `id`
- adjust tests for updated contexts
- cast drizzle adapter config to avoid TS errors

## Testing
- `npm run lint`
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68530ced9488832b8cb66923cc136cf2