### PR TITLE
feat: add logging to auth flow

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -14,6 +14,7 @@ const handler = withAuthorization(
     { session }: { session?: { user?: { role?: string } } },
   ) => {
     const s = session ?? (await getServerSession(authOptions));
+    console.log("admin page session", s?.user?.role);
     if (s?.user?.role !== "admin" && s?.user?.role !== "superadmin") {
       return new Response(null, { status: 403 });
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import LoggedOutLanding from "./LoggedOutLanding";
 
 export default async function Home() {
   const session = await getServerSession(authOptions);
+  console.log("home session", !!session);
   if (!session) {
     return <LoggedOutLanding />;
   }

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -18,6 +18,7 @@ export default function SignInPage() {
       <form
         onSubmit={(e) => {
           e.preventDefault();
+          console.log("Submitting sign in", email);
           signIn("email", { email, callbackUrl: withBasePath("/") });
         }}
         className="p-4 flex flex-col gap-2"

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -13,6 +13,7 @@ export function authAdapter() {
   return {
     ...base,
     async createUser(data: AdapterUser & { id?: string }) {
+      console.log("authAdapter.createUser", data.email);
       if (!data.id) data.id = crypto.randomUUID();
       if (!base.createUser) throw new Error("createUser not implemented");
       return base.createUser(data);
@@ -25,6 +26,7 @@ export async function seedSuperAdmin(newUser?: {
   email: string | null;
 }) {
   await migrationsReady;
+  console.log("seeding super admin", newUser?.email);
   const existing = orm
     .select()
     .from(users)

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -14,12 +14,14 @@ export const authOptions: NextAuthOptions = {
   providers: [
     EmailProvider({
       async sendVerificationRequest({ identifier, url }) {
+        console.log("sendVerificationRequest", identifier);
         if (process.env.TEST_APIS) {
           (global as Record<string, unknown>).verificationUrl = url;
           await writeFile("/tmp/verification-url.txt", url);
           return;
         }
         await sendEmail({ to: identifier, subject: "Sign in", body: url });
+        console.log("Verification email sent", identifier);
       },
       from: process.env.SMTP_FROM,
     }),
@@ -31,6 +33,7 @@ export const authOptions: NextAuthOptions = {
       session,
       user,
     }: { session: Session; user: User & { role?: string } }) {
+      console.log("session callback", user.id);
       if (session.user) {
         (session.user as User & { role?: string }).role = user.role;
         (session.user as User & { id: string }).id = user.id;
@@ -40,6 +43,7 @@ export const authOptions: NextAuthOptions = {
   },
   events: {
     async createUser({ user }) {
+      console.log("new user", user.id);
       try {
         await seedSuperAdmin({ id: user.id, email: user.email ?? null });
       } catch (err) {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -18,6 +18,7 @@ export async function sendEmail({
   body,
   attachments = [],
 }: EmailOptions): Promise<void> {
+  console.log("sendEmail", to, subject);
   const missing: string[] = [];
   if (!process.env.SMTP_HOST) missing.push("SMTP_HOST");
   if (!process.env.SMTP_USER) missing.push("SMTP_USER");
@@ -54,4 +55,5 @@ export async function sendEmail({
       path: path.join(process.cwd(), "public", p.replace(/^\//, "")),
     })),
   });
+  console.log("email sent", to);
 }


### PR DESCRIPTION
## Summary
- log sign-in submissions on the client
- log email sends and verification requests
- log session callbacks and user creation
- log auth adapter events and seed process
- log authorization checks
- trace session info on home and admin pages

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685364897b08832ba62dac0ecc7a4ecb