### PR TITLE
Update signIn callback path

### DIFF
--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { withBasePath } from "@/basePath";
 import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { signIn } from "../useSession";
@@ -17,7 +18,7 @@ export default function SignInPage() {
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          signIn("email", { email, callbackUrl: "/" });
+          signIn("email", { email, callbackUrl: withBasePath("/") });
         }}
         className="p-4 flex flex-col gap-2"
       >


### PR DESCRIPTION
## Summary
- import `withBasePath` in the sign-in page
- apply base path to email sign-in redirect

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853368642d8832ba38a8a37bf834b02