### PR TITLE
Add empty DB sign-in test

### DIFF
--- a/test/e2e/signinEmptyDb.test.ts
+++ b/test/e2e/signinEmptyDb.test.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type TestServer, startServer } from "./startServer";
+
+let server: TestServer;
+let dataDir: string;
+let cookie = "";
+
+async function api(p: string, opts: RequestInit = {}) {
+  const res = await fetch(`${server.url}${p}`, {
+    ...opts,
+    headers: { ...(opts.headers || {}), cookie },
+    redirect: "manual",
+  });
+  const set = res.headers.get("set-cookie");
+  if (set) cookie = set.split(";")[0];
+  return res;
+}
+
+beforeAll(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
+  server = await startServer(3013, {
+    CASE_STORE_FILE: path.join(dataDir, "cases.sqlite"),
+    NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
+    SMTP_FROM: "test@example.com",
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.close();
+  fs.rmSync(dataDir, { recursive: true, force: true });
+}, 120000);
+
+describe("sign in with empty db", () => {
+  it("creates the first user and signs in", async () => {
+    const csrf = await api("/api/auth/csrf").then((r) => r.json());
+    const email = "first@example.com";
+    await api("/api/auth/signin/email", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        csrfToken: csrf.csrfToken,
+        email,
+        callbackUrl: server.url,
+      }),
+    });
+
+    const ver = await api("/api/test/verification-url").then((r) => r.json());
+    expect(ver.url).toBeTruthy();
+    await api(
+      `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
+    );
+
+    const session = await api("/api/auth/session").then((r) => r.json());
+    expect(session?.user?.email).toBe(email);
+    expect(session?.user?.role).toBe("superadmin");
+  }, 30000);
+});


### PR DESCRIPTION
## Summary
- add e2e test verifying sign-in works when the server starts with no existing DB

## Testing
- `npm test`
- `npm run e2e` *(fails: `adminActions.test.ts` and others)*

------
https://chatgpt.com/codex/tasks/task_e_6853326bf69c832bb959127362bce557