### PR TITLE
Adjust NEXTAUTH_SECRET check

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,5 @@
 import type { NextConfig } from "next";
 
-if (!process.env.NEXTAUTH_SECRET) {
-  console.error(
-    "NEXTAUTH_SECRET environment variable must be set to preserve sessions",
-  );
-  process.exit(1);
-}
-
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
 const assetPrefix = basePath ? `${basePath}/` : undefined;
 

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -5,6 +5,12 @@ import EmailProvider from "next-auth/providers/email";
 import { authAdapter } from "./auth";
 import { sendEmail } from "./email";
 
+if (!process.env.NEXTAUTH_SECRET) {
+  console.error(
+    "NEXTAUTH_SECRET environment variable must be set to preserve sessions",
+  );
+}
+
 export const authOptions: NextAuthOptions = {
   adapter: authAdapter() as Adapter,
   providers: [


### PR DESCRIPTION
## Summary
- remove build-time NEXTAUTH_SECRET requirement from `next.config.ts`
- log an error at runtime if `NEXTAUTH_SECRET` is missing

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68540a7f829c832bbc21d8c3a9509e6c