### PR TITLE
Ensure all imports use alias

### DIFF
--- a/scripts/alias-relative-imports.js
+++ b/scripts/alias-relative-imports.js
@@ -1,0 +1,44 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..", "src");
+
+function processFile(file) {
+  let content = fs.readFileSync(file, "utf8");
+  const dir = path.dirname(file);
+  let changed = false;
+  function toAlias(rel) {
+    const abs = path.resolve(dir, rel);
+    const relToRoot = path.relative(root, abs).replace(/\\/g, "/");
+    changed = true;
+    return `@/${relToRoot}`;
+  }
+  const regexes = [
+    /from "(\.\.\/[^"']+)"/g,
+    /import\("(\.\.\/[^"']+)"/g,
+    /require\("(\.\.\/[^"']+)"/g,
+    /vi\.mock\("(\.\.\/[^"']+)"/g,
+    /"(\.\.\/[^"']+)"/g,
+    /'(\.\.\/[^']+)'/g,
+  ];
+  for (const regex of regexes) {
+    content = content.replace(regex, (match, rel) =>
+      match.replace(rel, toAlias(rel)),
+    );
+  }
+  if (changed) fs.writeFileSync(file, content);
+}
+
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const res = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(res);
+    } else if (/\.(ts|tsx|js|mjs)$/.test(entry.name)) {
+      processFile(res);
+    }
+  }
+}
+
+walk(path.resolve(__dirname, "..", "src"));
+walk(path.resolve(__dirname, "..", "test"));

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -1,7 +1,7 @@
+import Home from "@/app/page";
 import { getServerSession } from "next-auth/next";
 import { headers } from "next/headers";
 import { type Mock, beforeAll, describe, expect, it, vi } from "vitest";
