### PR TITLE
Fix TypeScript errors in tests and authOptions

### DIFF
--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -2,7 +2,7 @@ import { writeFile } from "node:fs/promises";
 import type { NextAuthOptions, Session, User } from "next-auth";
 import type { Adapter } from "next-auth/adapters";
 import EmailProvider from "next-auth/providers/email";
-import { authAdapter } from "./auth";
+import { authAdapter, seedSuperAdmin } from "./auth";
 import { sendEmail } from "./email";
 
 export const authOptions: NextAuthOptions = {

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -75,7 +75,7 @@ describe("permissions", () => {
   }, 30000);
 
   it("shows admin actions for admins", async () => {
-    cookie = "";
+    await signOut();
     await signIn("admin@example.com");
     const id = await createCase();
     const casePage = await api(`/cases/${id}`).then((r) => r.text());


### PR DESCRIPTION
## Summary
- clear session between permissions tests
- import seedSuperAdmin for auth options

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68540d48ac4c832b8cb0e7f6f29acc64