### PR TITLE
fix: adjust auth adapter imports

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,15 +1,12 @@
 import crypto from "node:crypto";
-import {
-  SQLiteDrizzleAdapter,
-  defineTables,
-} from "@auth/drizzle-adapter/lib/sqlite.js";
+import { DrizzleAdapter } from "@auth/drizzle-adapter";
 import { eq, sql } from "drizzle-orm";
 import { migrationsReady } from "./db";
 import { orm } from "./orm";
 import { users } from "./schema";
 
 export function authAdapter() {
-  const base = SQLiteDrizzleAdapter(orm, defineTables({ usersTable: users }));
+  const base = DrizzleAdapter(orm, { usersTable: users });
   return {
     ...base,
     async createUser(data) {


### PR DESCRIPTION
## Summary
- prevent Next.js module error by importing `DrizzleAdapter` from the package root

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68531ebfcc20832b96e278cb20384c16