### PR TITLE
Fix login email user creation

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import {
   SQLiteDrizzleAdapter,
   defineTables,
@@ -8,7 +9,14 @@ import { orm } from "./orm";
 import { users } from "./schema";
 
 export function authAdapter() {
-  return SQLiteDrizzleAdapter(orm, defineTables({ usersTable: users }));
+  const base = SQLiteDrizzleAdapter(orm, defineTables({ usersTable: users }));
+  return {
+    ...base,
+    async createUser(data) {
+      if (!data.id) data.id = crypto.randomUUID();
+      return base.createUser(data);
+    },
+  };
 }
 
 export async function seedSuperAdmin(newUser?: {


### PR DESCRIPTION
## Summary
- generate a UUID when creating a new user so session creation succeeds

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68531300c124832b91fa1fdc979ab155