### PR TITLE
Add instructions hint for point & shoot page

### DIFF
--- a/docs/feature-outline.md
+++ b/docs/feature-outline.md
@@ -80,6 +80,9 @@ fills the screen with two overlays:
 - **Upload Picture** prompts for one or more images from the device.
 - **Take Picture** immediately snaps a photo and starts a new case.
 
+A short message below the shutter button explains that the app will guess the
+license plate or violation type as you aim the camera.
+
 A small "Cases" link leads to the full case list if needed.
 Desktop users can access this page from the "Point & Shoot" link in the header.
 

--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -162,6 +162,15 @@ export default function PointAndShootPage() {
         >
           Take Picture
         </button>
+        {!analysisHint && (
+          <div
+            className="pointer-events-none text-white text-sm text-center"
+            data-testid="instructions"
+          >
+            Point your camera at the vehicle. We'll guess the plate or violation
+            below.
+          </div>
+        )}
         {analysisHint && (
           <div
             className="pointer-events-none text-white text-sm"


### PR DESCRIPTION
## Summary
- show brief instructions below the shutter button on the `/point` camera page
- document the new hint in the feature outline

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: all tests skipped after timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6853328f96a8832ba9c420a6c710f865