### PR TITLE
Fix imports to use alias paths

### DIFF
--- a/scripts/convert-imports.js
+++ b/scripts/convert-imports.js
@@ -1,0 +1,24 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const glob = require("glob");
+
+const root = path.resolve(__dirname, "../src");
+
+const files = glob.sync("src/**/*.{ts,tsx,js,jsx}");
+
+for (const file of files) {
+  const fullPath = path.resolve(file);
+  let content = fs.readFileSync(fullPath, "utf8");
+  let changed = false;
+  content = content.replace(
+    /from\s+(["'])((?:\.\.\/)+[^"']+?)\1/g,
+    (match, quote, rel) => {
+      const abs = path.resolve(path.dirname(fullPath), rel);
+      if (!abs.startsWith(root)) return match; // skip outside src
+      const relative = path.relative(root, abs).replace(/\\/g, "/");
+      changed = true;
+      return `from ${quote}@/${relative}${quote}`;
+    },
+  );
+  if (changed) fs.writeFileSync(fullPath, content);
+}

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -1,7 +1,7 @@
+import Home from "@/app/page";
 import { getServerSession } from "next-auth/next";
 import { headers } from "next/headers";
 import { type Mock, beforeAll, describe, expect, it, vi } from "vitest";
-import Home from "../page";
 
 vi.mock("next/headers", () => ({
   headers: vi.fn(),

--- a/src/app/__tests__/point.test.tsx
+++ b/src/app/__tests__/point.test.tsx
@@ -1,12 +1,12 @@
+import PointAndShootPage from "@/app/point/page";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import PointAndShootPage from "../point/page";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
-vi.mock("../useNewCaseFromFiles", () => ({
+vi.mock("@/app/useNewCaseFromFiles", () => ({
   default: () => async () => {},
 }));
 

--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import { useSession } from "@/app/useSession";
 import { useEffect, useState } from "react";
-import { useSession } from "../useSession";
 import AppConfigurationTab from "./AppConfigurationTab";
 
 export interface UserRecord {

--- a/src/app/admin/AppConfigurationTab.tsx
+++ b/src/app/admin/AppConfigurationTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import { useSession } from "@/app/useSession";
 import { useEffect, useState } from "react";
-import { useSession } from "../useSession";
 
 interface VinSourceStatus {
   id: string;

--- a/src/app/admin/__tests__/AdminPage.test.tsx
+++ b/src/app/admin/__tests__/AdminPage.test.tsx
@@ -1,6 +1,6 @@
+import AdminPage from "@/app/admin/page";
 import { getServerSession } from "next-auth/next";
 import { expect, it, vi } from "vitest";
-import AdminPage from "../page";
 
 vi.mock("next-auth/next", () => ({
   getServerSession: vi.fn(),

--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -1,8 +1,8 @@
+import type { useSession as useSessionFn } from "@/app/useSession";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { useSession as useSessionFn } from "../../useSession";
 
-vi.mock("../../useSession", () => ({
+vi.mock("@/app/useSession", () => ({
   useSession: vi.fn(
     () =>
       ({
@@ -11,14 +11,14 @@ vi.mock("../../useSession", () => ({
   ),
 }));
 
-import { useSession } from "../../useSession";
+import { useSession } from "@/app/useSession";
 
 vi.mock("@/apiClient", () => ({
   apiFetch: vi.fn(),
 }));
 
 import { apiFetch } from "@/apiClient";
-import AdminPageClient from "../AdminPageClient";
+import AdminPageClient from "@/app/admin/AdminPageClient";
 
 const users = [{ id: "1", email: "a@example.com", name: null, role: "admin" }];
 const rules = [{ ptype: "p", v0: "admin", v1: "users", v2: "read" }];

--- a/src/app/admin/__tests__/changeRoleRoute.test.ts
+++ b/src/app/admin/__tests__/changeRoleRoute.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
 
 describe("change role route", () => {
   it("allows superadmins", async () => {
-    const { PUT } = await import("../../api/users/[id]/role/route");
+    const { PUT } = await import("@/app/api/users/[id]/role/route");
     const res = await PUT(
       new Request("http://test", {
         method: "PUT",
@@ -54,7 +54,7 @@ describe("change role route", () => {
   });
 
   it("rejects non-superadmins", async () => {
-    const { PUT } = await import("../../api/users/[id]/role/route");
+    const { PUT } = await import("@/app/api/users/[id]/role/route");
     const res = await PUT(
       new Request("http://test", {
         method: "PUT",

--- a/src/app/cases/CasesLayoutClient.tsx
+++ b/src/app/cases/CasesLayoutClient.tsx
@@ -1,7 +1,7 @@
 "use client";
+import type { Case } from "@/lib/caseStore";
 import { useParams } from "next/navigation";
 import type { ReactNode } from "react";
-import type { Case } from "../../lib/caseStore";
 import ClientCasesPage from "./ClientCasesPage";
 
 export default function CasesLayoutClient({

--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -1,17 +1,14 @@
 "use client";
 import { apiEventSource, apiFetch } from "@/apiClient";
+import AnalysisInfo from "@/app/components/AnalysisInfo";
 import MapPreview from "@/app/components/MapPreview";
+import useNewCaseFromFiles from "@/app/useNewCaseFromFiles";
+import type { Case } from "@/lib/caseStore";
+import { getOfficialCaseGps, getRepresentativePhoto } from "@/lib/caseUtils";
+import { distanceBetween } from "@/lib/distance";
 import Image from "next/image";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
-import type { Case } from "../../lib/caseStore";
-import {
-  getOfficialCaseGps,
-  getRepresentativePhoto,
-} from "../../lib/caseUtils";
-import { distanceBetween } from "../../lib/distance";
-import AnalysisInfo from "../components/AnalysisInfo";
-import useNewCaseFromFiles from "../useNewCaseFromFiles";
 import useDragReset from "./useDragReset";
 
 type Order = "createdAt" | "updatedAt" | "distance";

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -1,11 +1,17 @@
 "use client";
 import { apiEventSource, apiFetch } from "@/apiClient";
+import useDragReset from "@/app/cases/useDragReset";
+import AnalysisInfo from "@/app/components/AnalysisInfo";
+import CaseLayout from "@/app/components/CaseLayout";
+import CaseProgressGraph from "@/app/components/CaseProgressGraph";
+import CaseToolbar from "@/app/components/CaseToolbar";
+import DebugWrapper from "@/app/components/DebugWrapper";
+import EditableText from "@/app/components/EditableText";
+import ImageHighlights from "@/app/components/ImageHighlights";
 import MapPreview from "@/app/components/MapPreview";
-import Image from "next/image";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
-import type { Case, SentEmail } from "../../../lib/caseStore";
+import useCloseOnOutsideClick from "@/app/useCloseOnOutsideClick";
+import { useSession } from "@/app/useSession";
+import type { Case, SentEmail } from "@/lib/caseStore";
 import {
   getCaseOwnerContact,
   getCasePlateNumber,
@@ -14,17 +20,11 @@ import {
   getOfficialCaseGps,
   getRepresentativePhoto,
   hasViolation,
-} from "../../../lib/caseUtils";
-import AnalysisInfo from "../../components/AnalysisInfo";
-import CaseLayout from "../../components/CaseLayout";
-import CaseProgressGraph from "../../components/CaseProgressGraph";
-import CaseToolbar from "../../components/CaseToolbar";
-import DebugWrapper from "../../components/DebugWrapper";
-import EditableText from "../../components/EditableText";
-import ImageHighlights from "../../components/ImageHighlights";
-import useCloseOnOutsideClick from "../../useCloseOnOutsideClick";
-import { useSession } from "../../useSession";
-import useDragReset from "../useDragReset";
+} from "@/lib/caseUtils";
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 
 function buildThreads(c: Case): SentEmail[] {
   const mails = c.sentEmails ?? [];

--- a/src/app/cases/[id]/compose/page.tsx
+++ b/src/app/cases/[id]/compose/page.tsx
@@ -1,5 +1,5 @@
+import ComposeWrapper from "@/app/cases/[id]/ComposeWrapper";
 import { getCase } from "@/lib/caseStore";
-import ComposeWrapper from "../ComposeWrapper";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -1,12 +1,12 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import { useSession } from "@/app/useSession";
 import type { EmailDraft } from "@/lib/caseReport";
 import type { Case } from "@/lib/caseStore";
 import type { ReportModule } from "@/lib/reportModules";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { useSession } from "../../../useSession";
 
 export default function DraftEditor({
   initialDraft,

--- a/src/app/cases/[id]/followup/FollowUpModal.tsx
+++ b/src/app/cases/[id]/followup/FollowUpModal.tsx
@@ -1,10 +1,10 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import DraftEditor from "@/app/cases/[id]/draft/DraftEditor";
 import type { EmailDraft } from "@/lib/caseReport";
 import type { ReportModule } from "@/lib/reportModules";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useEffect, useState } from "react";
-import DraftEditor from "../draft/DraftEditor";
 
 interface DraftData {
   email: EmailDraft;

--- a/src/app/cases/[id]/followup/page.tsx
+++ b/src/app/cases/[id]/followup/page.tsx
@@ -1,5 +1,5 @@
+import FollowUpWrapper from "@/app/cases/[id]/FollowUpWrapper";
 import { getCase } from "@/lib/caseStore";
-import FollowUpWrapper from "../FollowUpWrapper";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/cases/[id]/notify-owner/page.tsx
+++ b/src/app/cases/[id]/notify-owner/page.tsx
@@ -1,5 +1,5 @@
+import NotifyOwnerWrapper from "@/app/cases/[id]/NotifyOwnerWrapper";
 import { getCase } from "@/lib/caseStore";
-import NotifyOwnerWrapper from "../NotifyOwnerWrapper";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { getCase } from "../../../lib/caseStore";
+import { getCase } from "@/lib/caseStore";
 import ClientCasePage from "./ClientCasePage";
 
 export const dynamic = "force-dynamic";

--- a/src/app/cases/[id]/thread/[sent]/page.tsx
+++ b/src/app/cases/[id]/thread/[sent]/page.tsx
@@ -1,5 +1,5 @@
+import ThreadWrapper from "@/app/cases/[id]/ThreadWrapper";
 import { getCase } from "@/lib/caseStore";
-import ThreadWrapper from "../../ThreadWrapper";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/cases/__tests__/dragOverlayPosition.test.tsx
+++ b/src/app/cases/__tests__/dragOverlayPosition.test.tsx
@@ -1,9 +1,9 @@
+import ClientCasesPage from "@/app/cases/ClientCasesPage";
+import ClientCasePage from "@/app/cases/[id]/ClientCasePage";
+import type { Case } from "@/lib/caseStore";
 import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { Case } from "../../../lib/caseStore";
-import ClientCasesPage from "../ClientCasesPage";
-import ClientCasePage from "../[id]/ClientCasePage";
-vi.mock("../../useSession", () => ({ useSession: () => ({ data: null }) }));
+vi.mock("@/app/useSession", () => ({ useSession: () => ({ data: null }) }));
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({}),

--- a/src/app/cases/__tests__/useDragReset.test.tsx
+++ b/src/app/cases/__tests__/useDragReset.test.tsx
@@ -1,6 +1,6 @@
+import useDragReset from "@/app/cases/useDragReset";
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import useDragReset from "../useDragReset";
 
 describe("useDragReset", () => {
   it("invokes reset on dragleave with no relatedTarget", () => {

--- a/src/app/cases/layout.tsx
+++ b/src/app/cases/layout.tsx
@@ -1,5 +1,5 @@
+import { getCases } from "@/lib/caseStore";
 import type { ReactNode } from "react";
-import { getCases } from "../../lib/caseStore";
 import CasesLayoutClient from "./CasesLayoutClient";
 
 export const dynamic = "force-dynamic";

--- a/src/app/cases/page.tsx
+++ b/src/app/cases/page.tsx
@@ -1,8 +1,8 @@
 export const dynamic = "force-dynamic";
 
-import type { Case } from "../../lib/caseStore";
-import { getCase } from "../../lib/caseStore";
-import CaseSummary from "../components/CaseSummary";
+import CaseSummary from "@/app/components/CaseSummary";
+import type { Case } from "@/lib/caseStore";
+import { getCase } from "@/lib/caseStore";
 
 export default async function CasesPage({
   searchParams,

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -1,11 +1,11 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import useCloseOnOutsideClick from "@/app/useCloseOnOutsideClick";
 import { withBasePath } from "@/basePath";
 import { Progress } from "@/components/ui/progress";
 import type { LlmProgress } from "@/lib/openai";
 import Link from "next/link";
 import { useRef } from "react";
-import useCloseOnOutsideClick from "../useCloseOnOutsideClick";
 
 export default function CaseToolbar({
   caseId,

--- a/src/app/components/DebugWrapper.tsx
+++ b/src/app/components/DebugWrapper.tsx
@@ -1,9 +1,9 @@
 "use client";
+import useAltKey from "@/app/useAltKey";
+import { config } from "@/lib/config";
 import Tippy from "@tippyjs/react";
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
-import { config } from "../../lib/config";
-import useAltKey from "../useAltKey";
 
 function tokenize(json: string): ReactNode[] {
   const tokens: ReactNode[] = [];

--- a/src/app/components/MapPreview.tsx
+++ b/src/app/components/MapPreview.tsx
@@ -1,5 +1,5 @@
+import { config } from "@/lib/config";
 import Image from "next/image";
-import { config } from "../../lib/config";
 
 export default function MapPreview({
   lat,

--- a/src/app/components/MultiCaseToolbar.tsx
+++ b/src/app/components/MultiCaseToolbar.tsx
@@ -1,9 +1,9 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import useCloseOnOutsideClick from "@/app/useCloseOnOutsideClick";
 import { withBasePath } from "@/basePath";
 import Link from "next/link";
 import { useRef } from "react";
-import useCloseOnOutsideClick from "../useCloseOnOutsideClick";
 
 export default function MultiCaseToolbar({
   caseIds,

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import useNewCaseFromFiles from "@/app/useNewCaseFromFiles";
+import { signIn, signOut, useSession } from "@/app/useSession";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useRef } from "react";
-import useNewCaseFromFiles from "../useNewCaseFromFiles";
-import { signIn, signOut, useSession } from "../useSession";
 
 export default function NavBar() {
   const pathname = usePathname();

--- a/src/app/components/__tests__/ClientComponent.test.tsx
+++ b/src/app/components/__tests__/ClientComponent.test.tsx
@@ -1,7 +1,7 @@
+import ClientComponent from "@/app/components/ClientComponent";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import { describe, expect, it } from "vitest";
-import ClientComponent from "../ClientComponent";
 
 describe("ClientComponent", () => {
   it("renders text", () => {

--- a/src/app/components/__tests__/NavBar.test.tsx
+++ b/src/app/components/__tests__/NavBar.test.tsx
@@ -6,12 +6,12 @@ vi.mock("next/navigation", () => ({
   usePathname: () => mockedUsePathname(),
   useRouter: () => ({ push: vi.fn() }),
 }));
-vi.mock("../useNewCaseFromFiles", () => ({
+vi.mock("@/app/useNewCaseFromFiles", () => ({
   default: () => async () => {},
 }));
 
-import NavBar from "../NavBar";
-vi.mock("../../useSession", () => ({
+import NavBar from "@/app/components/NavBar";
+vi.mock("@/app/useSession", () => ({
   useSession: () => ({ data: null }),
   signIn: vi.fn(),
   signOut: vi.fn(),

--- a/src/app/components/__tests__/ServerComponent.test.tsx
+++ b/src/app/components/__tests__/ServerComponent.test.tsx
@@ -1,6 +1,6 @@
+import ServerComponent from "@/app/components/ServerComponent";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import ServerComponent from "../ServerComponent";
 
 describe("ServerComponent", () => {
   it("renders text", async () => {

--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -23,7 +23,7 @@ const TooltipAny = Tooltip as unknown as React.ComponentType<
   Record<string, unknown>
 >;
 
-import "../globals.css";
+import "@/app/globals.css";
 
 const markerSvg = `
   <svg xmlns="http://www.w3.org/2000/svg" width="25" height="41" viewBox="0 0 25 41">

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,8 +1,5 @@
-import { getCases } from "../../lib/caseStore";
-import {
-  getOfficialCaseGps,
-  getRepresentativePhoto,
-} from "../../lib/caseUtils";
+import { getCases } from "@/lib/caseStore";
+import { getOfficialCaseGps, getRepresentativePhoto } from "@/lib/caseUtils";
 import MapPageClient from "./MapPageClient";
 
 export const dynamic = "force-dynamic";

--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -10,7 +10,7 @@ const AnalyzerWorker = () =>
     : new Worker(new URL("./localAnalyzer.worker.ts", import.meta.url), {
         type: "module",
       });
-import useNewCaseFromFiles from "../useNewCaseFromFiles";
+import useNewCaseFromFiles from "@/app/useNewCaseFromFiles";
 
 export default function PointAndShootPage() {
   const videoRef = useRef<HTMLVideoElement>(null);

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useSession } from "../useSession";
+import { useSession } from "@/app/useSession";
 
 export default function UserSettingsPage() {
   const { data: session } = useSession();

--- a/src/app/signin/__tests__/SignInPage.test.tsx
+++ b/src/app/signin/__tests__/SignInPage.test.tsx
@@ -1,8 +1,8 @@
+import SignInPage from "@/app/signin/page";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import SignInPage from "../page";
 
-vi.mock("../../useSession", () => ({
+vi.mock("@/app/useSession", () => ({
   signIn: vi.fn(),
 }));
 

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,8 +1,8 @@
 "use client";
+import { signIn } from "@/app/useSession";
 import { withBasePath } from "@/basePath";
 import { useSearchParams } from "next/navigation";
 import { useState } from "react";
-import { signIn } from "../useSession";
 
 export default function SignInPage() {
   const [email, setEmail] = useState("");

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import useNewCaseFromFiles from "../useNewCaseFromFiles";
+import useNewCaseFromFiles from "@/app/useNewCaseFromFiles";
 
 export default function UploadPage() {
   const uploadCase = useNewCaseFromFiles();

--- a/src/jobs/analyzeCase.ts
+++ b/src/jobs/analyzeCase.ts
@@ -1,7 +1,7 @@
 import { parentPort, workerData } from "node:worker_threads";
-import { analyzeCase } from "../lib/caseAnalysis";
-import type { Case } from "../lib/caseStore";
-import { migrationsReady } from "../lib/db";
+import { analyzeCase } from "@/lib/caseAnalysis";
+import type { Case } from "@/lib/caseStore";
+import { migrationsReady } from "@/lib/db";
 
 (async () => {
   await migrationsReady;

--- a/src/jobs/analyzePhoto.ts
+++ b/src/jobs/analyzePhoto.ts
@@ -1,7 +1,7 @@
 import { parentPort, workerData } from "node:worker_threads";
-import { reanalyzePhoto } from "../lib/caseAnalysis";
-import type { Case } from "../lib/caseStore";
-import { migrationsReady } from "../lib/db";
+import { reanalyzePhoto } from "@/lib/caseAnalysis";
+import type { Case } from "@/lib/caseStore";
+import { migrationsReady } from "@/lib/db";
 
 (async () => {
   await migrationsReady;

--- a/src/jobs/fetchCaseLocation.ts
+++ b/src/jobs/fetchCaseLocation.ts
@@ -1,7 +1,7 @@
 import { parentPort, workerData } from "node:worker_threads";
-import { fetchCaseLocation } from "../lib/caseLocation";
-import type { Case } from "../lib/caseStore";
-import { migrationsReady } from "../lib/db";
+import { fetchCaseLocation } from "@/lib/caseLocation";
+import type { Case } from "@/lib/caseStore";
+import { migrationsReady } from "@/lib/db";
 
 (async () => {
   await migrationsReady;

--- a/src/jobs/fetchCaseVin.ts
+++ b/src/jobs/fetchCaseVin.ts
@@ -1,7 +1,7 @@
 import { parentPort, workerData } from "node:worker_threads";
-import type { Case } from "../lib/caseStore";
-import { migrationsReady } from "../lib/db";
-import { fetchCaseVin } from "../lib/vinLookup";
+import type { Case } from "@/lib/caseStore";
+import { migrationsReady } from "@/lib/db";
+import { fetchCaseVin } from "@/lib/vinLookup";
 
 (async () => {
   await migrationsReady;

--- a/src/jobs/sendSnailMail.ts
+++ b/src/jobs/sendSnailMail.ts
@@ -1,6 +1,6 @@
 import { parentPort, workerData } from "node:worker_threads";
-import { sendSnailMail } from "../lib/snailMail";
-import type { SnailMailOptions } from "../lib/snailMail";
+import { sendSnailMail } from "@/lib/snailMail";
+import type { SnailMailOptions } from "@/lib/snailMail";
 
 (async () => {
   const { jobData } = workerData as {

--- a/src/lib/__tests__/analyzeViolation.test.ts
+++ b/src/lib/__tests__/analyzeViolation.test.ts
@@ -1,7 +1,7 @@
+import { getLlm } from "@/lib/llm";
+import { analyzeViolation } from "@/lib/openai";
 import type { ChatCompletion } from "openai/resources/chat/completions";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getLlm } from "../llm";
-import { analyzeViolation } from "../openai";
 
 const imgs = [{ url: "data:image/png;base64,AA", filename: "foo.png" }];
 

--- a/src/lib/__tests__/caseReport.test.ts
+++ b/src/lib/__tests__/caseReport.test.ts
@@ -1,10 +1,10 @@
+import { draftEmail, draftOwnerNotification } from "@/lib/caseReport";
+import type { Case } from "@/lib/caseStore";
+import { getLlm } from "@/lib/llm";
+import { reportModules } from "@/lib/reportModules";
+import * as violationCodes from "@/lib/violationCodes";
 import type { ChatCompletion } from "openai/resources/chat/completions";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { draftEmail, draftOwnerNotification } from "../caseReport";
-import type { Case } from "../caseStore";
-import { getLlm } from "../llm";
-import { reportModules } from "../reportModules";
-import * as violationCodes from "../violationCodes";
 
 const baseCase: Case = {
   id: "1",

--- a/src/lib/__tests__/contactMethods.test.ts
+++ b/src/lib/__tests__/contactMethods.test.ts
@@ -1,5 +1,5 @@
+import { makeRobocall, sendSms, sendWhatsapp } from "@/lib/contactMethods";
 import { describe, expect, it, vi } from "vitest";
-import { makeRobocall, sendSms, sendWhatsapp } from "../contactMethods";
 
 const callCreateMock = vi.fn();
 const messageCreateMock = vi.fn();

--- a/src/lib/__tests__/openai.test.ts
+++ b/src/lib/__tests__/openai.test.ts
@@ -1,7 +1,7 @@
+import { getLlm } from "@/lib/llm";
+import { ocrPaperwork } from "@/lib/openai";
 import type { ChatCompletion } from "openai/resources/chat/completions";
 import { describe, expect, it, vi } from "vitest";
-import { getLlm } from "../llm";
-import { ocrPaperwork } from "../openai";
 
 describe("openai client", () => {
   it("provides a client instance", () => {

--- a/src/lib/__tests__/ownershipModules.test.ts
+++ b/src/lib/__tests__/ownershipModules.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
+import { ownershipModules } from "@/lib/ownershipModules";
+import * as snailMail from "@/lib/snailMail";
 import { describe, expect, it, vi } from "vitest";
-import { ownershipModules } from "../ownershipModules";
-import * as snailMail from "../snailMail";
 
 describe("ownershipModules.il.requestVin", () => {
   it("generates a PDF and mails it", async () => {

--- a/src/lib/__tests__/snailMail.test.ts
+++ b/src/lib/__tests__/snailMail.test.ts
@@ -1,5 +1,5 @@
+import { sendSnailMail, snailMailProviders } from "@/lib/snailMail";
 import { describe, expect, it, vi } from "vitest";
-import { sendSnailMail, snailMailProviders } from "../snailMail";
 
 const opts = {
   to: { address1: "1 A St", city: "Nowhere", state: "IL", postalCode: "12345" },

--- a/src/lib/apiContract.ts
+++ b/src/lib/apiContract.ts
@@ -1,10 +1,10 @@
+import { caseSchema } from "@/generated/zod/caseStore";
+import { emailOptionsSchema } from "@/generated/zod/email";
+import { reportModuleSchema } from "@/generated/zod/reportModules";
+import { snailMailProviderStatusSchema } from "@/generated/zod/snailMailProviders";
+import { vinSourceStatusSchema } from "@/generated/zod/vinSources";
 import { initContract } from "@ts-rest/core";
 import { z } from "zod";
-import { caseSchema } from "../generated/zod/caseStore";
-import { emailOptionsSchema } from "../generated/zod/email";
-import { reportModuleSchema } from "../generated/zod/reportModules";
-import { snailMailProviderStatusSchema } from "../generated/zod/snailMailProviders";
-import { vinSourceStatusSchema } from "../generated/zod/vinSources";
 
 const c = initContract();
 


### PR DESCRIPTION
## Summary
- switch all relative imports to `@/` alias
- add helper script to convert imports

## Testing
- `npm run lint`
- `npm test` *(fails: RETURN_ADDRESS not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68556712cde8832b881b457195f5f765