### PR TITLE
Fix canvas capture when video dimensions are zero

### DIFF
--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -87,6 +87,7 @@ export default function PointAndShootPage() {
       if (!ctx) return;
       canvas.width = video.videoWidth;
       canvas.height = video.videoHeight;
+      if (canvas.width === 0 || canvas.height === 0) return;
       ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
       const data = ctx.getImageData(0, 0, canvas.width, canvas.height);
       w.postMessage({ type: "analyze", image: data }, [data.data.buffer]);

--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/api.ts
+++ b/test/e2e/api.ts
@@ -3,7 +3,10 @@ export interface ApiOptions {
   [key: string]: unknown;
 }
 
-export function createApi(server: { url: string }): (path: string, opts?: RequestInit) => Promise<Response> {
+export function createApi(server: { url: string }): (
+  path: string,
+  opts?: RequestInit,
+) => Promise<Response> {
   let cookie = "";
   return async (path: string, opts: RequestInit = {}): Promise<Response> => {
     const res = await fetch(`${server.url}${path}`, {
@@ -13,7 +16,9 @@ export function createApi(server: { url: string }): (path: string, opts?: Reques
     });
     const set =
       res.headers.getSetCookie?.() ??
-      (res.headers.has("set-cookie") ? [res.headers.get("set-cookie") as string] : []);
+      (res.headers.has("set-cookie")
+        ? [res.headers.get("set-cookie") as string]
+        : []);
     if (set.length > 0) {
       cookie = set.map((c) => c.split(";")[0]).join("; ");
     }

--- a/test/e2e/auth.test.ts
+++ b/test/e2e/auth.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/freshDatabase.test.ts
+++ b/test/e2e/freshDatabase.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let tmpDir: string;

--- a/test/e2e/members.test.ts
+++ b/test/e2e/members.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/signinEmptyDb.test.ts
+++ b/test/e2e/signinEmptyDb.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let dataDir: string;


### PR DESCRIPTION
## Summary
- skip frame analysis when the camera video stream reports zero width/height
- sort imports in e2e tests to satisfy linter
- format test helper API

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68540726b15c832b9abca0737dfde712