-import Home from "../page";
 
 vi.mock("next/headers", () => ({
   headers: vi.fn(),

--- a/src/app/__tests__/point.test.tsx
+++ b/src/app/__tests__/point.test.tsx
@@ -1,12 +1,12 @@
+import PointAndShootPage from "@/app/point/page";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import PointAndShootPage from "../point/page";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
-vi.mock("../useNewCaseFromFiles", () => ({
+vi.mock("@/app/useNewCaseFromFiles", () => ({
   default: () => async () => {},
 }));
 

--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import { useSession } from "@/app/useSession";
 import { useEffect, useState } from "react";
-import { useSession } from "../useSession";
 import AppConfigurationTab from "./AppConfigurationTab";
 
 export interface UserRecord {

--- a/src/app/admin/AppConfigurationTab.tsx
+++ b/src/app/admin/AppConfigurationTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import { useSession } from "@/app/useSession";
 import { useEffect, useState } from "react";
-import { useSession } from "../useSession";
 
 interface VinSourceStatus {
   id: string;

--- a/src/app/admin/__tests__/AdminPage.test.tsx
+++ b/src/app/admin/__tests__/AdminPage.test.tsx
@@ -1,6 +1,6 @@
+import AdminPage from "@/app/admin/page";
 import { getServerSession } from "next-auth/next";
 import { expect, it, vi } from "vitest";
-import AdminPage from "../page";
 
 vi.mock("next-auth/next", () => ({
   getServerSession: vi.fn(),

--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -1,8 +1,8 @@
+import type { useSession as useSessionFn } from "@/app/useSession";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { useSession as useSessionFn } from "../../useSession";
 
-vi.mock("../../useSession", () => ({
+vi.mock("@/app/useSession", () => ({
   useSession: vi.fn(
     () =>
       ({
@@ -11,14 +11,14 @@ vi.mock("../../useSession", () => ({
   ),
 }));
 
-import { useSession } from "../../useSession";
+import { useSession } from "@/app/useSession";
 
 vi.mock("@/apiClient", () => ({
   apiFetch: vi.fn(),
 }));
 
 import { apiFetch } from "@/apiClient";
-import AdminPageClient from "../AdminPageClient";
+import AdminPageClient from "@/app/admin/AdminPageClient";
 
 const users = [{ id: "1", email: "a@example.com", name: null, role: "admin" }];
 const rules = [{ ptype: "p", v0: "admin", v1: "users", v2: "read" }];

--- a/src/app/admin/__tests__/changeRoleRoute.test.ts
+++ b/src/app/admin/__tests__/changeRoleRoute.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
 
 describe("change role route", () => {
   it("allows superadmins", async () => {
-    const { PUT } = await import("../../api/users/[id]/role/route");
+    const { PUT } = await import("@/app/api/users/[id]/role/route");
     const res = await PUT(
       new Request("http://test", {
         method: "PUT",
@@ -54,7 +54,7 @@ describe("change role route", () => {
   });
 
   it("rejects non-superadmins", async () => {
-    const { PUT } = await import("../../api/users/[id]/role/route");
+    const { PUT } = await import("@/app/api/users/[id]/role/route");
     const res = await PUT(
       new Request("http://test", {
         method: "PUT",

--- a/src/app/cases/CasesLayoutClient.tsx
+++ b/src/app/cases/CasesLayoutClient.tsx
@@ -1,7 +1,7 @@
 "use client";
+import type { Case } from "@/lib/caseStore";
 import { useParams } from "next/navigation";
 import type { ReactNode } from "react";
-import type { Case } from "../../lib/caseStore";
 import ClientCasesPage from "./ClientCasesPage";
 
 export default function CasesLayoutClient({

--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -1,17 +1,14 @@
 "use client";
 import { apiEventSource, apiFetch } from "@/apiClient";
+import AnalysisInfo from "@/app/components/AnalysisInfo";
 import MapPreview from "@/app/components/MapPreview";
+import useNewCaseFromFiles from "@/app/useNewCaseFromFiles";
+import type { Case } from "@/lib/caseStore";
+import { getOfficialCaseGps, getRepresentativePhoto } from "@/lib/caseUtils";
+import { distanceBetween } from "@/lib/distance";
 import Image from "next/image";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
-import type { Case } from "../../lib/caseStore";
-import {
-  getOfficialCaseGps,
-  getRepresentativePhoto,
-} from "../../lib/caseUtils";
-import { distanceBetween } from "../../lib/distance";
-import AnalysisInfo from "../components/AnalysisInfo";
-import useNewCaseFromFiles from "../useNewCaseFromFiles";
 import useDragReset from "./useDragReset";
 
 type Order = "createdAt" | "updatedAt" | "distance";

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -1,11 +1,17 @@
 "use client";
 import { apiEventSource, apiFetch } from "@/apiClient";
+import useDragReset from "@/app/cases/useDragReset";
+import AnalysisInfo from "@/app/components/AnalysisInfo";
+import CaseLayout from "@/app/components/CaseLayout";
+import CaseProgressGraph from "@/app/components/CaseProgressGraph";
+import CaseToolbar from "@/app/components/CaseToolbar";
+import DebugWrapper from "@/app/components/DebugWrapper";
+import EditableText from "@/app/components/EditableText";
+import ImageHighlights from "@/app/components/ImageHighlights";
 import MapPreview from "@/app/components/MapPreview";
-import Image from "next/image";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
-import type { Case, SentEmail } from "../../../lib/caseStore";
+import useCloseOnOutsideClick from "@/app/useCloseOnOutsideClick";
+import { useSession } from "@/app/useSession";
+import type { Case, SentEmail } from "@/lib/caseStore";
 import {
   getCaseOwnerContact,
   getCasePlateNumber,
@@ -14,17 +20,11 @@ import {
   getOfficialCaseGps,
   getRepresentativePhoto,
   hasViolation,
-} from "../../../lib/caseUtils";
-import AnalysisInfo from "../../components/AnalysisInfo";
-import CaseLayout from "../../components/CaseLayout";
-import CaseProgressGraph from "../../components/CaseProgressGraph";
-import CaseToolbar from "../../components/CaseToolbar";
-import DebugWrapper from "../../components/DebugWrapper";
-import EditableText from "../../components/EditableText";
-import ImageHighlights from "../../components/ImageHighlights";
-import useCloseOnOutsideClick from "../../useCloseOnOutsideClick";
-import { useSession } from "../../useSession";
-import useDragReset from "../useDragReset";
+} from "@/lib/caseUtils";
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 
 function buildThreads(c: Case): SentEmail[] {
   const mails = c.sentEmails ?? [];

--- a/src/app/cases/[id]/compose/page.tsx
+++ b/src/app/cases/[id]/compose/page.tsx
@@ -1,5 +1,5 @@
+import ComposeWrapper from "@/app/cases/[id]/ComposeWrapper";
 import { getCase } from "@/lib/caseStore";
-import ComposeWrapper from "../ComposeWrapper";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -1,12 +1,12 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import { useSession } from "@/app/useSession";
 import type { EmailDraft } from "@/lib/caseReport";
 import type { Case } from "@/lib/caseStore";
 import type { ReportModule } from "@/lib/reportModules";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { useSession } from "../../../useSession";
 
 export default function DraftEditor({
   initialDraft,

--- a/src/app/cases/[id]/followup/FollowUpModal.tsx
+++ b/src/app/cases/[id]/followup/FollowUpModal.tsx
@@ -1,10 +1,10 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import DraftEditor from "@/app/cases/[id]/draft/DraftEditor";
 import type { EmailDraft } from "@/lib/caseReport";
 import type { ReportModule } from "@/lib/reportModules";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useEffect, useState } from "react";
-import DraftEditor from "../draft/DraftEditor";
 
 interface DraftData {
   email: EmailDraft;

--- a/src/app/cases/[id]/followup/page.tsx
+++ b/src/app/cases/[id]/followup/page.tsx
@@ -1,5 +1,5 @@
+import FollowUpWrapper from "@/app/cases/[id]/FollowUpWrapper";
 import { getCase } from "@/lib/caseStore";
-import FollowUpWrapper from "../FollowUpWrapper";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/cases/[id]/notify-owner/page.tsx
+++ b/src/app/cases/[id]/notify-owner/page.tsx
@@ -1,5 +1,5 @@
+import NotifyOwnerWrapper from "@/app/cases/[id]/NotifyOwnerWrapper";
 import { getCase } from "@/lib/caseStore";
-import NotifyOwnerWrapper from "../NotifyOwnerWrapper";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { getCase } from "../../../lib/caseStore";
+import { getCase } from "@/lib/caseStore";
 import ClientCasePage from "./ClientCasePage";
 
 export const dynamic = "force-dynamic";

--- a/src/app/cases/[id]/thread/[sent]/page.tsx
+++ b/src/app/cases/[id]/thread/[sent]/page.tsx
@@ -1,5 +1,5 @@
+import ThreadWrapper from "@/app/cases/[id]/ThreadWrapper";
 import { getCase } from "@/lib/caseStore";
-import ThreadWrapper from "../../ThreadWrapper";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/cases/__tests__/dragOverlayPosition.test.tsx
+++ b/src/app/cases/__tests__/dragOverlayPosition.test.tsx
@@ -1,9 +1,9 @@
+import ClientCasesPage from "@/app/cases/ClientCasesPage";
+import ClientCasePage from "@/app/cases/[id]/ClientCasePage";
+import type { Case } from "@/lib/caseStore";
 import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { Case } from "../../../lib/caseStore";
-import ClientCasesPage from "../ClientCasesPage";
-import ClientCasePage from "../[id]/ClientCasePage";
-vi.mock("../../useSession", () => ({ useSession: () => ({ data: null }) }));
+vi.mock("@/app/useSession", () => ({ useSession: () => ({ data: null }) }));
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({}),

--- a/src/app/cases/__tests__/useDragReset.test.tsx
+++ b/src/app/cases/__tests__/useDragReset.test.tsx
@@ -1,6 +1,6 @@
+import useDragReset from "@/app/cases/useDragReset";
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import useDragReset from "../useDragReset";
 
 describe("useDragReset", () => {
   it("invokes reset on dragleave with no relatedTarget", () => {

--- a/src/app/cases/layout.tsx
+++ b/src/app/cases/layout.tsx
@@ -1,5 +1,5 @@
+import { getCases } from "@/lib/caseStore";
 import type { ReactNode } from "react";
-import { getCases } from "../../lib/caseStore";
 import CasesLayoutClient from "./CasesLayoutClient";
 
 export const dynamic = "force-dynamic";

--- a/src/app/cases/page.tsx
+++ b/src/app/cases/page.tsx
@@ -1,8 +1,8 @@
 export const dynamic = "force-dynamic";
 
-import type { Case } from "../../lib/caseStore";
-import { getCase } from "../../lib/caseStore";
-import CaseSummary from "../components/CaseSummary";
+import CaseSummary from "@/app/components/CaseSummary";
+import type { Case } from "@/lib/caseStore";
+import { getCase } from "@/lib/caseStore";
 
 export default async function CasesPage({
   searchParams,

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -1,11 +1,11 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import useCloseOnOutsideClick from "@/app/useCloseOnOutsideClick";
 import { withBasePath } from "@/basePath";
 import { Progress } from "@/components/ui/progress";
 import type { LlmProgress } from "@/lib/openai";
 import Link from "next/link";
 import { useRef } from "react";
-import useCloseOnOutsideClick from "../useCloseOnOutsideClick";
 
 export default function CaseToolbar({
   caseId,

--- a/src/app/components/DebugWrapper.tsx
+++ b/src/app/components/DebugWrapper.tsx
@@ -1,9 +1,9 @@
 "use client";
+import useAltKey from "@/app/useAltKey";
+import { config } from "@/lib/config";
 import Tippy from "@tippyjs/react";
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
-import { config } from "../../lib/config";
-import useAltKey from "../useAltKey";
 
 function tokenize(json: string): ReactNode[] {
   const tokens: ReactNode[] = [];

--- a/src/app/components/MapPreview.tsx
+++ b/src/app/components/MapPreview.tsx
@@ -1,5 +1,5 @@
+import { config } from "@/lib/config";
 import Image from "next/image";
-import { config } from "../../lib/config";
 
 export default function MapPreview({
   lat,

--- a/src/app/components/MultiCaseToolbar.tsx
+++ b/src/app/components/MultiCaseToolbar.tsx
@@ -1,9 +1,9 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import useCloseOnOutsideClick from "@/app/useCloseOnOutsideClick";
 import { withBasePath } from "@/basePath";
 import Link from "next/link";
 import { useRef } from "react";
-import useCloseOnOutsideClick from "../useCloseOnOutsideClick";
 
 export default function MultiCaseToolbar({
   caseIds,

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import useNewCaseFromFiles from "@/app/useNewCaseFromFiles";
+import { signIn, signOut, useSession } from "@/app/useSession";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useRef } from "react";
-import useNewCaseFromFiles from "../useNewCaseFromFiles";
-import { signIn, signOut, useSession } from "../useSession";
 
 export default function NavBar() {
   const pathname = usePathname();

--- a/src/app/components/__tests__/ClientComponent.test.tsx
+++ b/src/app/components/__tests__/ClientComponent.test.tsx
@@ -1,7 +1,7 @@
+import ClientComponent from "@/app/components/ClientComponent";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import { describe, expect, it } from "vitest";
-import ClientComponent from "../ClientComponent";
 
 describe("ClientComponent", () => {
   it("renders text", () => {

--- a/src/app/components/__tests__/NavBar.test.tsx
+++ b/src/app/components/__tests__/NavBar.test.tsx
@@ -6,12 +6,12 @@ vi.mock("next/navigation", () => ({
   usePathname: () => mockedUsePathname(),
   useRouter: () => ({ push: vi.fn() }),
 }));
-vi.mock("../useNewCaseFromFiles", () => ({
+vi.mock("@/app/components/useNewCaseFromFiles", () => ({
   default: () => async () => {},
 }));
 
-import NavBar from "../NavBar";
-vi.mock("../../useSession", () => ({
+import NavBar from "@/app/components/NavBar";
+vi.mock("@/app/useSession", () => ({
   useSession: () => ({ data: null }),
   signIn: vi.fn(),
   signOut: vi.fn(),

--- a/src/app/components/__tests__/ServerComponent.test.tsx
+++ b/src/app/components/__tests__/ServerComponent.test.tsx
@@ -1,6 +1,6 @@
+import ServerComponent from "@/app/components/ServerComponent";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import ServerComponent from "../ServerComponent";
 
 describe("ServerComponent", () => {
   it("renders text", async () => {

--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -23,7 +23,7 @@ const TooltipAny = Tooltip as unknown as React.ComponentType<
   Record<string, unknown>
 >;
 
-import "../globals.css";
+import "@/app/globals.css";
 
 const markerSvg = `
   <svg xmlns="http://www.w3.org/2000/svg" width="25" height="41" viewBox="0 0 25 41">

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,8 +1,5 @@
-import { getCases } from "../../lib/caseStore";
-import {
-  getOfficialCaseGps,
-  getRepresentativePhoto,
-} from "../../lib/caseUtils";
+import { getCases } from "@/lib/caseStore";
+import { getOfficialCaseGps, getRepresentativePhoto } from "@/lib/caseUtils";
 import MapPageClient from "./MapPageClient";
 
 export const dynamic = "force-dynamic";

--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -10,7 +10,7 @@ const AnalyzerWorker = () =>
     : new Worker(new URL("./localAnalyzer.worker.ts", import.meta.url), {
         type: "module",
       });
-import useNewCaseFromFiles from "../useNewCaseFromFiles";
+import useNewCaseFromFiles from "@/app/useNewCaseFromFiles";
 
 export default function PointAndShootPage() {
   const videoRef = useRef<HTMLVideoElement>(null);

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useSession } from "../useSession";
+import { useSession } from "@/app/useSession";
 
 export default function UserSettingsPage() {
   const { data: session } = useSession();

--- a/src/app/signin/__tests__/SignInPage.test.tsx
+++ b/src/app/signin/__tests__/SignInPage.test.tsx
@@ -1,8 +1,8 @@
+import SignInPage from "@/app/signin/page";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import SignInPage from "../page";
 
-vi.mock("../../useSession", () => ({
+vi.mock("@/app/useSession", () => ({
   signIn: vi.fn(),
 }));
 

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,8 +1,8 @@
 "use client";
+import { signIn } from "@/app/useSession";
 import { withBasePath } from "@/basePath";
 import { useSearchParams } from "next/navigation";
 import { useState } from "react";
-import { signIn } from "../useSession";
 
 export default function SignInPage() {
   const [email, setEmail] = useState("");

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import useNewCaseFromFiles from "../useNewCaseFromFiles";
+import useNewCaseFromFiles from "@/app/useNewCaseFromFiles";
 
 export default function UploadPage() {
   const uploadCase = useNewCaseFromFiles();

--- a/src/jobs/analyzeCase.ts
+++ b/src/jobs/analyzeCase.ts
@@ -1,7 +1,7 @@
 import { parentPort, workerData } from "node:worker_threads";
-import { analyzeCase } from "../lib/caseAnalysis";
-import type { Case } from "../lib/caseStore";
-import { migrationsReady } from "../lib/db";
+import { analyzeCase } from "@/lib/caseAnalysis";
+import type { Case } from "@/lib/caseStore";
+import { migrationsReady } from "@/lib/db";
 
 (async () => {
   await migrationsReady;

--- a/src/jobs/analyzePhoto.ts
+++ b/src/jobs/analyzePhoto.ts
@@ -1,7 +1,7 @@
 import { parentPort, workerData } from "node:worker_threads";
-import { reanalyzePhoto } from "../lib/caseAnalysis";
-import type { Case } from "../lib/caseStore";
-import { migrationsReady } from "../lib/db";
+import { reanalyzePhoto } from "@/lib/caseAnalysis";
+import type { Case } from "@/lib/caseStore";
+import { migrationsReady } from "@/lib/db";
 
 (async () => {
   await migrationsReady;

--- a/src/jobs/fetchCaseLocation.ts
+++ b/src/jobs/fetchCaseLocation.ts
@@ -1,7 +1,7 @@
 import { parentPort, workerData } from "node:worker_threads";
-import { fetchCaseLocation } from "../lib/caseLocation";
-import type { Case } from "../lib/caseStore";
-import { migrationsReady } from "../lib/db";
+import { fetchCaseLocation } from "@/lib/caseLocation";
+import type { Case } from "@/lib/caseStore";
+import { migrationsReady } from "@/lib/db";
 
 (async () => {
   await migrationsReady;

--- a/src/jobs/fetchCaseVin.ts
+++ b/src/jobs/fetchCaseVin.ts
@@ -1,7 +1,7 @@
 import { parentPort, workerData } from "node:worker_threads";
-import type { Case } from "../lib/caseStore";
-import { migrationsReady } from "../lib/db";
-import { fetchCaseVin } from "../lib/vinLookup";
+import type { Case } from "@/lib/caseStore";
+import { migrationsReady } from "@/lib/db";
+import { fetchCaseVin } from "@/lib/vinLookup";
 
 (async () => {
   await migrationsReady;

--- a/src/jobs/sendSnailMail.ts
+++ b/src/jobs/sendSnailMail.ts
@@ -1,6 +1,6 @@
 import { parentPort, workerData } from "node:worker_threads";
-import { sendSnailMail } from "../lib/snailMail";
-import type { SnailMailOptions } from "../lib/snailMail";
+import { sendSnailMail } from "@/lib/snailMail";
+import type { SnailMailOptions } from "@/lib/snailMail";
 
 (async () => {
   const { jobData } = workerData as {

--- a/src/lib/__tests__/analyzeViolation.test.ts
+++ b/src/lib/__tests__/analyzeViolation.test.ts
@@ -1,7 +1,7 @@
+import { getLlm } from "@/lib/llm";
+import { analyzeViolation } from "@/lib/openai";
 import type { ChatCompletion } from "openai/resources/chat/completions";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getLlm } from "../llm";
-import { analyzeViolation } from "../openai";
 
 const imgs = [{ url: "data:image/png;base64,AA", filename: "foo.png" }];
 

--- a/src/lib/__tests__/caseReport.test.ts
+++ b/src/lib/__tests__/caseReport.test.ts
@@ -1,10 +1,10 @@
+import { draftEmail, draftOwnerNotification } from "@/lib/caseReport";
+import type { Case } from "@/lib/caseStore";
+import { getLlm } from "@/lib/llm";
+import { reportModules } from "@/lib/reportModules";
+import * as violationCodes from "@/lib/violationCodes";
 import type { ChatCompletion } from "openai/resources/chat/completions";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { draftEmail, draftOwnerNotification } from "../caseReport";
-import type { Case } from "../caseStore";
-import { getLlm } from "../llm";
-import { reportModules } from "../reportModules";
-import * as violationCodes from "../violationCodes";
 
 const baseCase: Case = {
   id: "1",

--- a/src/lib/__tests__/contactMethods.test.ts
+++ b/src/lib/__tests__/contactMethods.test.ts
@@ -1,5 +1,5 @@
+import { makeRobocall, sendSms, sendWhatsapp } from "@/lib/contactMethods";
 import { describe, expect, it, vi } from "vitest";
-import { makeRobocall, sendSms, sendWhatsapp } from "../contactMethods";
 
 const callCreateMock = vi.fn();
 const messageCreateMock = vi.fn();

--- a/src/lib/__tests__/openai.test.ts
+++ b/src/lib/__tests__/openai.test.ts
@@ -1,7 +1,7 @@
+import { getLlm } from "@/lib/llm";
+import { ocrPaperwork } from "@/lib/openai";
 import type { ChatCompletion } from "openai/resources/chat/completions";
 import { describe, expect, it, vi } from "vitest";
-import { getLlm } from "../llm";
-import { ocrPaperwork } from "../openai";
 
 describe("openai client", () => {
   it("provides a client instance", () => {

--- a/src/lib/__tests__/ownershipModules.test.ts
+++ b/src/lib/__tests__/ownershipModules.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
+import { ownershipModules } from "@/lib/ownershipModules";
+import * as snailMail from "@/lib/snailMail";
 import { describe, expect, it, vi } from "vitest";
-import { ownershipModules } from "../ownershipModules";
-import * as snailMail from "../snailMail";
 
 describe("ownershipModules.il.requestVin", () => {
   it("generates a PDF and mails it", async () => {

--- a/src/lib/__tests__/snailMail.test.ts
+++ b/src/lib/__tests__/snailMail.test.ts
@@ -1,5 +1,5 @@
+import { sendSnailMail, snailMailProviders } from "@/lib/snailMail";
 import { describe, expect, it, vi } from "vitest";
-import { sendSnailMail, snailMailProviders } from "../snailMail";
 
 const opts = {
   to: { address1: "1 A St", city: "Nowhere", state: "IL", postalCode: "12345" },

--- a/src/lib/apiContract.ts
+++ b/src/lib/apiContract.ts
@@ -1,10 +1,10 @@
+import { caseSchema } from "@/generated/zod/caseStore";
+import { emailOptionsSchema } from "@/generated/zod/email";
+import { reportModuleSchema } from "@/generated/zod/reportModules";
+import { snailMailProviderStatusSchema } from "@/generated/zod/snailMailProviders";
+import { vinSourceStatusSchema } from "@/generated/zod/vinSources";
 import { initContract } from "@ts-rest/core";
 import { z } from "zod";
-import { caseSchema } from "../generated/zod/caseStore";
-import { emailOptionsSchema } from "../generated/zod/email";
-import { reportModuleSchema } from "../generated/zod/reportModules";
-import { snailMailProviderStatusSchema } from "../generated/zod/snailMailProviders";
-import { vinSourceStatusSchema } from "../generated/zod/vinSources";
 
 const c = initContract();
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -53,5 +53,14 @@ const envSchema = z
   })
   .passthrough();
 
-export const config = envSchema.parse(process.env);
-export type Config = typeof config;
+export type Config = z.infer<typeof envSchema>;
+
+function parseEnv(): Config {
+  return envSchema.parse(process.env);
+}
+
+export const config: Config = new Proxy({} as Config, {
+  get(_target, prop: keyof Config) {
+    return parseEnv()[prop];
+  },
+});

--- a/test/authz.test.ts
+++ b/test/authz.test.ts
@@ -9,10 +9,10 @@ beforeEach(async () => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
-  const db = await import("../src/lib/db");
+  const db = await import("@/lib/db");
   await db.migrationsReady;
-  const { orm } = await import("../src/lib/orm");
-  const { casbinRules, users } = await import("../src/lib/schema");
+  const { orm } = await import("@/lib/orm");
+  const { casbinRules, users } = await import("@/lib/schema");
   orm
     .insert(casbinRules)
     .values({ ptype: "p", v0: "superadmin", v1: "cases", v2: "delete" })
@@ -33,14 +33,14 @@ afterEach(() => {
 
 describe("casbin", () => {
   it("authorizes based on db rules", async () => {
-    const { authorize } = await import("../src/lib/authz");
+    const { authorize } = await import("@/lib/authz");
     expect(await authorize("superadmin", "cases", "delete")).toBe(true);
     expect(await authorize("user", "cases", "delete")).toBe(false);
   });
 
   it("checks case membership", async () => {
-    const { authorize } = await import("../src/lib/authz");
-    const caseStore = await import("../src/lib/caseStore");
+    const { authorize } = await import("@/lib/authz");
+    const caseStore = await import("@/lib/caseStore");
     const c = caseStore.createCase("/x.jpg", null, undefined, null, "u1");
     expect(
       await authorize("user", "cases", "read", { caseId: c.id, userId: "u1" }),

--- a/test/casbinRulesRoute.test.ts
+++ b/test/casbinRulesRoute.test.ts
@@ -9,10 +9,10 @@ beforeEach(async () => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
-  const db = await import("../src/lib/db");
+  const db = await import("@/lib/db");
   await db.migrationsReady;
-  const { orm } = await import("../src/lib/orm");
-  const { casbinRules } = await import("../src/lib/schema");
+  const { orm } = await import("@/lib/orm");
+  const { casbinRules } = await import("@/lib/schema");
   orm
     .insert(casbinRules)
     .values([
@@ -30,7 +30,7 @@ afterEach(() => {
 
 describe("casbin rules API", () => {
   it("allows admins to read", async () => {
-    const mod = await import("../src/app/api/casbin-rules/route");
+    const mod = await import("@/app/api/casbin-rules/route");
     const res = await mod.GET(new Request("http://test"), {
       params: Promise.resolve({}),
       session: { user: { role: "admin" } },
@@ -39,7 +39,7 @@ describe("casbin rules API", () => {
   });
 
   it("rejects regular users", async () => {
-    const mod = await import("../src/app/api/casbin-rules/route");
+    const mod = await import("@/app/api/casbin-rules/route");
     const res = await mod.GET(new Request("http://test"), {
       params: Promise.resolve({}),
       session: { user: { role: "user" } },
@@ -48,7 +48,7 @@ describe("casbin rules API", () => {
   });
 
   it("allows only superadmin to update", async () => {
-    const mod = await import("../src/app/api/casbin-rules/route");
+    const mod = await import("@/app/api/casbin-rules/route");
     const req = new Request("http://test", {
       method: "PUT",
       body: JSON.stringify([]),
@@ -66,8 +66,8 @@ describe("casbin rules API", () => {
   });
 
   it("applies new policies immediately", async () => {
-    const { authorize } = await import("../src/lib/authz");
-    const mod = await import("../src/app/api/casbin-rules/route");
+    const { authorize } = await import("@/lib/authz");
+    const mod = await import("@/app/api/casbin-rules/route");
     expect(await authorize("admin", "admin", "update")).toBe(false);
     const req = new Request("http://test", {
       method: "PUT",

--- a/test/caseAnalysis.test.ts
+++ b/test/caseAnalysis.test.ts
@@ -1,13 +1,13 @@
 // @vitest-environment node
 import { EventEmitter } from "node:events";
 import type { Worker } from "node:worker_threads";
+import type { Case } from "@/lib/caseStore";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Case } from "../src/lib/caseStore";
 
 const worker = new EventEmitter() as unknown as Worker;
 
 const runJobMock = vi.fn(() => worker);
-vi.mock("../src/lib/jobScheduler", () => ({ runJob: runJobMock }));
+vi.mock("@/lib/jobScheduler", () => ({ runJob: runJobMock }));
 
 describe("analyzeCaseInBackground", () => {
   beforeEach(() => {
@@ -15,7 +15,7 @@ describe("analyzeCaseInBackground", () => {
   });
 
   it("does not start a new worker when analysis is active", async () => {
-    const mod = await import("../src/lib/caseAnalysis");
+    const mod = await import("@/lib/caseAnalysis");
     const { analyzeCaseInBackground, isCaseAnalysisActive } = mod;
     const c: Case = {
       id: "1",

--- a/test/caseAuthorization.test.ts
+++ b/test/caseAuthorization.test.ts
@@ -4,17 +4,17 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 let dataDir: string;
-let caseStore: typeof import("../src/lib/caseStore");
+let caseStore: typeof import("@/lib/caseStore");
 
 beforeEach(async () => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
-  const db = await import("../src/lib/db");
+  const db = await import("@/lib/db");
   await db.migrationsReady;
-  caseStore = await import("../src/lib/caseStore");
-  const { orm } = await import("../src/lib/orm");
-  const { users } = await import("../src/lib/schema");
+  caseStore = await import("@/lib/caseStore");
+  const { orm } = await import("@/lib/orm");
+  const { users } = await import("@/lib/schema");
   orm
     .insert(users)
     .values([{ id: "u1" }, { id: "u2" }])
@@ -30,7 +30,7 @@ afterEach(() => {
 describe("case authorization", () => {
   it("rejects deletion by non-member", async () => {
     const c = caseStore.createCase("/a.jpg", null, undefined, null, "u1");
-    const { DELETE } = await import("../src/app/api/cases/[id]/route");
+    const { DELETE } = await import("@/app/api/cases/[id]/route");
     const res = await DELETE(new Request("http://test", { method: "DELETE" }), {
       params: Promise.resolve({ id: c.id }),
       session: { user: { id: "u2", role: "user" } },
@@ -40,7 +40,7 @@ describe("case authorization", () => {
 
   it("rejects update by non-member", async () => {
     const c = caseStore.createCase("/b.jpg", null, undefined, null, "u1");
-    const { PUT } = await import("../src/app/api/cases/[id]/vin/route");
+    const { PUT } = await import("@/app/api/cases/[id]/vin/route");
     const req = new Request("http://test", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -55,7 +55,7 @@ describe("case authorization", () => {
 
   it("rejects public toggle by non-member", async () => {
     const c = caseStore.createCase("/c.jpg", null, undefined, null, "u1");
-    const { PUT } = await import("../src/app/api/cases/[id]/public/route");
+    const { PUT } = await import("@/app/api/cases/[id]/public/route");
     const req = new Request("http://test", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -70,7 +70,7 @@ describe("case authorization", () => {
 
   it("rejects private case read by anonymous user", async () => {
     const c = caseStore.createCase("/d.jpg", null, undefined, null, "u1");
-    const { GET } = await import("../src/app/api/cases/[id]/route");
+    const { GET } = await import("@/app/api/cases/[id]/route");
     const res = await GET(new Request("http://test"), {
       params: Promise.resolve({ id: c.id }),
     });
@@ -79,7 +79,7 @@ describe("case authorization", () => {
 
   it("allows superadmin to toggle visibility", async () => {
     const c = caseStore.createCase("/d.jpg", null, undefined, null, "u1");
-    const { PUT } = await import("../src/app/api/cases/[id]/public/route");
+    const { PUT } = await import("@/app/api/cases/[id]/public/route");
     const req = new Request("http://test", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },

--- a/test/caseMembers.test.ts
+++ b/test/caseMembers.test.ts
@@ -4,19 +4,19 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 let dataDir: string;
-let caseStore: typeof import("../src/lib/caseStore");
-let members: typeof import("../src/lib/caseMembers");
-let orm: typeof import("../src/lib/orm").orm;
-let schema: typeof import("../src/lib/schema");
+let caseStore: typeof import("@/lib/caseStore");
+let members: typeof import("@/lib/caseMembers");
+let orm: typeof import("@/lib/orm").orm;
+let schema: typeof import("@/lib/schema");
 
 beforeEach(async () => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
-  const db = await import("../src/lib/db");
+  const db = await import("@/lib/db");
   await db.migrationsReady;
-  ({ orm } = await import("../src/lib/orm"));
-  schema = await import("../src/lib/schema");
+  ({ orm } = await import("@/lib/orm"));
+  schema = await import("@/lib/schema");
   orm
     .insert(schema.casbinRules)
     .values({ ptype: "p", v0: "user", v1: "cases", v2: "read" })
@@ -24,8 +24,8 @@ beforeEach(async () => {
   orm.insert(schema.users).values({ id: "u1" }).run();
   orm.insert(schema.users).values({ id: "u2" }).run();
   orm.insert(schema.users).values({ id: "u3", role: "admin" }).run();
-  caseStore = await import("../src/lib/caseStore");
-  members = await import("../src/lib/caseMembers");
+  caseStore = await import("@/lib/caseStore");
+  members = await import("@/lib/caseMembers");
 });
 
 afterEach(() => {
@@ -65,7 +65,7 @@ describe("case members", () => {
 
   it("owner invites collaborator via API", async () => {
     const c = caseStore.createCase("/d.jpg", null, undefined, null, "u1");
-    const { POST } = await import("../src/app/api/cases/[id]/invite/route");
+    const { POST } = await import("@/app/api/cases/[id]/invite/route");
     const res = await POST(
       new Request("http://test", {
         method: "POST",
@@ -85,7 +85,7 @@ describe("case members", () => {
   it("rejects collaborator invite", async () => {
     const c = caseStore.createCase("/e.jpg", null, undefined, null, "u1");
     members.addCaseMember(c.id, "u2", "collaborator");
-    const { POST } = await import("../src/app/api/cases/[id]/invite/route");
+    const { POST } = await import("@/app/api/cases/[id]/invite/route");
     const res = await POST(
       new Request("http://test", {
         method: "POST",
@@ -103,9 +103,7 @@ describe("case members", () => {
   it("admin can remove member", async () => {
     const c = caseStore.createCase("/f.jpg", null, undefined, null, "u1");
     members.addCaseMember(c.id, "u2", "collaborator");
-    const { DELETE } = await import(
-      "../src/app/api/cases/[id]/members/[uid]/route"
-    );
+    const { DELETE } = await import("@/app/api/cases/[id]/members/[uid]/route");
     const res = await DELETE(new Request("http://test"), {
       params: Promise.resolve({ id: c.id, uid: "u2" }),
       session: { user: { id: "u3", role: "admin" } },
@@ -118,9 +116,7 @@ describe("case members", () => {
   it("non-owner cannot remove member", async () => {
     const c = caseStore.createCase("/g.jpg", null, undefined, null, "u1");
     members.addCaseMember(c.id, "u2", "collaborator");
-    const { DELETE } = await import(
-      "../src/app/api/cases/[id]/members/[uid]/route"
-    );
+    const { DELETE } = await import("@/app/api/cases/[id]/members/[uid]/route");
     const res = await DELETE(new Request("http://test"), {
       params: Promise.resolve({ id: c.id, uid: "u2" }),
       session: { user: { id: "u2", role: "user" } },

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -1,24 +1,24 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { getRepresentativePhoto } from "@/lib/caseUtils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getRepresentativePhoto } from "../src/lib/caseUtils";
 
 let dataDir: string;
-let caseStore: typeof import("../src/lib/caseStore");
-let members: typeof import("../src/lib/caseMembers");
-let orm: typeof import("../src/lib/orm").orm;
-let schema: typeof import("../src/lib/schema");
+let caseStore: typeof import("@/lib/caseStore");
+let members: typeof import("@/lib/caseMembers");
+let orm: typeof import("@/lib/orm").orm;
+let schema: typeof import("@/lib/schema");
 
 beforeEach(async () => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
-  const dbModule = await import("../src/lib/db");
-  caseStore = await import("../src/lib/caseStore");
-  members = await import("../src/lib/caseMembers");
-  ({ orm } = await import("../src/lib/orm"));
-  schema = await import("../src/lib/schema");
+  const dbModule = await import("@/lib/db");
+  caseStore = await import("@/lib/caseStore");
+  members = await import("@/lib/caseMembers");
+  ({ orm } = await import("@/lib/orm"));
+  schema = await import("@/lib/schema");
   orm.insert(schema.users).values({ id: "u1" }).run();
   await dbModule.migrationsReady;
 });

--- a/test/citationStatusModules.test.ts
+++ b/test/citationStatusModules.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 describe("citationStatusModules", () => {
   it("returns a mock status", async () => {
     const { citationStatusModules } = await import(
-      "../src/lib/citationStatusModules"
+      "@/lib/citationStatusModules"
     );
     const result = await citationStatusModules.mock.lookupCitationStatus(
       "IL",

--- a/test/e2e/analysisQueue.test.ts
+++ b/test/e2e/analysisQueue.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { Case } from "@/lib/caseStore";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { Case } from "../../src/lib/caseStore";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";

--- a/test/e2e/paperwork.test.ts
+++ b/test/e2e/paperwork.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 
-let ocrPaperwork: typeof import("../../src/lib/openai").ocrPaperwork;
+let ocrPaperwork: typeof import("@/lib/openai").ocrPaperwork;
 
 let stub: OpenAIStub;
 
@@ -9,7 +9,7 @@ beforeAll(async () => {
   stub = await startOpenAIStub(["owner joe", { callsToAction: ["pay"] }]);
   process.env.OPENAI_BASE_URL = stub.url;
   process.env.OPENAI_API_KEY = "test";
-  const mod = await import("../../src/lib/openai");
+  const mod = await import("@/lib/openai");
   ocrPaperwork = mod.ocrPaperwork;
 });
 

--- a/test/emailSettings.test.ts
+++ b/test/emailSettings.test.ts
@@ -23,7 +23,7 @@ describe("sendEmail", () => {
     process.env.SMTP_USER = "";
     process.env.SMTP_PASS = "";
     process.env.SMTP_FROM = "";
-    const { sendEmail } = await import("../src/lib/email");
+    const { sendEmail } = await import("@/lib/email");
     await expect(
       sendEmail({ to: "x@example.com", subject: "a", body: "b" }),
     ).rejects.toThrow(/SMTP/);
@@ -37,7 +37,7 @@ describe("sendEmail", () => {
     process.env.SMTP_USER = "user";
     process.env.SMTP_PASS = "pass";
     process.env.SMTP_FROM = "from@example.com";
-    const { sendEmail } = await import("../src/lib/email");
+    const { sendEmail } = await import("@/lib/email");
     await sendEmail({ to: "x@example.com", subject: "a", body: "b" });
     expect(createTransport).toHaveBeenCalled();
     expect(sendMail).toHaveBeenCalled();

--- a/test/exif.test.ts
+++ b/test/exif.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
+import { extractGps, extractTimestamp } from "@/lib/exif";
 import { describe, expect, it } from "vitest";
-import { extractGps, extractTimestamp } from "../src/lib/exif";
 
 const starfish = fs.readFileSync("node_modules/exif-parser/test/starfish.jpg");
 

--- a/test/protectedRoutes.test.ts
+++ b/test/protectedRoutes.test.ts
@@ -10,7 +10,7 @@ beforeEach(async () => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
-  const db = await import("../src/lib/db");
+  const db = await import("@/lib/db");
   await db.migrationsReady;
 });
 
@@ -22,9 +22,9 @@ afterEach(() => {
 
 describe("protected routes", () => {
   it("returns 403 when unauthorized", async () => {
-    const store = await import("../src/lib/caseStore");
+    const store = await import("@/lib/caseStore");
     const c = store.createCase("/a.jpg", null);
-    const mod = await import("../src/app/api/cases/[id]/route");
+    const mod = await import("@/app/api/cases/[id]/route");
     const res = await mod.GET(new Request("http://test"), {
       params: Promise.resolve({ id: c.id }),
       session: { user: { role: "anonymous" } },
@@ -33,7 +33,7 @@ describe("protected routes", () => {
   });
 
   it("protects upload", async () => {
-    const mod = await import("../src/app/api/upload/route");
+    const mod = await import("@/app/api/upload/route");
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();
     form.append("photo", file);

--- a/test/publicCases.test.ts
+++ b/test/publicCases.test.ts
@@ -4,15 +4,15 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 let dataDir: string;
-let caseStore: typeof import("../src/lib/caseStore");
+let caseStore: typeof import("@/lib/caseStore");
 
 beforeEach(async () => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
-  const db = await import("../src/lib/db");
+  const db = await import("@/lib/db");
   await db.migrationsReady;
-  caseStore = await import("../src/lib/caseStore");
+  caseStore = await import("@/lib/caseStore");
 });
 
 afterEach(() => {
@@ -31,7 +31,7 @@ describe("public cases API", () => {
       undefined,
       true,
     );
-    const mod = await import("../src/app/api/public/cases/[id]/route");
+    const mod = await import("@/app/api/public/cases/[id]/route");
     const res = await mod.GET(new Request("http://test"), {
       params: Promise.resolve({ id: c.id }),
     });
@@ -42,7 +42,7 @@ describe("public cases API", () => {
 
   it("rejects private cases", async () => {
     const c = caseStore.createCase("/b.jpg", null);
-    const mod = await import("../src/app/api/public/cases/[id]/route");
+    const mod = await import("@/app/api/public/cases/[id]/route");
     const res = await mod.GET(new Request("http://test"), {
       params: Promise.resolve({ id: c.id }),
     });

--- a/test/snailMailAttachments.test.ts
+++ b/test/snailMailAttachments.test.ts
@@ -3,8 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { sendSnailMail } from "../src/lib/contactMethods";
-import { snailMailProviders } from "../src/lib/snailMail";
+import { sendSnailMail } from "@/lib/contactMethods";
+import { snailMailProviders } from "@/lib/snailMail";
 
 let tmpDir: string;
 let root: string;

--- a/test/snailMailProviders.test.ts
+++ b/test/snailMailProviders.test.ts
@@ -10,9 +10,9 @@ beforeEach(async () => {
   process.env.SNAIL_MAIL_PROVIDER_FILE = path.join(dataDir, "providers.json");
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
-  const db = await import("../src/lib/db");
+  const db = await import("@/lib/db");
   await db.migrationsReady;
-  const { snailMailProviders } = await import("../src/lib/snailMail");
+  const { snailMailProviders } = await import("@/lib/snailMail");
   const statuses = Object.keys(snailMailProviders).map((id, idx) => ({
     id,
     active: idx === 0,
@@ -33,7 +33,7 @@ afterEach(() => {
 
 describe("snail mail provider store", () => {
   it("activates the selected provider", async () => {
-    const store = await import("../src/lib/snailMailProviders");
+    const store = await import("@/lib/snailMailProviders");
     store.setActiveSnailMailProvider("docsmit");
     const list = store.getSnailMailProviderStatuses();
     const active = list.find((p) => p.active);
@@ -41,7 +41,7 @@ describe("snail mail provider store", () => {
   });
 
   it("records failures", async () => {
-    const store = await import("../src/lib/snailMailProviders");
+    const store = await import("@/lib/snailMailProviders");
     store.recordProviderFailure("mock");
     const item = store
       .getSnailMailProviderStatuses()
@@ -52,7 +52,7 @@ describe("snail mail provider store", () => {
 
 describe("snail mail provider API authorization", () => {
   it("rejects listing without admin role", async () => {
-    const mod = await import("../src/app/api/snail-mail-providers/route");
+    const mod = await import("@/app/api/snail-mail-providers/route");
     const res = await mod.GET(new Request("http://test"), {
       params: Promise.resolve({}) as Promise<Record<string, string>>,
       session: { user: { role: "user" } },
@@ -61,7 +61,7 @@ describe("snail mail provider API authorization", () => {
   });
 
   it("rejects update without admin role", async () => {
-    const mod = await import("../src/app/api/snail-mail-providers/[id]/route");
+    const mod = await import("@/app/api/snail-mail-providers/[id]/route");
     const req = new Request("http://test", { method: "PUT" });
     const res = await mod.PUT(req, {
       params: Promise.resolve({ id: "mock" }) as Promise<{ id: string }>,

--- a/test/vinLookup.test.ts
+++ b/test/vinLookup.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { Case } from "@/lib/caseStore";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Case } from "../src/lib/caseStore";
 
 let dataDir: string;
 
@@ -10,7 +10,7 @@ beforeEach(async () => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   process.env.VIN_SOURCE_FILE = path.join(dataDir, "vinSources.json");
-  const { defaultVinSources } = await import("../src/lib/vinSources");
+  const { defaultVinSources } = await import("@/lib/vinSources");
   const statuses = defaultVinSources.map((s) => ({
     id: s.id,
     enabled: true,
@@ -18,7 +18,7 @@ beforeEach(async () => {
   }));
   fs.writeFileSync(process.env.VIN_SOURCE_FILE, JSON.stringify(statuses));
   vi.resetModules();
-  const dbModule = await import("../src/lib/db");
+  const dbModule = await import("@/lib/db");
   await dbModule.migrationsReady;
 });
 
@@ -31,7 +31,7 @@ afterEach(() => {
 
 describe("vinLookup", () => {
   it("parses vin from html", async () => {
-    const { parseVinFromHtml } = await import("../src/lib/vinLookup");
+    const { parseVinFromHtml } = await import("@/lib/vinLookup");
     const html = "<div><span id='v'>VIN: 1HGCM82633A004352</span></div>";
     expect(parseVinFromHtml(html, "#v")).toBe("1HGCM82633A004352");
   });
@@ -46,7 +46,7 @@ describe("vinLookup", () => {
     const globalAny: any = global;
     const originalFetch = globalAny.fetch;
     globalAny.fetch = fetchMock;
-    const { lookupVin } = await import("../src/lib/vinLookup");
+    const { lookupVin } = await import("@/lib/vinLookup");
     const vin = await lookupVin("ABC123", "IL");
     expect(fetchMock).toHaveBeenCalled();
     const callArgs = fetchMock.mock.calls[0];
@@ -66,8 +66,8 @@ describe("vinLookup", () => {
     const originalFetch = globalAny.fetch;
     globalAny.fetch = fetchMock;
     const logSpy = vi.spyOn(console, "log");
-    const { fetchCaseVin } = await import("../src/lib/vinLookup");
-    const caseStore = await import("../src/lib/caseStore");
+    const { fetchCaseVin } = await import("@/lib/vinLookup");
+    const caseStore = await import("@/lib/caseStore");
     const c = caseStore.createCase("/x.jpg");
     caseStore.updateCase(c.id, {
       analysis: {
@@ -88,9 +88,9 @@ describe("vinLookup", () => {
   });
 
   it("updates a case with the fetched vin", async () => {
-    const caseStore = await import("../src/lib/caseStore");
+    const caseStore = await import("@/lib/caseStore");
     const { createCase, updateCase, getCase } = caseStore;
-    const vinLookup = await import("../src/lib/vinLookup");
+    const vinLookup = await import("@/lib/vinLookup");
     const { fetchCaseVin } = vinLookup;
     const json = JSON.stringify({ vins: ["1HGCM82633A004352"] });
     const fetchMock = vi.fn().mockResolvedValue({
@@ -130,7 +130,7 @@ describe("vinLookup", () => {
     const globalAny: any = global;
     const originalFetch = globalAny.fetch;
     globalAny.fetch = fetchMock;
-    const { lookupVin } = await import("../src/lib/vinLookup");
+    const { lookupVin } = await import("@/lib/vinLookup");
     const vin = await lookupVin("A", "B");
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(vin).toBe("1HGCM82633A004352");

--- a/test/vinSources.test.ts
+++ b/test/vinSources.test.ts
@@ -10,9 +10,9 @@ beforeEach(async () => {
   process.env.VIN_SOURCE_FILE = path.join(dataDir, "vinSources.json");
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
-  const db = await import("../src/lib/db");
+  const db = await import("@/lib/db");
   await db.migrationsReady;
-  const { defaultVinSources } = await import("../src/lib/vinSources");
+  const { defaultVinSources } = await import("@/lib/vinSources");
   const statuses = defaultVinSources.map((s: { id: string }) => ({
     id: s.id,
     enabled: true,
@@ -30,7 +30,7 @@ afterEach(() => {
 
 describe("vin source health", () => {
   it("disables after three failures", async () => {
-    const store = await import("../src/lib/vinSources");
+    const store = await import("@/lib/vinSources");
     store.recordVinSourceFailure("edmunds");
     store.recordVinSourceFailure("edmunds");
     store.recordVinSourceFailure("edmunds");
@@ -43,7 +43,7 @@ describe("vin source health", () => {
 
 describe("vin source API authorization", () => {
   it("rejects listing without admin role", async () => {
-    const mod = await import("../src/app/api/vin-sources/route");
+    const mod = await import("@/app/api/vin-sources/route");
     const res = await mod.GET(new Request("http://test"), {
       params: Promise.resolve({}) as Promise<Record<string, string>>,
       session: { user: { role: "user" } },
@@ -52,7 +52,7 @@ describe("vin source API authorization", () => {
   });
 
   it("rejects update without admin role", async () => {
-    const mod = await import("../src/app/api/vin-sources/[id]/route");
+    const mod = await import("@/app/api/vin-sources/[id]/route");
     const req = new Request("http://test", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },

--- a/test/violationCodesLookup.test.ts
+++ b/test/violationCodesLookup.test.ts
@@ -20,8 +20,8 @@ afterEach(() => {
 
 describe("getViolationCode", () => {
   it("uses llm when missing and caches result", async () => {
-    const mod = await import("../src/lib/violationCodes");
-    const { client } = (await import("../src/lib/llm")).getLlm("lookup_code");
+    const mod = await import("@/lib/violationCodes");
+    const { client } = (await import("@/lib/llm")).getLlm("lookup_code");
     vi.spyOn(client.chat.completions, "create").mockResolvedValueOnce({
       choices: [{ message: { content: JSON.stringify({ code: "A1" }) } }],
     } as unknown as ChatCompletion);
@@ -38,8 +38,8 @@ describe("getViolationCode", () => {
       process.env.VIOLATION_CODE_FILE ?? "",
       JSON.stringify({ "oak-park": { parking: "B2" } }, null, 2),
     );
-    const mod = await import("../src/lib/violationCodes");
-    const { client } = (await import("../src/lib/llm")).getLlm("lookup_code");
+    const mod = await import("@/lib/violationCodes");
+    const { client } = (await import("@/lib/llm")).getLlm("lookup_code");
     const spy = vi.spyOn(client.chat.completions, "create");
     const code = await mod.getViolationCode("oak-park", "parking");
     expect(code).toBe("B2");

--- a/test/violationUtils.test.ts
+++ b/test/violationUtils.test.ts
@@ -1,5 +1,5 @@
+import { getBestViolationPhoto, hasViolation } from "@/lib/caseUtils";
 import { describe, expect, it } from "vitest";
-import { getBestViolationPhoto, hasViolation } from "../src/lib/caseUtils";
 
 describe("hasViolation", () => {
   it("detects violation from image flags", () => {


### PR DESCRIPTION
## Summary
- rewrite `config.ts` to return environment variables dynamically
- convert all relative parent imports to `@/` path alias
- add a helper script to fix imports automatically

## Testing
- `npm run format`
- `npm run lint`
- `TWILIO_ACCOUNT_SID=sid TWILIO_AUTH_TOKEN=token TWILIO_FROM_NUMBER=+15551234567 RETURN_ADDRESS="Me\n1 A St\nTown, ST 12345" SNAIL_MAIL_PROVIDER=mock npm test`


------
https://chatgpt.com/codex/tasks/task_e_68556712cde8832b881b457195f5f765