### PR TITLE
Fix CASE_STORE_FILE references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,8 @@ SUPER_ADMIN_EMAIL=
 NEXTAUTH_SECRET=
 NEXTAUTH_URL=
 
-# JSON data file locations
+# SQLite database locations
+# Default case store is data/cases.sqlite
 CASE_STORE_FILE=
 VIN_SOURCE_FILE=
 SNAIL_MAIL_FILE=

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -12,7 +12,7 @@ let schema: typeof import("../src/lib/schema");
 
 beforeEach(async () => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
-  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.json");
+  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
   const dbModule = await import("../src/lib/db");
   caseStore = await import("../src/lib/caseStore");

--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -52,7 +52,7 @@ beforeAll(async () => {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);
 }, 120000);

--- a/test/e2e/analysisQueue.test.ts
+++ b/test/e2e/analysisQueue.test.ts
@@ -43,7 +43,7 @@ function envFiles() {
     ),
   );
   return {
-    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
     OPENAI_BASE_URL: stub.url,
     NEXTAUTH_SECRET: "secret",

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -38,7 +38,7 @@ beforeAll(async () => {
   });
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   const env = {
-    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
     OPENAI_BASE_URL: stub.url,
     NEXTAUTH_SECRET: "secret",

--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -42,7 +42,7 @@ beforeAll(async () => {
   ]);
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   const env = {
-    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
     OPENAI_BASE_URL: stub.url,
     NEXTAUTH_SECRET: "secret",
@@ -104,7 +104,7 @@ describe("follow up", () => {
 
   it("passes prior emails to openai", async () => {
     const id = await createCase();
-    const caseFile = path.join(tmpDir, "cases.json");
+    const caseFile = path.join(tmpDir, "cases.sqlite");
     const db = new Database(caseFile);
     const row = db.prepare("SELECT data FROM cases WHERE id = ?").get(id) as {
       data: string;

--- a/test/e2e/members.test.ts
+++ b/test/e2e/members.test.ts
@@ -52,7 +52,7 @@ beforeAll(async () => {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);
 }, 120000);

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -52,7 +52,7 @@ beforeAll(async () => {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);
 }, 120000);

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -52,7 +52,7 @@ beforeAll(async () => {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);
 }, 120000);

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -31,7 +31,7 @@ beforeAll(async () => {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);
 }, 120000);

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -34,7 +34,7 @@ async function setup(responses: Array<import("./openaiStub").StubResponse>) {
   stub = await startOpenAIStub(responses);
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   const env = {
-    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
     OPENAI_BASE_URL: stub.url,
     NEXTAUTH_SECRET: "secret",

--- a/test/e2e/snailmail.test.ts
+++ b/test/e2e/snailmail.test.ts
@@ -49,7 +49,7 @@ beforeAll(async () => {
     NODE_ENV: string;
     NEXTAUTH_SECRET: string;
   } = {
-    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
     OPENAI_BASE_URL: stub.url,
     SNAIL_MAIL_PROVIDER_FILE: path.join(tmpDir, "providers.json"),

--- a/test/e2e/thread.test.ts
+++ b/test/e2e/thread.test.ts
@@ -10,7 +10,7 @@ let tmpDir: string;
 beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   const env = {
-    CASE_STORE_FILE: path.join(tmpDir, "cases.json"),
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     NEXTAUTH_SECRET: "secret",
   };
   server = await startServer(3006, env);

--- a/test/vinLookup.test.ts
+++ b/test/vinLookup.test.ts
@@ -8,7 +8,7 @@ let dataDir: string;
 
 beforeEach(async () => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
-  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.json");
+  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   process.env.VIN_SOURCE_FILE = path.join(dataDir, "vinSources.json");
   const { defaultVinSources } = await import("../src/lib/vinSources");
   const statuses = defaultVinSources.map((s) => ({


### PR DESCRIPTION
## Summary
- use `.sqlite` extension for all CASE_STORE_FILE paths
- clarify CASE_STORE_FILE entry in `.env.example`

## Testing
- `npm run lint`
- `RETURN_ADDRESS='Me\n1 A St\nTown, ST 12345' SNAIL_MAIL_PROVIDER=mock TWILIO_ACCOUNT_SID=s TWILIO_AUTH_TOKEN=t TWILIO_FROM_NUMBER=+15551234567 npm test` *(fails: Twilio tests)*

------
https://chatgpt.com/codex/tasks/task_e_68549ede589c832ba94cee1600fc37f9