### PR TITLE
Fix session loading in authorization checks

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -53,5 +53,17 @@ const envSchema = z
   })
   .passthrough();
 
-export const config = envSchema.parse(process.env);
-export type Config = typeof config;
+export type Config = z.infer<typeof envSchema>;
+
+export function getConfig(): Config {
+  return envSchema.parse(process.env);
+}
+
+export const config: Config = new Proxy(
+  {},
+  {
+    get(_t, prop: string) {
+      return (getConfig() as Record<string, unknown>)[prop];
+    },
+  },
+) as Config;


### PR DESCRIPTION
## Summary
- auto-load NextAuth sessions in `withAuthorization` and `withCaseAuthorization`
- make configuration values refresh from `process.env`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: expected 403 to be 200)*

------
https://chatgpt.com/codex/tasks/task_e_68555646fdb8832b9079dcb3aa51144d