### PR TITLE
Add env config parsing with zod

### DIFF
--- a/src/app/api/test/verification-url/route.ts
+++ b/src/app/api/test/verification-url/route.ts
@@ -1,8 +1,9 @@
 import { readFile } from "node:fs/promises";
 import { NextResponse } from "next/server";
+import { config } from "../../../lib/config";
 
 export async function GET() {
-  if (!process.env.TEST_APIS) {
+  if (!config.TEST_APIS) {
     return new NextResponse(null, { status: 404 });
   }
   let url: string | undefined;

--- a/src/app/components/CaseProgressGraph.tsx
+++ b/src/app/components/CaseProgressGraph.tsx
@@ -10,10 +10,14 @@ import {
   getCaseVin,
   hasViolation,
 } from "@/lib/caseUtils";
+import { config } from "@/lib/config";
 import dynamic from "next/dynamic";
 import { useEffect, useMemo, useRef, useState } from "react";
 import tippy from "tippy.js";
-if (typeof window !== "undefined" && !process.env.VITEST) {
+if (
+  typeof window !== "undefined" &&
+  !(config as Record<string, unknown>).VITEST
+) {
   import("tippy.js/dist/tippy.css");
 }
 

--- a/src/app/components/DebugWrapper.tsx
+++ b/src/app/components/DebugWrapper.tsx
@@ -2,6 +2,7 @@
 import Tippy from "@tippyjs/react";
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
+import { config } from "../../lib/config";
 import useAltKey from "../useAltKey";
 
 function tokenize(json: string): ReactNode[] {
@@ -38,7 +39,7 @@ export default function DebugWrapper({
   data: unknown;
   children: ReactNode;
 }) {
-  const enabled = Boolean(process.env.NEXT_PUBLIC_BROWSER_DEBUG);
+  const enabled = Boolean(config.NEXT_PUBLIC_BROWSER_DEBUG);
   const alt = useAltKey();
   const [refHover, setRefHover] = useState(false);
   const [tipHover, setTipHover] = useState(false);

--- a/src/app/components/MapPreview.tsx
+++ b/src/app/components/MapPreview.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { config } from "../../lib/config";
 
 export default function MapPreview({
   lat,
@@ -15,7 +16,7 @@ export default function MapPreview({
   className?: string;
   link?: string;
 }) {
-  const key = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+  const key = config.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
   const url = key
     ? `https://maps.googleapis.com/maps/api/staticmap?center=${lat},${lon}&zoom=16&size=${width}x${height}&markers=color:red|${lat},${lon}&key=${key}`
     : `https://staticmap.openstreetmap.de/staticmap.php?center=${lat},${lon}&zoom=16&size=${width}x${height}&markers=${lat},${lon},red`;

--- a/src/basePath.ts
+++ b/src/basePath.ts
@@ -1,4 +1,6 @@
-export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || "";
+import { config } from "./lib/config";
+
+export const BASE_PATH = config.NEXT_PUBLIC_BASE_PATH || "";
 export function withBasePath(path: string): string {
   return `${BASE_PATH}${path}`;
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import type { AdapterUser } from "@auth/core/adapters";
 import { DrizzleAdapter } from "@auth/drizzle-adapter";
 import { eq, sql } from "drizzle-orm";
+import { config } from "./config";
 import { migrationsReady } from "./db";
 import { orm } from "./orm";
 import { users } from "./schema";
@@ -33,7 +34,7 @@ export async function seedSuperAdmin(newUser?: {
     .get();
   if (existing) return;
   let target: { id: string } | undefined;
-  const envEmail = process.env.SUPER_ADMIN_EMAIL;
+  const envEmail = config.SUPER_ADMIN_EMAIL;
   if (envEmail) {
     if (newUser && newUser.email === envEmail) target = newUser;
     else

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -3,9 +3,10 @@ import type { NextAuthOptions, Session, User } from "next-auth";
 import type { Adapter } from "next-auth/adapters";
 import EmailProvider from "next-auth/providers/email";
 import { authAdapter, seedSuperAdmin } from "./auth";
+import { config } from "./config";
 import { sendEmail } from "./email";
 
-if (!process.env.NEXTAUTH_SECRET) {
+if (!config.NEXTAUTH_SECRET) {
   console.error(
     "NEXTAUTH_SECRET environment variable must be set to preserve sessions",
   );
@@ -17,7 +18,7 @@ export const authOptions: NextAuthOptions = {
     EmailProvider({
       async sendVerificationRequest({ identifier, url }) {
         console.log("sendVerificationRequest", identifier);
-        if (process.env.TEST_APIS) {
+        if (config.TEST_APIS) {
           (global as Record<string, unknown>).verificationUrl = url;
           await writeFile("/tmp/verification-url.txt", url);
           return;
@@ -25,7 +26,7 @@ export const authOptions: NextAuthOptions = {
         await sendEmail({ to: identifier, subject: "Sign in", body: url });
         console.log("Verification email sent", identifier);
       },
-      from: process.env.SMTP_FROM,
+      from: config.SMTP_FROM,
     }),
   ],
   pages: { signIn: "/signin" },
@@ -53,5 +54,5 @@ export const authOptions: NextAuthOptions = {
       }
     },
   },
-  secret: process.env.NEXTAUTH_SECRET,
+  secret: config.NEXTAUTH_SECRET,
 };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,57 @@
+import dotenv from "dotenv";
+import { z } from "zod";
+
+dotenv.config();
+
+const envSchema = z
+  .object({
+    OPENAI_API_KEY: z.string().optional(),
+    OPENAI_BASE_URL: z.string().optional(),
+    LLM_PROVIDERS: z.string().default("openai"),
+    LLM_DRAFT_EMAIL_MODEL: z.string().default("gpt-4o"),
+    LLM_DRAFT_EMAIL_PROVIDER: z.string().default("openai"),
+    LLM_ANALYZE_IMAGES_MODEL: z.string().default("gpt-4o"),
+    LLM_ANALYZE_IMAGES_PROVIDER: z.string().default("openai"),
+    LLM_OCR_PAPERWORK_MODEL: z.string().default("gpt-4o"),
+    LLM_OCR_PAPERWORK_PROVIDER: z.string().default("openai"),
+    LLM_EXTRACT_INFO_MODEL: z.string().default("gpt-4o"),
+    LLM_EXTRACT_INFO_PROVIDER: z.string().default("openai"),
+    GOOGLE_MAPS_API_KEY: z.string().optional(),
+    NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: z.string().optional(),
+    SMTP_HOST: z.string().optional(),
+    SMTP_PORT: z.coerce.number().optional(),
+    SMTP_SECURE: z.coerce.boolean().optional(),
+    SMTP_USER: z.string().optional(),
+    SMTP_PASS: z.string().optional(),
+    SMTP_FROM: z.string().optional(),
+    MOCK_EMAIL_TO: z.string().optional(),
+    SUPER_ADMIN_EMAIL: z.string().optional(),
+    NEXTAUTH_SECRET: z.string().optional(),
+    NEXTAUTH_URL: z.string().optional(),
+    CASE_STORE_FILE: z.string().optional(),
+    VIN_SOURCE_FILE: z.string().optional(),
+    SNAIL_MAIL_FILE: z.string().optional(),
+    SNAIL_MAIL_PROVIDER_FILE: z.string().optional(),
+    RETURN_ADDRESS: z.string().optional(),
+    SNAIL_MAIL_PROVIDER: z.string().default("mock"),
+    SNAIL_MAIL_OUT_DIR: z.string().optional(),
+    TWILIO_ACCOUNT_SID: z.string().optional(),
+    TWILIO_AUTH_TOKEN: z.string().optional(),
+    TWILIO_FROM_NUMBER: z.string().optional(),
+    DOCSMIT_BASE_URL: z.string().optional(),
+    DOCSMIT_EMAIL: z.string().optional(),
+    DOCSMIT_PASSWORD: z.string().optional(),
+    DOCSMIT_SOFTWARE_ID: z.string().optional(),
+    IMAP_HOST: z.string().optional(),
+    IMAP_PORT: z.coerce.number().optional(),
+    IMAP_USER: z.string().optional(),
+    IMAP_PASS: z.string().optional(),
+    IMAP_TLS: z.coerce.boolean().default(true),
+    INBOX_STATE_FILE: z.string().optional(),
+    NEXT_PUBLIC_BROWSER_DEBUG: z.coerce.boolean().default(false),
+    NEXT_PUBLIC_BASE_PATH: z.string().default(""),
+  })
+  .passthrough();
+
+export const config = envSchema.parse(process.env);
+export type Config = typeof config;

--- a/src/lib/contactMethods.ts
+++ b/src/lib/contactMethods.ts
@@ -7,15 +7,13 @@ export interface OwnerContactInfo {
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import dotenv from "dotenv";
 import twilio from "twilio";
+import { config } from "./config";
 
 import {
   type MailingAddress,
   sendSnailMail as providerSendSnailMail,
 } from "./snailMail";
-
-dotenv.config();
 
 function parseAddress(text: string): MailingAddress {
   const lines = text.trim().split(/\n+/);
@@ -34,9 +32,9 @@ function parseAddress(text: string): MailingAddress {
 }
 
 export async function sendSms(to: string, message: string): Promise<void> {
-  const sid = process.env.TWILIO_ACCOUNT_SID;
-  const token = process.env.TWILIO_AUTH_TOKEN;
-  const from = process.env.TWILIO_FROM_NUMBER;
+  const sid = config.TWILIO_ACCOUNT_SID;
+  const token = config.TWILIO_AUTH_TOKEN;
+  const from = config.TWILIO_FROM_NUMBER;
   if (!sid || !token || !from) {
     throw new Error("Twilio SMS not configured");
   }
@@ -49,9 +47,9 @@ export async function sendSms(to: string, message: string): Promise<void> {
 }
 
 export async function sendWhatsapp(to: string, message: string): Promise<void> {
-  const sid = process.env.TWILIO_ACCOUNT_SID;
-  const token = process.env.TWILIO_AUTH_TOKEN;
-  const from = process.env.TWILIO_FROM_NUMBER;
+  const sid = config.TWILIO_ACCOUNT_SID;
+  const token = config.TWILIO_AUTH_TOKEN;
+  const from = config.TWILIO_FROM_NUMBER;
   if (!sid || !token || !from) {
     throw new Error("Twilio WhatsApp not configured");
   }
@@ -64,9 +62,9 @@ export async function sendWhatsapp(to: string, message: string): Promise<void> {
 }
 
 export async function makeRobocall(to: string, message: string): Promise<void> {
-  const sid = process.env.TWILIO_ACCOUNT_SID;
-  const token = process.env.TWILIO_AUTH_TOKEN;
-  const from = process.env.TWILIO_FROM_NUMBER;
+  const sid = config.TWILIO_ACCOUNT_SID;
+  const token = config.TWILIO_AUTH_TOKEN;
+  const from = config.TWILIO_FROM_NUMBER;
   if (!sid || !token || !from) {
     throw new Error("Twilio voice not configured");
   }
@@ -84,8 +82,8 @@ export async function sendSnailMail(options: {
   body: string;
   attachments: string[];
 }): Promise<void> {
-  const provider = process.env.SNAIL_MAIL_PROVIDER || "mock";
-  const returnAddr = process.env.RETURN_ADDRESS;
+  const provider = config.SNAIL_MAIL_PROVIDER || "mock";
+  const returnAddr = config.RETURN_ADDRESS;
   if (!returnAddr) {
     throw new Error("RETURN_ADDRESS not configured");
   }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import Database from "better-sqlite3";
+import { config } from "./config";
 import { runMigrations } from "./migrate";
 
-const dbFile = process.env.CASE_STORE_FILE
-  ? path.resolve(process.env.CASE_STORE_FILE)
+const dbFile = config.CASE_STORE_FILE
+  ? path.resolve(config.CASE_STORE_FILE)
   : path.join(process.cwd(), "data", "cases.sqlite");
 
 fs.mkdirSync(path.dirname(dbFile), { recursive: true });

--- a/src/lib/docsmitProvider.ts
+++ b/src/lib/docsmitProvider.ts
@@ -1,8 +1,8 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import dotenv from "dotenv";
 import FormData from "form-data";
+import { config } from "./config";
 import type {
   MailingAddress,
   SnailMailOptions,
@@ -10,8 +10,6 @@ import type {
   SnailMailStatus,
 } from "./snailMail";
 import { addSentMail } from "./snailMailStore";
-
-dotenv.config();
 
 let cachedToken: { token: string; fetchedAt: number } | null = null;
 
@@ -104,10 +102,10 @@ const provider: SnailMailProvider = {
   docs: "https://docs.docsmit.com",
   async send(opts: SnailMailOptions): Promise<SnailMailStatus> {
     const base =
-      process.env.DOCSMIT_BASE_URL || "https://secure.tracksmit.com/api/v1";
-    const email = process.env.DOCSMIT_EMAIL || "";
-    const password = process.env.DOCSMIT_PASSWORD || "";
-    const softwareID = process.env.DOCSMIT_SOFTWARE_ID || "";
+      config.DOCSMIT_BASE_URL || "https://secure.tracksmit.com/api/v1";
+    const email = config.DOCSMIT_EMAIL || "";
+    const password = config.DOCSMIT_PASSWORD || "";
+    const softwareID = config.DOCSMIT_SOFTWARE_ID || "";
     if (!email || !password || !softwareID)
       throw new Error("Docsmit env vars not set");
     const createBody = {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,8 +1,6 @@
 import path from "node:path";
-import dotenv from "dotenv";
 import nodemailer from "nodemailer";
-
-dotenv.config();
+import { config } from "./config";
 
 export interface EmailOptions {
   /** @zod.email */
@@ -20,10 +18,10 @@ export async function sendEmail({
 }: EmailOptions): Promise<void> {
   console.log("sendEmail", to, subject);
   const missing: string[] = [];
-  if (!process.env.SMTP_HOST) missing.push("SMTP_HOST");
-  if (!process.env.SMTP_USER) missing.push("SMTP_USER");
-  if (!process.env.SMTP_PASS) missing.push("SMTP_PASS");
-  if (!process.env.SMTP_FROM) missing.push("SMTP_FROM");
+  if (!config.SMTP_HOST) missing.push("SMTP_HOST");
+  if (!config.SMTP_USER) missing.push("SMTP_USER");
+  if (!config.SMTP_PASS) missing.push("SMTP_PASS");
+  if (!config.SMTP_FROM) missing.push("SMTP_FROM");
   if (missing.length) {
     throw new Error(`Missing SMTP configuration: ${missing.join(", ")}`);
   }
@@ -31,12 +29,12 @@ export async function sendEmail({
   let transporter: ReturnType<typeof nodemailer.createTransport>;
   try {
     transporter = nodemailer.createTransport({
-      host: process.env.SMTP_HOST,
-      port: process.env.SMTP_PORT ? Number(process.env.SMTP_PORT) : 587,
-      secure: process.env.SMTP_SECURE === "true",
+      host: config.SMTP_HOST,
+      port: config.SMTP_PORT ? Number(config.SMTP_PORT) : 587,
+      secure: config.SMTP_SECURE === true,
       auth: {
-        user: process.env.SMTP_USER,
-        pass: process.env.SMTP_PASS,
+        user: config.SMTP_USER,
+        pass: config.SMTP_PASS,
       },
     });
   } catch (err) {
@@ -44,9 +42,9 @@ export async function sendEmail({
     throw err;
   }
 
-  const override = process.env.MOCK_EMAIL_TO;
+  const override = config.MOCK_EMAIL_TO;
   await transporter.sendMail({
-    from: process.env.SMTP_FROM,
+    from: config.SMTP_FROM,
     to: override || to,
     subject,
     text: body,

--- a/src/lib/fileSnailMailProvider.ts
+++ b/src/lib/fileSnailMailProvider.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { config } from "./config";
 import type {
   SnailMailOptions,
   SnailMailProvider,
@@ -18,7 +19,7 @@ const provider: SnailMailProvider = {
   ): Promise<SnailMailStatus> {
     const dir =
       (config?.dir as string) ||
-      process.env.SNAIL_MAIL_OUT_DIR ||
+      config.SNAIL_MAIL_OUT_DIR ||
       path.join(process.cwd(), "data", "snailmail_out");
     fs.mkdirSync(dir, { recursive: true });
     const id = crypto.randomUUID();

--- a/src/lib/geocode.ts
+++ b/src/lib/geocode.ts
@@ -1,6 +1,4 @@
-import dotenv from "dotenv";
-
-dotenv.config();
+import { config } from "./config";
 
 export interface Coordinates {
   lat: number;
@@ -9,7 +7,7 @@ export interface Coordinates {
 
 async function fetchGeocode(params: Record<string, string>): Promise<unknown> {
   const query = new URLSearchParams({
-    key: process.env.GOOGLE_MAPS_API_KEY || "",
+    key: config.GOOGLE_MAPS_API_KEY,
     ...params,
   });
   const res = await fetch(

--- a/src/lib/inboxScanner.ts
+++ b/src/lib/inboxScanner.ts
@@ -1,19 +1,17 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import dotenv from "dotenv";
 import { ImapFlow } from "imapflow";
 import { simpleParser } from "mailparser";
 import { analyzeCaseInBackground } from "./caseAnalysis";
 import { fetchCaseLocationInBackground } from "./caseLocation";
 import { addCasePhoto, createCase } from "./caseStore";
+import { config } from "./config";
 import { extractGps, extractTimestamp } from "./exif";
 import { readJsonFile, writeJsonFile } from "./fileUtils";
 
-dotenv.config();
-
-const stateFile = process.env.INBOX_STATE_FILE
-  ? path.resolve(process.env.INBOX_STATE_FILE)
+const stateFile = config.INBOX_STATE_FILE
+  ? path.resolve(config.INBOX_STATE_FILE)
   : path.join(process.cwd(), "data", "inbox.json");
 
 function loadState(): number {
@@ -27,12 +25,12 @@ function saveState(uid: number): void {
 
 export async function scanInbox(): Promise<void> {
   const client = new ImapFlow({
-    host: process.env.IMAP_HOST,
-    port: process.env.IMAP_PORT ? Number(process.env.IMAP_PORT) : 993,
-    secure: process.env.IMAP_TLS !== "false",
+    host: config.IMAP_HOST,
+    port: config.IMAP_PORT ? Number(config.IMAP_PORT) : 993,
+    secure: config.IMAP_TLS !== false,
     auth: {
-      user: process.env.IMAP_USER,
-      pass: process.env.IMAP_PASS,
+      user: config.IMAP_USER,
+      pass: config.IMAP_PASS,
     },
   });
 

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -1,7 +1,5 @@
-import dotenv from "dotenv";
 import OpenAI from "openai";
-
-dotenv.config();
+import { config } from "./config";
 
 export interface LlmProvider {
   id: string;
@@ -17,7 +15,7 @@ export type LlmFeature =
   | "lookup_code";
 
 function loadProviders(): Record<string, LlmProvider> {
-  const list = (process.env.LLM_PROVIDERS || "openai").split(/[,\s]+/);
+  const list = config.LLM_PROVIDERS.split(/[,\s]+/);
   const map: Record<string, LlmProvider> = {};
   for (const name of list) {
     if (!name) continue;
@@ -25,8 +23,12 @@ function loadProviders(): Record<string, LlmProvider> {
     const upper = key.toUpperCase().replace(/-/g, "_");
     map[key] = {
       id: key,
-      apiKey: process.env[`${upper}_API_KEY`] || "",
-      baseURL: process.env[`${upper}_BASE_URL`],
+      apiKey:
+        (config as Record<string, string | undefined>)[`${upper}_API_KEY`] ||
+        "",
+      baseURL: (config as Record<string, string | undefined>)[
+        `${upper}_BASE_URL`
+      ],
     };
   }
   return map;
@@ -52,12 +54,16 @@ function toEnvKey(feature: LlmFeature): string {
 }
 
 function getFeatureProvider(feature: LlmFeature): string {
-  const env = process.env[`LLM_${toEnvKey(feature)}_PROVIDER`];
+  const env = (config as Record<string, string | undefined>)[
+    `LLM_${toEnvKey(feature)}_PROVIDER`
+  ];
   return env || "openai";
 }
 
 function getFeatureModel(feature: LlmFeature): string {
-  const env = process.env[`LLM_${toEnvKey(feature)}_MODEL`];
+  const env = (config as Record<string, string | undefined>)[
+    `LLM_${toEnvKey(feature)}_MODEL`
+  ];
   return env || "gpt-4o";
 }
 

--- a/src/lib/ownershipModules.ts
+++ b/src/lib/ownershipModules.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { PDFDocument } from "pdf-lib";
+import { config } from "./config";
 import type { MailingAddress } from "./snailMail";
 import { sendSnailMail as providerSendSnailMail } from "./snailMail";
 
@@ -41,8 +42,8 @@ function parseAddress(text: string): MailingAddress {
 }
 
 async function mailPdf(address: string, pdfPath: string): Promise<void> {
-  const provider = process.env.SNAIL_MAIL_PROVIDER || "mock";
-  const returnAddr = process.env.RETURN_ADDRESS;
+  const provider = config.SNAIL_MAIL_PROVIDER || "mock";
+  const returnAddr = config.RETURN_ADDRESS;
   if (!returnAddr) throw new Error("RETURN_ADDRESS not configured");
   const to = parseAddress(address);
   const from = parseAddress(returnAddr);

--- a/src/lib/snailMailProviders.ts
+++ b/src/lib/snailMailProviders.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { config } from "./config";
 import { readJsonFile, writeJsonFile } from "./fileUtils";
 import { snailMailProviders } from "./snailMail";
 
@@ -9,8 +10,8 @@ export interface SnailMailProviderStatus {
   failureCount: number;
 }
 
-const dataFile = process.env.SNAIL_MAIL_PROVIDER_FILE
-  ? path.resolve(process.env.SNAIL_MAIL_PROVIDER_FILE)
+const dataFile = config.SNAIL_MAIL_PROVIDER_FILE
+  ? path.resolve(config.SNAIL_MAIL_PROVIDER_FILE)
   : path.join(process.cwd(), "data", "snailMailProviders.json");
 
 function defaultStatuses(): SnailMailProviderStatus[] {

--- a/src/lib/snailMailStore.ts
+++ b/src/lib/snailMailStore.ts
@@ -13,10 +13,11 @@ export interface SentMail {
 }
 
 import path from "node:path";
+import { config } from "./config";
 import { readJsonFile, writeJsonFile } from "./fileUtils";
 
-const dataFile = process.env.SNAIL_MAIL_FILE
-  ? path.resolve(process.env.SNAIL_MAIL_FILE)
+const dataFile = config.SNAIL_MAIL_FILE
+  ? path.resolve(config.SNAIL_MAIL_FILE)
   : path.join(process.cwd(), "data", "snailMail.json");
 
 function loadMails(): SentMail[] {

--- a/src/lib/vinSources.ts
+++ b/src/lib/vinSources.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { config } from "./config";
 import { readJsonFile, writeJsonFile } from "./fileUtils";
 
 export interface VinSource {
@@ -57,8 +58,8 @@ export interface VinSourceStatus {
   failureCount: number;
 }
 
-const dataFile = process.env.VIN_SOURCE_FILE
-  ? path.resolve(process.env.VIN_SOURCE_FILE)
+const dataFile = config.VIN_SOURCE_FILE
+  ? path.resolve(config.VIN_SOURCE_FILE)
   : path.join(process.cwd(), "data", "vinSources.json");
 
 function loadStatuses(): VinSourceStatus[] {

--- a/src/lib/violationCodes.ts
+++ b/src/lib/violationCodes.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+import { config } from "./config";
 import { readJsonFile, writeJsonFile } from "./fileUtils";
 import { getLlm } from "./llm";
 
@@ -7,8 +8,8 @@ export interface ViolationCodeMap {
   [municipality: string]: Record<string, string>;
 }
 
-const dataFile = process.env.VIOLATION_CODE_FILE
-  ? path.resolve(process.env.VIOLATION_CODE_FILE)
+const dataFile = config.VIOLATION_CODE_FILE
+  ? path.resolve(config.VIOLATION_CODE_FILE)
   : path.join(process.cwd(), "data", "violationCodes.json");
 
 function loadCodes(): ViolationCodeMap {


### PR DESCRIPTION
## Summary
- centralize environment variable validation in `src/lib/config.ts`
- use typed config in backend modules and components
- update basePath helper to use typed config

## Testing
- `npm run lint`
- `npm test` *(fails: Could not locate better_sqlite3 bindings)*

------
https://chatgpt.com/codex/tasks/task_e_6854160b9aa0832bb3649eb412787bbe