### PR TITLE
fix verification api path

### DIFF
--- a/src/app/api/test/verification-url/route.ts
+++ b/src/app/api/test/verification-url/route.ts
@@ -1,8 +1,8 @@
 import { readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { config } from "@/lib/config";
 import { NextResponse } from "next/server";
-import { config } from "../../../lib/config";
 
 const verFile = path.join(os.tmpdir(), "verification-url.txt");
 


### PR DESCRIPTION
## Summary
- fix the import path in the test verification API

## Testing
- `npm run lint`
- `npm test` *(fails: RETURN_ADDRESS not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68548c2b5234832bb4a51c1b6cc84f41