### PR TITLE
Add browser-based violation analysis

### DIFF
--- a/docs/feature-outline.md
+++ b/docs/feature-outline.md
@@ -95,13 +95,22 @@ The system sends each photo to the configured language model with a prompt
 describing the expected fields. The response is validated against a schema
 before being stored in the case record.
 
-### 4.2 Handling Errors
+### 4.2 Local Browser Analysis
+
+The mobile `/point` page performs a quick pass using a lightweight WASM model
+running in a Web Worker. Each captured frame is evaluated locally so the user
+gets instant feedback on the likely violation type or detected license plate
+numbers. These hints appear below the camera view while the image uploads in
+the background. The final server‑side OpenAI workflow refines the results once
+the photo reaches the server.
+
+### 4.3 Handling Errors
 
 If the analysis fails or returns invalid data, the job logs an error and
 continues without blocking the case. Users can review the log and trigger a new
 analysis run if needed.
 
-### 4.3 Reanalyzing Cases
+### 4.4 Reanalyzing Cases
 
 Cases may be reanalyzed at any time. This is useful when analysis logic is
 updated or additional photos are added. Previous results are replaced with the

--- a/src/app/api/snail-mail-providers/[id]/route.ts
+++ b/src/app/api/snail-mail-providers/[id]/route.ts
@@ -8,7 +8,15 @@ import { NextResponse } from "next/server";
 export const PUT = withAuthorization(
   "admin",
   "update",
-  async (_req: Request, { params }: { params: Promise<{ id: string }> }) => {
+  async (
+    _req: Request,
+    {
+      params,
+    }: {
+      params: Promise<{ id: string }>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
     const { id } = await params;
     const result = setActiveSnailMailProvider(id);
     if (!result) {

--- a/src/app/api/vin-sources/[id]/route.ts
+++ b/src/app/api/vin-sources/[id]/route.ts
@@ -5,7 +5,15 @@ import { NextResponse } from "next/server";
 export const PUT = withAuthorization(
   "admin",
   "update",
-  async (req: Request, { params }: { params: Promise<{ id: string }> }) => {
+  async (
+    req: Request,
+    {
+      params,
+    }: {
+      params: Promise<{ id: string }>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
     const { id } = await params;
     const { enabled } = (await req.json()) as { enabled: boolean };
     const result = setVinSourceEnabled(id, enabled);

--- a/src/app/point/localAnalyzer.worker.ts
+++ b/src/app/point/localAnalyzer.worker.ts
@@ -1,0 +1,18 @@
+import { analyzeViolationLocal, loadOnnxModel } from "@/lib/browserAnalysis";
+
+let session: unknown = null;
+
+self.onmessage = async (e: MessageEvent) => {
+  const { type, modelUrl, image } = e.data as {
+    type: string;
+    modelUrl?: string;
+    image?: ImageData;
+  };
+  if (type === "load" && modelUrl) {
+    session = await loadOnnxModel(modelUrl);
+    self.postMessage({ type: "ready" });
+  } else if (type === "analyze" && image && session) {
+    const result = await analyzeViolationLocal([image], { onnx: session });
+    self.postMessage({ type: "result", result });
+  }
+};

--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -16,7 +16,7 @@ export default function PointAndShootPage() {
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const workerRef = useRef<Worker>();
+  const workerRef = useRef<Worker | null>(null);
   const [analysisHint, setAnalysisHint] = useState<string | null>(null);
   const [cameraError, setCameraError] = useState<string | null>(null);
   const uploadCase = useNewCaseFromFiles();

--- a/src/lib/browserAnalysis.ts
+++ b/src/lib/browserAnalysis.ts
@@ -1,0 +1,99 @@
+import type { ViolationReport } from "./openai";
+
+export interface BrowserAnalysisProgress {
+  stage: "load" | "run";
+  index: number;
+  total: number;
+}
+
+interface OnnxRuntime {
+  env?: { init?: () => Promise<void> };
+  Tensor: new (type: string, data: Float32Array, dims: number[]) => unknown;
+  InferenceSession: { create(path: string): Promise<unknown> };
+}
+
+interface Tfjs {
+  setBackend(name: string): Promise<void> | void;
+  ready(): Promise<void>;
+  loadGraphModel(path: string): Promise<unknown>;
+  browser: { fromPixels(img: ImageData): { expandDims(n: number): unknown } };
+}
+
+let ort: OnnxRuntime | undefined;
+let tf: Tfjs | undefined;
+
+export async function loadOnnxModel(url: string): Promise<unknown> {
+  if (!ort) {
+    ort = (await import("onnxruntime-web")) as OnnxRuntime;
+    if (ort.env?.init) await ort.env.init();
+  }
+  return ort.InferenceSession.create(url);
+}
+
+export async function loadTfliteModel(url: string): Promise<unknown> {
+  if (!tf) {
+    tf = (await import("@tensorflow/tfjs")) as Tfjs;
+    await import("@tensorflow/tfjs-backend-wasm");
+    await tf.setBackend("wasm");
+    await tf.ready();
+  }
+  return tf.loadGraphModel(url);
+}
+
+export async function analyzeViolationLocal(
+  images: ImageData[],
+  options: {
+    onnx?: unknown;
+    tflite?: unknown;
+    progress?: (p: BrowserAnalysisProgress) => void;
+  },
+): Promise<ViolationReport> {
+  if (images.length === 0) {
+    throw new Error("images");
+  }
+  const results: Array<{ plate?: string; type?: string }> = [];
+  let idx = 0;
+  for (const img of images) {
+    options.progress?.({ stage: "run", index: idx, total: images.length });
+    if (options.onnx) {
+      const arr = Float32Array.from(img.data, (v) => v / 255);
+      const tensor = new (ort as OnnxRuntime).Tensor("float32", arr, [
+        1,
+        img.height,
+        img.width,
+        4,
+      ]);
+      const out = await (
+        options.onnx as {
+          run: (
+            x: unknown,
+          ) => Promise<{ result: { plate?: string; type?: string } }>;
+        }
+      ).run({ input: tensor });
+      results.push(out.result);
+    } else if (options.tflite) {
+      const tensor = tf?.browser.fromPixels(img).expandDims(0);
+      const out = (
+        options.tflite as {
+          predict: (t: unknown) => {
+            data: () => Promise<{ plate?: string; type?: string }>;
+          };
+        }
+      ).predict(tensor);
+      results.push(await out.data());
+    } else {
+      const mean = img.data.reduce((a, b) => a + b, 0) / img.data.length;
+      results.push({ plate: `DBG${Math.round(mean)}` });
+    }
+    idx++;
+  }
+  const best = results[0] ?? {};
+  return {
+    violationType: best.type ?? "unknown",
+    details: "", // local model provides minimal detail
+    vehicle: {
+      licensePlateNumber: best.plate,
+    },
+    images: {},
+  } as ViolationReport;
+}

--- a/types/auth-drizzle-sqlite.d.ts
+++ b/types/auth-drizzle-sqlite.d.ts
@@ -1,0 +1,1 @@
+declare module "@auth/drizzle-adapter/lib/sqlite.js";

--- a/types/onnxruntime-web.d.ts
+++ b/types/onnxruntime-web.d.ts
@@ -1,0 +1,1 @@
+declare module "onnxruntime-web";

--- a/types/tensorflow-tfjs-backend-wasm.d.ts
+++ b/types/tensorflow-tfjs-backend-wasm.d.ts
@@ -1,0 +1,1 @@
+declare module "@tensorflow/tfjs-backend-wasm";

--- a/types/tensorflow-tfjs.d.ts
+++ b/types/tensorflow-tfjs.d.ts
@@ -1,0 +1,1 @@
+declare module "@tensorflow/tfjs";


### PR DESCRIPTION
## Summary
- implement `browserAnalysis.ts` for running ONNX/TFLite models in the browser
- use a Web Worker on the `/point` page to run lightweight local analysis
- show immediate hints from the worker
- document the local analysis step

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68531367a334832b9af22256411fdf18