### PR TITLE
Add Next.js error boundaries

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { withBasePath } from "@/basePath";
+import Link from "next/link";
+import { useEffect } from "react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+  return (
+    <div className="p-8 text-center">
+      <h1 className="text-2xl font-bold mb-4">Something went wrong</h1>
+      <p className="mb-4">Please try again or report the issue.</p>
+      <div className="flex gap-4 justify-center">
+        <button type="button" onClick={reset} className="underline">
+          Retry
+        </button>
+        <Link
+          href="https://github.com/antialias/photo-to-citation/issues"
+          className="underline"
+        >
+          Report Issue
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,14 @@
+import { withBasePath } from "@/basePath";
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="p-8 text-center">
+      <h1 className="text-2xl font-bold mb-4">Page Not Found</h1>
+      <p className="mb-4">Sorry, we couldn't find that page.</p>
+      <Link href={withBasePath("/")} className="underline">
+        Back to home
+      </Link>
+    </div>
+  );
+}

--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/api.ts
+++ b/test/e2e/api.ts
@@ -3,7 +3,10 @@ export interface ApiOptions {
   [key: string]: unknown;
 }
 
-export function createApi(server: { url: string }): (path: string, opts?: RequestInit) => Promise<Response> {
+export function createApi(server: { url: string }): (
+  path: string,
+  opts?: RequestInit,
+) => Promise<Response> {
   let cookie = "";
   return async (path: string, opts: RequestInit = {}): Promise<Response> => {
     const res = await fetch(`${server.url}${path}`, {
@@ -13,7 +16,9 @@ export function createApi(server: { url: string }): (path: string, opts?: Reques
     });
     const set =
       res.headers.getSetCookie?.() ??
-      (res.headers.has("set-cookie") ? [res.headers.get("set-cookie") as string] : []);
+      (res.headers.has("set-cookie")
+        ? [res.headers.get("set-cookie") as string]
+        : []);
     if (set.length > 0) {
       cookie = set.map((c) => c.split(";")[0]).join("; ");
     }

--- a/test/e2e/auth.test.ts
+++ b/test/e2e/auth.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/freshDatabase.test.ts
+++ b/test/e2e/freshDatabase.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let tmpDir: string;

--- a/test/e2e/members.test.ts
+++ b/test/e2e/members.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;

--- a/test/e2e/signinEmptyDb.test.ts
+++ b/test/e2e/signinEmptyDb.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
 import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let dataDir: string;


### PR DESCRIPTION
## Summary
- add global `not-found.tsx` for friendly 404s
- add Next.js `error.tsx` boundary with retry link
- reorder e2e imports for lint

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: NEXTAUTH_SECRET environment variable must be set)*
- `npm run dev` *(fails: NEXTAUTH_SECRET environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68540517d3f0832b879345586c75488f