### PR TITLE
Fix super admin seeding

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -26,7 +26,6 @@ export async function seedSuperAdmin(newUser?: {
   email: string | null;
 }) {
   await migrationsReady;
-  console.log("seeding super admin", newUser?.email);
   const existing = orm
     .select()
     .from(users)
@@ -44,6 +43,7 @@ export async function seedSuperAdmin(newUser?: {
       newUser ?? orm.select().from(users).orderBy(sql`rowid`).limit(1).get();
   }
   if (target) {
+    console.log("seeding super admin", newUser?.email);
     orm
       .update(users)
       .set({ role: "superadmin" })

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -2,12 +2,8 @@ import { writeFile } from "node:fs/promises";
 import type { NextAuthOptions, Session, User } from "next-auth";
 import type { Adapter } from "next-auth/adapters";
 import EmailProvider from "next-auth/providers/email";
-import { authAdapter, seedSuperAdmin } from "./auth";
+import { authAdapter } from "./auth";
 import { sendEmail } from "./email";
-
-seedSuperAdmin().catch((err) => {
-  console.error("Failed to seed super admin", err);
-});
 
 export const authOptions: NextAuthOptions = {
   adapter: authAdapter() as Adapter,


### PR DESCRIPTION
## Summary
- seed the super admin only when a target exists
- remove duplicate call to `seedSuperAdmin`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68540b1331c0832b816cbbdd14049370