### PR TITLE
Add coverage checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ website/dist
 data
 storybook-static
 storybook-screenshots
+coverage
 *.tsbuildinfo
 public/uploads
 

--- a/README.md
+++ b/README.md
@@ -326,6 +326,21 @@ export const citationStatusModules: Record<string, CitationStatusModule> = {
 Add new modules to this record and run `npm run generate:schemas` to update the
 runtime schema.
 
+## Testing
+
+Run all unit tests with:
+
+```bash
+npm test
+```
+
+Generate a coverage report and fail if coverage drops below the configured
+thresholds with:
+
+```bash
+npm run test:coverage
+```
+
 ## Docker
 
 To run the app in containers, install Docker and Docker Compose then build the stack:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "biome check .",
     "format": "biome format . --write",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "e2e": "vitest run -c vitest.e2e.config.ts",
     "reanalyze": "ts-node --transpile-only scripts/updateMissingAnalysis.ts",
     "poll:snailmail": "ts-node --transpile-only scripts/pollSnailMail.ts",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,5 +15,16 @@ export default defineConfig({
     globals: true,
     setupFiles: "./vitest.setup.ts",
     exclude: [...configDefaults.exclude, "test/e2e/**"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      all: true,
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add coverage folder to `.gitignore`
- document how to run coverage in README
- add `test:coverage` npm script
- enable coverage thresholds in vitest config

## Testing
- `npm run lint`
- `npm test`
- `npm run test:coverage` *(fails because coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68534a269104832b93ab1d7ba8a9abc2