### PR TITLE
Improve sign-in configuration error

### DIFF
--- a/src/app/signin/__tests__/SignInPage.test.tsx
+++ b/src/app/signin/__tests__/SignInPage.test.tsx
@@ -12,8 +12,18 @@ vi.mock("next/navigation", () => ({
 }));
 
 describe("SignInPage", () => {
-  it("shows error message from query", () => {
-    mockGet.mockReturnValueOnce("some-error");
+  it("shows configuration error message", () => {
+    mockGet.mockReturnValueOnce("Configuration");
+    render(<SignInPage />);
+    expect(
+      screen.getByText(
+        /Configuration error\. NEXTAUTH_URL must match the site URL including any base path\./i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows generic error message for other errors", () => {
+    mockGet.mockReturnValueOnce("other");
     render(<SignInPage />);
     expect(
       screen.getByText(/Sign-in failed. The link may have expired./i),

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -8,11 +8,19 @@ export default function SignInPage() {
   const [email, setEmail] = useState("");
   const params = useSearchParams();
   const error = params.get("error");
+  const errorMessages: Record<string, string> = {
+    Configuration:
+      "Configuration error. NEXTAUTH_URL must match the site URL including any base path.",
+    Verification: "Sign-in failed. The link may have expired.",
+  };
+  const message = error
+    ? (errorMessages[error] ?? errorMessages.Verification)
+    : null;
   return (
     <>
-      {error ? (
+      {message ? (
         <div className="bg-red-100 border border-red-300 text-red-700 p-2 mb-2">
-          Sign-in failed. The link may have expired.
+          {message}
         </div>
       ) : null}
       <form


### PR DESCRIPTION
## Summary
- show a detailed configuration error message on the sign-in page
- test sign-in page error handling for configuration issues

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685409a2126c832ba5a0b81c065847de