### PR TITLE
Add SMTP config checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ variable is omitted, the very first registered user becomes the super admin.
 NextAuth now integrates with Drizzle using a custom adapter that points to the
 `users` table so the user's role appears in the session object.
 
+The sign‑in flow sends a verification email, so set `SMTP_HOST`, `SMTP_PORT`,
+`SMTP_USER`, `SMTP_PASS`, and `SMTP_FROM` in your environment. Without these
+values login emails cannot be delivered.
+
 ## Generating Zod Schemas
 
 When interfaces in `src/lib` change, update the runtime schemas and verify the output with:

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -18,17 +18,34 @@ export async function sendEmail({
   body,
   attachments = [],
 }: EmailOptions): Promise<void> {
-  const transporter = nodemailer.createTransport({
-    host: process.env.SMTP_HOST,
-    port: process.env.SMTP_PORT ? Number(process.env.SMTP_PORT) : 587,
-    secure: process.env.SMTP_SECURE === "true",
-    auth: process.env.SMTP_USER
-      ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS || "" }
-      : undefined,
-  });
+  const missing: string[] = [];
+  if (!process.env.SMTP_HOST) missing.push("SMTP_HOST");
+  if (!process.env.SMTP_USER) missing.push("SMTP_USER");
+  if (!process.env.SMTP_PASS) missing.push("SMTP_PASS");
+  if (!process.env.SMTP_FROM) missing.push("SMTP_FROM");
+  if (missing.length) {
+    throw new Error(`Missing SMTP configuration: ${missing.join(", ")}`);
+  }
+
+  let transporter: ReturnType<typeof nodemailer.createTransport>;
+  try {
+    transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: process.env.SMTP_PORT ? Number(process.env.SMTP_PORT) : 587,
+      secure: process.env.SMTP_SECURE === "true",
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+  } catch (err) {
+    console.error("Failed to create SMTP transporter", err);
+    throw err;
+  }
+
   const override = process.env.MOCK_EMAIL_TO;
   await transporter.sendMail({
-    from: process.env.SMTP_FROM || process.env.SMTP_USER,
+    from: process.env.SMTP_FROM,
     to: override || to,
     subject,
     text: body,

--- a/test/emailSettings.test.ts
+++ b/test/emailSettings.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const createTransport = vi.fn();
+vi.mock("nodemailer", () => ({ default: { createTransport } }));
+
+let envBackup: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  envBackup = { ...process.env };
+  vi.resetModules();
+  createTransport.mockReset();
+});
+
+afterEach(() => {
+  process.env = envBackup;
+  vi.restoreAllMocks();
+});
+
+describe("sendEmail", () => {
+  it("throws when SMTP variables are missing", async () => {
+    process.env.SMTP_HOST = "";
+    process.env.SMTP_USER = "";
+    process.env.SMTP_PASS = "";
+    process.env.SMTP_FROM = "";
+    const { sendEmail } = await import("../src/lib/email");
+    await expect(
+      sendEmail({ to: "x@example.com", subject: "a", body: "b" }),
+    ).rejects.toThrow(/SMTP/);
+  });
+
+  it("creates a transporter when variables exist", async () => {
+    const sendMail = vi.fn().mockResolvedValue(undefined);
+    createTransport.mockReturnValue({ sendMail });
+    process.env.SMTP_HOST = "localhost";
+    process.env.SMTP_PORT = "587";
+    process.env.SMTP_USER = "user";
+    process.env.SMTP_PASS = "pass";
+    process.env.SMTP_FROM = "from@example.com";
+    const { sendEmail } = await import("../src/lib/email");
+    await sendEmail({ to: "x@example.com", subject: "a", body: "b" });
+    expect(createTransport).toHaveBeenCalled();
+    expect(sendMail).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- validate SMTP variables when sending email and log if transport fails
- explain required SMTP variables for login in README
- test email setup validation

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68533263f004832ba04ca900aad59192