### PR TITLE
Add JSON file helpers and refactor modules

### DIFF
--- a/src/lib/fileUtils.ts
+++ b/src/lib/fileUtils.ts
@@ -1,0 +1,17 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export function readJsonFile<T>(file: string, fallback: T): T {
+  if (!fs.existsSync(file)) return fallback;
+  try {
+    const text = fs.readFileSync(file, "utf8");
+    return JSON.parse(text) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function writeJsonFile(file: string, data: unknown): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+}

--- a/src/lib/inboxScanner.ts
+++ b/src/lib/inboxScanner.ts
@@ -8,6 +8,7 @@ import { analyzeCaseInBackground } from "./caseAnalysis";
 import { fetchCaseLocationInBackground } from "./caseLocation";
 import { addCasePhoto, createCase } from "./caseStore";
 import { extractGps, extractTimestamp } from "./exif";
+import { readJsonFile, writeJsonFile } from "./fileUtils";
 
 dotenv.config();
 
@@ -16,17 +17,12 @@ const stateFile = process.env.INBOX_STATE_FILE
   : path.join(process.cwd(), "data", "inbox.json");
 
 function loadState(): number {
-  try {
-    const val = JSON.parse(fs.readFileSync(stateFile, "utf8"));
-    return typeof val.lastUid === "number" ? val.lastUid : 0;
-  } catch {
-    return 0;
-  }
+  const val = readJsonFile<{ lastUid?: number }>(stateFile, {});
+  return typeof val.lastUid === "number" ? val.lastUid : 0;
 }
 
 function saveState(uid: number): void {
-  fs.mkdirSync(path.dirname(stateFile), { recursive: true });
-  fs.writeFileSync(stateFile, JSON.stringify({ lastUid: uid }, null, 2));
+  writeJsonFile(stateFile, { lastUid: uid });
 }
 
 export async function scanInbox(): Promise<void> {

--- a/src/lib/snailMailProviders.ts
+++ b/src/lib/snailMailProviders.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { readJsonFile, writeJsonFile } from "./fileUtils";
 import { snailMailProviders } from "./snailMail";
 
 export interface SnailMailProviderStatus {
@@ -23,22 +24,14 @@ function defaultStatuses(): SnailMailProviderStatus[] {
 function loadStatuses(): SnailMailProviderStatus[] {
   if (!fs.existsSync(dataFile)) {
     const defaults = defaultStatuses();
-    fs.mkdirSync(path.dirname(dataFile), { recursive: true });
-    fs.writeFileSync(dataFile, JSON.stringify(defaults, null, 2));
+    writeJsonFile(dataFile, defaults);
     return defaults;
   }
-  try {
-    return JSON.parse(
-      fs.readFileSync(dataFile, "utf8"),
-    ) as SnailMailProviderStatus[];
-  } catch {
-    return defaultStatuses();
-  }
+  return readJsonFile<SnailMailProviderStatus[]>(dataFile, defaultStatuses());
 }
 
 function saveStatuses(list: SnailMailProviderStatus[]): void {
-  fs.mkdirSync(path.dirname(dataFile), { recursive: true });
-  fs.writeFileSync(dataFile, JSON.stringify(list, null, 2));
+  writeJsonFile(dataFile, list);
 }
 
 export function getSnailMailProviderStatuses(): SnailMailProviderStatus[] {

--- a/src/lib/snailMailStore.ts
+++ b/src/lib/snailMailStore.ts
@@ -12,25 +12,19 @@ export interface SentMail {
   sentAt: string;
 }
 
-import fs from "node:fs";
 import path from "node:path";
+import { readJsonFile, writeJsonFile } from "./fileUtils";
 
 const dataFile = process.env.SNAIL_MAIL_FILE
   ? path.resolve(process.env.SNAIL_MAIL_FILE)
   : path.join(process.cwd(), "data", "snailMail.json");
 
 function loadMails(): SentMail[] {
-  if (!fs.existsSync(dataFile)) return [];
-  try {
-    return JSON.parse(fs.readFileSync(dataFile, "utf8")) as SentMail[];
-  } catch {
-    return [];
-  }
+  return readJsonFile<SentMail[]>(dataFile, []);
 }
 
 function saveMails(list: SentMail[]): void {
-  fs.mkdirSync(path.dirname(dataFile), { recursive: true });
-  fs.writeFileSync(dataFile, JSON.stringify(list, null, 2));
+  writeJsonFile(dataFile, list);
 }
 
 export function addSentMail(mail: SentMail): SentMail {

--- a/src/lib/vinSources.ts
+++ b/src/lib/vinSources.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { readJsonFile, writeJsonFile } from "./fileUtils";
 
 export interface VinSource {
   id: string;
@@ -67,20 +68,14 @@ function loadStatuses(): VinSourceStatus[] {
       enabled: true,
       failureCount: 0,
     }));
-    fs.mkdirSync(path.dirname(dataFile), { recursive: true });
-    fs.writeFileSync(dataFile, JSON.stringify(defaults, null, 2));
+    writeJsonFile(dataFile, defaults);
     return defaults;
   }
-  try {
-    return JSON.parse(fs.readFileSync(dataFile, "utf8")) as VinSourceStatus[];
-  } catch {
-    return [];
-  }
+  return readJsonFile<VinSourceStatus[]>(dataFile, []);
 }
 
 function saveStatuses(statuses: VinSourceStatus[]): void {
-  fs.mkdirSync(path.dirname(dataFile), { recursive: true });
-  fs.writeFileSync(dataFile, JSON.stringify(statuses, null, 2));
+  writeJsonFile(dataFile, statuses);
 }
 
 export function getVinSourceStatuses(): VinSourceStatus[] {

--- a/src/lib/violationCodes.ts
+++ b/src/lib/violationCodes.ts
@@ -1,6 +1,6 @@
-import fs from "node:fs";
 import path from "node:path";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+import { readJsonFile, writeJsonFile } from "./fileUtils";
 import { getLlm } from "./llm";
 
 export interface ViolationCodeMap {
@@ -12,17 +12,11 @@ const dataFile = process.env.VIOLATION_CODE_FILE
   : path.join(process.cwd(), "data", "violationCodes.json");
 
 function loadCodes(): ViolationCodeMap {
-  if (!fs.existsSync(dataFile)) return {};
-  try {
-    return JSON.parse(fs.readFileSync(dataFile, "utf8")) as ViolationCodeMap;
-  } catch {
-    return {};
-  }
+  return readJsonFile<ViolationCodeMap>(dataFile, {});
 }
 
 function saveCodes(map: ViolationCodeMap): void {
-  fs.mkdirSync(path.dirname(dataFile), { recursive: true });
-  fs.writeFileSync(dataFile, JSON.stringify(map, null, 2));
+  writeJsonFile(dataFile, map);
 }
 
 function getStoredCode(municipality: string, violation: string): string | null {

--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/auth.test.ts
+++ b/test/e2e/auth.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/freshDatabase.test.ts
+++ b/test/e2e/freshDatabase.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let tmpDir: string;

--- a/test/e2e/members.test.ts
+++ b/test/e2e/members.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/signinEmptyDb.test.ts
+++ b/test/e2e/signinEmptyDb.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let dataDir: string;


### PR DESCRIPTION
## Summary
- add `readJsonFile` and `writeJsonFile` utilities
- refactor snail mail, inbox scanner and other modules to use the utilities
- fix import order in e2e tests so lint passes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854059d7e58832b9bac9d915e38ceff