### PR TITLE
Fix auth test verification endpoint

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,16 +1,23 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { sendEmail } from "@/lib/email";
 import { orm } from "@/lib/orm";
 import { DrizzleAdapter } from "@auth/drizzle-adapter";
 import NextAuth from "next-auth";
 import EmailProvider from "next-auth/providers/email";
 
+const verFile = path.join(os.tmpdir(), "verification-url.txt");
+
+export const runtime = "nodejs";
+
 export const authOptions = {
   adapter: DrizzleAdapter(orm),
   providers: [
     EmailProvider({
       async sendVerificationRequest({ identifier, url }) {
-        if (process.env.NODE_ENV === "test") {
-          (global as Record<string, unknown>).verificationUrl = url;
+        if (process.env.CI === "1") {
+          fs.writeFileSync(verFile, url, "utf8");
           return;
         }
         await sendEmail({ to: identifier, subject: "Sign in", body: url });

--- a/src/app/api/test/verification-url/route.ts
+++ b/src/app/api/test/verification-url/route.ts
@@ -1,9 +1,18 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { NextResponse } from "next/server";
 
+const verFile = path.join(os.tmpdir(), "verification-url.txt");
+
+export const runtime = "nodejs";
+
 export async function GET() {
-  if (process.env.NODE_ENV !== "test") {
+  if (process.env.CI !== "1") {
     return new NextResponse(null, { status: 404 });
   }
-  const url = (global as Record<string, unknown>).verificationUrl;
+  const url = fs.existsSync(verFile)
+    ? fs.readFileSync(verFile, "utf8")
+    : undefined;
   return NextResponse.json({ url });
 }


### PR DESCRIPTION
## Summary
- use CI env var to save the test verification URL
- expose the stored verification link to tests
- handle multiple cookies in e2e auth test and expect empty session

## Testing
- `npm test`
- `npx vitest run -c vitest.e2e.config.ts test/e2e/auth.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_685418e40268832b990e0dbba8836a95