### PR TITLE
Fix TypeScript implicit any issues

### DIFF
--- a/scripts/migrateAnalysisImages.ts
+++ b/scripts/migrateAnalysisImages.ts
@@ -18,7 +18,7 @@ async function run() {
       | undefined;
     if (!analysisImages) continue;
     const photos = orm
-      .select({ url: casePhotos.url })
+      .select()
       .from(casePhotos)
       .where(eq(casePhotos.caseId, row.id))
       .all();

--- a/scripts/seedCases.ts
+++ b/scripts/seedCases.ts
@@ -25,7 +25,7 @@ const program = new Command()
   .option(
     "-s, --scenario <prompt>",
     "Scenario prompt (can be repeated)",
-    (v, p: string[]) => {
+    (v: string, p: string[]) => {
       p.push(v);
       return p;
     },

--- a/src/lib/adminStore.ts
+++ b/src/lib/adminStore.ts
@@ -16,7 +16,7 @@ export function listUsers(): UserRecord[] {
     .select()
     .from(users)
     .all()
-    .map((u) => ({ ...u }));
+    .map((u: typeof users.$inferSelect) => ({ ...u }));
 }
 
 export function inviteUser(email: string, role = "user"): UserRecord {
@@ -52,7 +52,7 @@ export function getCasbinRules(): CasbinRule[] {
     .select()
     .from(casbinRules)
     .all()
-    .map((r) => ({ ...r }));
+    .map((r: typeof casbinRules.$inferSelect) => ({ ...r }));
 }
 
 export async function replaceCasbinRules(


### PR DESCRIPTION
## Summary
- narrow admin store map callbacks
- give types to script helpers
- fix migrations script TypeScript error

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68534fcd434c832b9968227e5932f658