### PR TITLE
Refactor session handling

### DIFF
--- a/src/app/api/cases/[id]/invite/route.ts
+++ b/src/app/api/cases/[id]/invite/route.ts
@@ -1,4 +1,4 @@
-import { withCaseAuthorization } from "@/lib/authz";
+import { getSessionDetails, withCaseAuthorization } from "@/lib/authz";
 import { addCaseMember, isCaseMember } from "@/lib/caseMembers";
 import { getCase } from "@/lib/caseStore";
 import { NextResponse } from "next/server";
@@ -21,12 +21,14 @@ export const POST = withCaseAuthorization(
     if (!c) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
-    const requester = session?.user;
-    const role = requester?.role ?? "user";
+    const { role, userId: requesterId } = getSessionDetails(
+      { session },
+      "user",
+    );
     if (
       role !== "admin" &&
       role !== "superadmin" &&
-      (!requester?.id || !isCaseMember(id, requester.id, "owner"))
+      (!requesterId || !isCaseMember(id, requesterId, "owner"))
     ) {
       return new Response(null, { status: 403 });
     }

--- a/src/app/api/cases/[id]/members/[uid]/route.ts
+++ b/src/app/api/cases/[id]/members/[uid]/route.ts
@@ -1,4 +1,4 @@
-import { withCaseAuthorization } from "@/lib/authz";
+import { getSessionDetails, withCaseAuthorization } from "@/lib/authz";
 import { isCaseMember, removeCaseMember } from "@/lib/caseMembers";
 import { getCase } from "@/lib/caseStore";
 import { NextResponse } from "next/server";
@@ -20,12 +20,14 @@ export const DELETE = withCaseAuthorization(
     if (!c) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
-    const requester = session?.user;
-    const role = requester?.role ?? "user";
+    const { role, userId: requesterId } = getSessionDetails(
+      { session },
+      "user",
+    );
     if (
       role !== "admin" &&
       role !== "superadmin" &&
-      (!requester?.id || !isCaseMember(id, requester.id, "owner"))
+      (!requesterId || !isCaseMember(id, requesterId, "owner"))
     ) {
       return new Response(null, { status: 403 });
     }

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -1,4 +1,8 @@
-import { withAuthorization, withCaseAuthorization } from "@/lib/authz";
+import {
+  getSessionDetails,
+  withAuthorization,
+  withCaseAuthorization,
+} from "@/lib/authz";
 import { isCaseMember } from "@/lib/caseMembers";
 import { deleteCase, getCase } from "@/lib/caseStore";
 import { NextResponse } from "next/server";
@@ -21,8 +25,7 @@ export const GET = withAuthorization(
     if (!c) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
-    const userId = session?.user?.id;
-    const role = session?.user?.role ?? "user";
+    const { userId, role } = getSessionDetails({ session }, "user");
     if (!c.public && role !== "admin" && role !== "superadmin") {
       if (!userId || !isCaseMember(id, userId)) {
         return new Response(null, { status: 403 });

--- a/src/app/api/cases/stream/route.ts
+++ b/src/app/api/cases/stream/route.ts
@@ -1,4 +1,4 @@
-import { withAuthorization } from "@/lib/authz";
+import { getSessionDetails, withAuthorization } from "@/lib/authz";
 import { caseEvents } from "@/lib/caseEvents";
 import { NextResponse } from "next/server";
 
@@ -16,7 +16,8 @@ export const GET = withAuthorization(
       session?: { user?: { role?: string } };
     },
   ) => {
-    if (!session?.user) {
+    const { userId } = getSessionDetails({ session });
+    if (!userId) {
       return new Response(null, { status: 403 });
     }
     const encoder = new TextEncoder();

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { withAuthorization } from "@/lib/authz";
+import { getSessionDetails, withAuthorization } from "@/lib/authz";
 import { analyzeCaseInBackground } from "@/lib/caseAnalysis";
 import { fetchCaseLocationInBackground } from "@/lib/caseLocation";
 import { addCasePhoto, createCase, getCase, updateCase } from "@/lib/caseStore";
@@ -63,12 +63,13 @@ export const POST = withAuthorization(
       analyzeCaseInBackground(p || updated);
       return NextResponse.json({ caseId: updated.id });
     }
+    const { userId } = getSessionDetails({ session }, "user");
     const newCase = createCase(
       `/uploads/${filename}`,
       gps,
       clientId || undefined,
       takenAt,
-      session?.user?.id ?? null,
+      userId ?? null,
     );
     const p = updateCase(newCase.id, {
       analysisStatus: "pending",

--- a/src/app/api/users/[id]/role/route.ts
+++ b/src/app/api/users/[id]/role/route.ts
@@ -1,5 +1,5 @@
 import { updateUserRole } from "@/lib/adminStore";
-import { withAuthorization } from "@/lib/authz";
+import { getSessionDetails, withAuthorization } from "@/lib/authz";
 import { NextResponse } from "next/server";
 
 export const PUT = withAuthorization(
@@ -15,7 +15,8 @@ export const PUT = withAuthorization(
       session?: { user?: { role?: string } };
     },
   ) => {
-    if (session?.user?.role !== "superadmin") {
+    const { role: requesterRole } = getSessionDetails({ session });
+    if (requesterRole !== "superadmin") {
       return new Response(null, { status: 403 });
     }
     const { id } = await params;


### PR DESCRIPTION
## Summary
- centralize extracting role and user ID from the session
- use shared function in `withAuthorization` and `withCaseAuthorization`
- refactor several API routes to use the new helper

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854057770ec832b98331b94305e3733