### PR TITLE
fix verification url temp file path

### DIFF
--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -1,4 +1,6 @@
 import { writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { NextAuthOptions, Session, User } from "next-auth";
 import type { Adapter } from "next-auth/adapters";
 import EmailProvider from "next-auth/providers/email";
@@ -20,7 +22,8 @@ export const authOptions: NextAuthOptions = {
         console.log("sendVerificationRequest", identifier);
         if (config.TEST_APIS) {
           (global as Record<string, unknown>).verificationUrl = url;
-          await writeFile("/tmp/verification-url.txt", url);
+          const filePath = path.join(os.tmpdir(), "verification-url.txt");
+          await writeFile(filePath, url);
           return;
         }
         await sendEmail({ to: identifier, subject: "Sign in", body: url });


### PR DESCRIPTION
## Summary
- write verification URL to path under os.tmpdir so tests use the same location

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: RETURN_ADDRESS not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68554ffe6b40832b85b33e629a0bd9c8