### PR TITLE
feat: display sign-in errors

### DIFF
--- a/src/app/signin/__tests__/SignInPage.test.tsx
+++ b/src/app/signin/__tests__/SignInPage.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import SignInPage from "../page";
+
+vi.mock("../../useSession", () => ({
+  signIn: vi.fn(),
+}));
+
+const mockGet = vi.fn();
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: mockGet }),
+}));
+
+describe("SignInPage", () => {
+  it("shows error message from query", () => {
+    mockGet.mockReturnValueOnce("some-error");
+    render(<SignInPage />);
+    expect(
+      screen.getByText(/Sign-in failed. The link may have expired./i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,28 +1,38 @@
 "use client";
+import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { signIn } from "../useSession";
 
 export default function SignInPage() {
   const [email, setEmail] = useState("");
+  const params = useSearchParams();
+  const error = params.get("error");
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        signIn("email", { email, callbackUrl: "/" });
-      }}
-      className="p-4 flex flex-col gap-2"
-    >
-      <label htmlFor="email">Email</label>
-      <input
-        id="email"
-        type="email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        className="border p-2"
-      />
-      <button type="submit" className="bg-blue-500 text-white px-4 py-2">
-        Sign In
-      </button>
-    </form>
+    <>
+      {error ? (
+        <div className="bg-red-100 border border-red-300 text-red-700 p-2 mb-2">
+          Sign-in failed. The link may have expired.
+        </div>
+      ) : null}
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          signIn("email", { email, callbackUrl: "/" });
+        }}
+        className="p-4 flex flex-col gap-2"
+      >
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2"
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+          Sign In
+        </button>
+      </form>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- show an error alert in the sign-in page when the `error` query parameter is present
- unit test ensuring the alert renders with a query string

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853325650fc832bb899c3384bb4efbb