### PR TITLE
Add NextAuth env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,9 @@ SMTP_FROM=
 MOCK_EMAIL_TO=
 # User promoted to super admin on first sign in
 SUPER_ADMIN_EMAIL=
+# NextAuth settings
+NEXTAUTH_SECRET=
+NEXTAUTH_URL=
 
 # JSON data file locations
 CASE_STORE_FILE=

--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ Then browse to [https://localhost](https://localhost).
 ## Authentication
 
 Copy `.env.example` to `.env` and set `SUPER_ADMIN_EMAIL` to automatically
-promote that user to the `superadmin` role on their first sign in. When the
-variable is omitted, the very first registered user becomes the super admin.
+promote that user to the `superadmin` role on their first sign in. Add a
+`NEXTAUTH_SECRET` for signing cookies and set `NEXTAUTH_URL` to your site URL
+(include the base path when `NEXT_PUBLIC_BASE_PATH` is configured). When
+`SUPER_ADMIN_EMAIL` is omitted, the very first registered user becomes the
+super admin.
 
 NextAuth now integrates with Drizzle using a custom adapter that points to the
 `users` table so the user's role appears in the session object.


### PR DESCRIPTION
## Summary
- expose `NEXTAUTH_SECRET` and `NEXTAUTH_URL` in `.env.example`
- describe these variables in the README setup instructions

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685331e4c14c832ba71d41126ae0fd4b