### PR TITLE
Gracefully exit when NEXTAUTH_SECRET is missing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,8 @@ SMTP_FROM=
 MOCK_EMAIL_TO=
 # User promoted to super admin on first sign in
 SUPER_ADMIN_EMAIL=
+# Required to maintain session integrity
+NEXTAUTH_SECRET=
 
 # JSON data file locations
 CASE_STORE_FILE=

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Then browse to [https://localhost](https://localhost).
 Copy `.env.example` to `.env` and set `SUPER_ADMIN_EMAIL` to automatically
 promote that user to the `superadmin` role on their first sign in. When the
 variable is omitted, the very first registered user becomes the super admin.
+The `NEXTAUTH_SECRET` variable **must** also be set to keep sessions valid;
+the server exits with an error when it is missing.
 
 NextAuth now integrates with Drizzle using a custom adapter that points to the
 `users` table so the user's role appears in the session object.

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -5,6 +5,11 @@ import EmailProvider from "next-auth/providers/email";
 import { authAdapter, seedSuperAdmin } from "./auth";
 import { sendEmail } from "./email";
 
+if (!process.env.NEXTAUTH_SECRET) {
+  console.error("NEXTAUTH_SECRET not configured");
+  process.exit(1);
+}
+
 seedSuperAdmin().catch(() => {});
 
 export const authOptions: NextAuthOptions = {


### PR DESCRIPTION
## Summary
- enforce `NEXTAUTH_SECRET` presence in `authOptions`
- document the requirement in the README
- add `NEXTAUTH_SECRET` example to `.env.example`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853295f5e24832b9478eeb3d1e80077