### PR TITLE
Fix e2e env setup

### DIFF
--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -3,20 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { type TestServer, startServer } from "./startServer";
+import { createApi } from "./api";
 
 let server: TestServer;
-let cookie = "";
-
-async function api(path: string, opts: RequestInit = {}) {
-  const res = await fetch(`${server.url}${path}`, {
-    ...opts,
-    headers: { ...(opts.headers || {}), cookie },
-    redirect: "manual",
-  });
-  const set = res.headers.get("set-cookie");
-  if (set) cookie = set.split(";")[0];
-  return res;
-}
+let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
 async function signIn(email: string) {
   const csrf = await api("/api/auth/csrf").then((r) => r.json());
@@ -64,6 +54,7 @@ beforeAll(async () => {
     SMTP_FROM: "test@example.com",
     CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
   });
+  api = createApi(server);
 }, 120000);
 
 afterAll(async () => {

--- a/test/e2e/api.ts
+++ b/test/e2e/api.ts
@@ -1,0 +1,22 @@
+export interface ApiOptions {
+  headers?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+export function createApi(server: { url: string }): (path: string, opts?: RequestInit) => Promise<Response> {
+  let cookie = "";
+  return async (path: string, opts: RequestInit = {}): Promise<Response> => {
+    const res = await fetch(`${server.url}${path}`, {
+      ...opts,
+      headers: { ...(opts.headers || {}), cookie },
+      redirect: "manual",
+    });
+    const set =
+      res.headers.getSetCookie?.() ??
+      (res.headers.has("set-cookie") ? [res.headers.get("set-cookie") as string] : []);
+    if (set.length > 0) {
+      cookie = set.map((c) => c.split(";")[0]).join("; ");
+    }
+    return res;
+  };
+}

--- a/test/e2e/auth.test.ts
+++ b/test/e2e/auth.test.ts
@@ -1,19 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { type TestServer, startServer } from "./startServer";
+import { createApi } from "./api";
 
 let server: TestServer;
-let cookie = "";
-
-async function api(path: string, opts: RequestInit = {}) {
-  const res = await fetch(`${server.url}${path}`, {
-    ...opts,
-    headers: { ...(opts.headers || {}), cookie },
-    redirect: "manual",
-  });
-  const set = res.headers.get("set-cookie");
-  if (set) cookie = set.split(";")[0];
-  return res;
-}
+let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
 beforeAll(async () => {
   server = await startServer(3010, {
@@ -21,6 +11,7 @@ beforeAll(async () => {
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
   });
+  api = createApi(server);
 }, 120000);
 
 afterAll(async () => {

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -4,7 +4,9 @@ import { type TestServer, startServer } from "./startServer";
 let server: TestServer;
 
 beforeAll(async () => {
-  server = await startServer(3002);
+  server = await startServer(3002, {
+    NEXTAUTH_SECRET: "secret",
+  });
 }, 120000);
 
 afterAll(async () => {

--- a/test/e2e/members.test.ts
+++ b/test/e2e/members.test.ts
@@ -3,20 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { type TestServer, startServer } from "./startServer";
+import { createApi } from "./api";
 
 let server: TestServer;
-let cookie = "";
-
-async function api(path: string, opts: RequestInit = {}) {
-  const res = await fetch(`${server.url}${path}`, {
-    ...opts,
-    headers: { ...(opts.headers || {}), cookie },
-    redirect: "manual",
-  });
-  const set = res.headers.get("set-cookie");
-  if (set) cookie = set.split(";")[0];
-  return res;
-}
+let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
 async function signIn(email: string) {
   const csrf = await api("/api/auth/csrf").then((r) => r.json());
@@ -64,6 +54,7 @@ beforeAll(async () => {
     SMTP_FROM: "test@example.com",
     CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
   });
+  api = createApi(server);
 }, 120000);
 
 afterAll(async () => {

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -3,20 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { type TestServer, startServer } from "./startServer";
+import { createApi } from "./api";
 
 let server: TestServer;
-let cookie = "";
-
-async function api(path: string, opts: RequestInit = {}) {
-  const res = await fetch(`${server.url}${path}`, {
-    ...opts,
-    headers: { ...(opts.headers || {}), cookie },
-    redirect: "manual",
-  });
-  const set = res.headers.get("set-cookie");
-  if (set) cookie = set.split(";")[0];
-  return res;
-}
+let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
 async function signIn(email: string) {
   const csrf = await api("/api/auth/csrf").then((r) => r.json());
@@ -64,6 +54,7 @@ beforeAll(async () => {
     SMTP_FROM: "test@example.com",
     CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
   });
+  api = createApi(server);
 }, 120000);
 
 afterAll(async () => {

--- a/test/e2e/point.test.ts
+++ b/test/e2e/point.test.ts
@@ -4,7 +4,9 @@ import { type TestServer, startServer } from "./startServer";
 let server: TestServer;
 
 beforeAll(async () => {
-  server = await startServer(3005);
+  server = await startServer(3005, {
+    NEXTAUTH_SECRET: "secret",
+  });
 }, 120000);
 
 afterAll(async () => {

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -3,20 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { type TestServer, startServer } from "./startServer";
+import { createApi } from "./api";
 
 let server: TestServer;
-let cookie = "";
-
-async function api(path: string, opts: RequestInit = {}) {
-  const res = await fetch(`${server.url}${path}`, {
-    ...opts,
-    headers: { ...(opts.headers || {}), cookie },
-    redirect: "manual",
-  });
-  const set = res.headers.get("set-cookie");
-  if (set) cookie = set.split(";")[0];
-  return res;
-}
+let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
 async function signIn(email: string) {
   const csrf = await api("/api/auth/csrf").then((r) => r.json());
@@ -64,6 +54,7 @@ beforeAll(async () => {
     SMTP_FROM: "test@example.com",
     CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
   });
+  api = createApi(server);
 }, 120000);
 
 afterAll(async () => {

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -3,20 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { type TestServer, startServer } from "./startServer";
+import { createApi } from "./api";
 
 let server: TestServer;
-let cookie = "";
-
-async function api(path: string, opts: RequestInit = {}) {
-  const res = await fetch(`${server.url}${path}`, {
-    ...opts,
-    headers: { ...(opts.headers || {}), cookie },
-    redirect: "manual",
-  });
-  const set = res.headers.get("set-cookie");
-  if (set) cookie = set.split(";")[0];
-  return res;
-}
+let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
 async function signIn(email: string) {
   const csrf = await api("/api/auth/csrf").then((r) => r.json());
@@ -43,6 +33,7 @@ beforeAll(async () => {
     SMTP_FROM: "test@example.com",
     CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
   });
+  api = createApi(server);
 }, 120000);
 
 afterAll(async () => {

--- a/test/e2e/signinEmptyDb.test.ts
+++ b/test/e2e/signinEmptyDb.test.ts
@@ -3,21 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { type TestServer, startServer } from "./startServer";
+import { createApi } from "./api";
 
 let server: TestServer;
 let dataDir: string;
-let cookie = "";
-
-async function api(p: string, opts: RequestInit = {}) {
-  const res = await fetch(`${server.url}${p}`, {
-    ...opts,
-    headers: { ...(opts.headers || {}), cookie },
-    redirect: "manual",
-  });
-  const set = res.headers.get("set-cookie");
-  if (set) cookie = set.split(";")[0];
-  return res;
-}
+let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
 beforeAll(async () => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
@@ -27,6 +17,7 @@ beforeAll(async () => {
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
   });
+  api = createApi(server);
 }, 120000);
 
 afterAll(async () => {

--- a/test/e2e/stream.test.ts
+++ b/test/e2e/stream.test.ts
@@ -4,7 +4,9 @@ import { type TestServer, startServer } from "./startServer";
 let server: TestServer;
 
 beforeAll(async () => {
-  server = await startServer(3004);
+  server = await startServer(3004, {
+    NEXTAUTH_SECRET: "secret",
+  });
 }, 120000);
 
 afterAll(async () => {

--- a/test/e2e/thread.test.ts
+++ b/test/e2e/thread.test.ts
@@ -9,7 +9,10 @@ let tmpDir: string;
 
 beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  const env = { CASE_STORE_FILE: path.join(tmpDir, "cases.json") };
+  const env = {
+    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+    NEXTAUTH_SECRET: "secret",
+  };
   server = await startServer(3006, env);
 }, 120000);
 


### PR DESCRIPTION
## Summary
- add `NEXTAUTH_SECRET` to various e2e test servers so NextAuth can start

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: several tests still failing)*

------
https://chatgpt.com/codex/tasks/task_e_685348e05114832b833aa1df3cf1744a