### PR TITLE
Use single Next.js server for e2e tests

### DIFF
--- a/src/lib/__tests__/ownershipModules.test.ts
+++ b/src/lib/__tests__/ownershipModules.test.ts
@@ -1,14 +1,15 @@
 import fs from "node:fs";
-import { ownershipModules } from "@/lib/ownershipModules";
-import * as snailMail from "@/lib/snailMail";
+import type * as snailMail from "@/lib/snailMail";
 import { describe, expect, it, vi } from "vitest";
 
 describe("ownershipModules.il.requestVin", () => {
   it("generates a PDF and mails it", async () => {
     process.env.RETURN_ADDRESS = "1 A St\nCity, IL 12345";
     process.env.SNAIL_MAIL_PROVIDER = "mock";
+    const snail = await import("@/lib/snailMail");
+    const { ownershipModules } = await import("@/lib/ownershipModules");
     const sendMock = vi
-      .spyOn(snailMail, "sendSnailMail")
+      .spyOn(snail, "sendSnailMail")
       .mockResolvedValue({ id: "1", status: "saved" });
 
     await ownershipModules.il.requestVin?.({

--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -1,9 +1,12 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
-import { type TestServer, startServer } from "./startServer";
+
+interface TestServer {
+  url: string;
+}
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
@@ -46,20 +49,10 @@ async function createCase(): Promise<string> {
   return data.caseId;
 }
 
-beforeAll(async () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-admin-"));
-  server = await startServer(3021, {
-    NEXTAUTH_SECRET: "secret",
-    NODE_ENV: "test",
-    SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
-  });
+beforeAll(() => {
+  server = global.__E2E_SERVER__ as TestServer;
   api = createApi(server);
-}, 120000);
-
-afterAll(async () => {
-  await server.close();
-}, 120000);
+});
 
 describe("admin actions", () => {
   it("promotes and demotes users", async () => {

--- a/test/e2e/analysisQueue.test.ts
+++ b/test/e2e/analysisQueue.test.ts
@@ -5,7 +5,10 @@ import type { Case } from "@/lib/caseStore";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
-import { type TestServer, startServer } from "./startServer";
+
+interface TestServer {
+  url: string;
+}
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
@@ -75,13 +78,12 @@ beforeAll(async () => {
     }),
   ]);
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  server = await startServer(3007, envFiles());
+  server = global.__E2E_SERVER__ as TestServer;
   api = createApi(server);
   await signIn("user@example.com");
 }, 120000);
 
 afterAll(async () => {
-  await server.close();
   await stub.close();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 }, 120000);

--- a/test/e2e/auth.test.ts
+++ b/test/e2e/auth.test.ts
@@ -1,22 +1,17 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
-import { type TestServer, startServer } from "./startServer";
+
+interface TestServer {
+  url: string;
+}
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
-beforeAll(async () => {
-  server = await startServer(3010, {
-    NEXTAUTH_SECRET: "secret",
-    NODE_ENV: "test",
-    SMTP_FROM: "test@example.com",
-  });
+beforeAll(() => {
+  server = global.__E2E_SERVER__ as TestServer;
   api = createApi(server);
-}, 120000);
-
-afterAll(async () => {
-  await server.close();
-}, 120000);
+});
 
 describe("auth flow", () => {
   it("logs in and out", async () => {

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -1,17 +1,14 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
+import { beforeAll, describe, expect, it } from "vitest";
+
+interface TestServer {
+  url: string;
+}
 
 let server: TestServer;
 
-beforeAll(async () => {
-  server = await startServer(3002, {
-    NEXTAUTH_SECRET: "secret",
-  });
-}, 120000);
-
-afterAll(async () => {
-  await server.close();
-}, 120000);
+beforeAll(() => {
+  server = global.__E2E_SERVER__ as TestServer;
+});
 
 describe("end-to-end", () => {
   it("serves the homepage", async () => {

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
-import { type TestServer, startServer } from "./startServer";
+
+interface TestServer {
+  url: string;
+}
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
@@ -54,13 +57,12 @@ beforeAll(async () => {
       2,
     ),
   );
-  server = await startServer(3003, env);
+  server = global.__E2E_SERVER__ as TestServer;
   api = createApi(server);
   await signIn("user@example.com");
 }, 120000);
 
 afterAll(async () => {
-  await server.close();
   await stub.close();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 }, 120000);

--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -5,7 +5,10 @@ import Database from "better-sqlite3";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
-import { type TestServer, startServer } from "./startServer";
+
+interface TestServer {
+  url: string;
+}
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
@@ -58,13 +61,12 @@ beforeAll(async () => {
       2,
     ),
   );
-  server = await startServer(3005, env);
+  server = global.__E2E_SERVER__ as TestServer;
   api = createApi(server);
   await signIn("user@example.com");
 }, 120000);
 
 afterAll(async () => {
-  await server.close();
   await stub.close();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 }, 120000);

--- a/test/e2e/freshDatabase.test.ts
+++ b/test/e2e/freshDatabase.test.ts
@@ -3,7 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
-import { type TestServer, startServer } from "./startServer";
+
+interface TestServer {
+  url: string;
+}
 
 let server: TestServer;
 let tmpDir: string;
@@ -26,19 +29,13 @@ async function signIn(email: string) {
   );
 }
 
-beforeAll(async () => {
+beforeAll(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-auth-"));
-  server = await startServer(3022, {
-    NEXTAUTH_SECRET: "secret",
-    NODE_ENV: "test",
-    SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
-  });
+  server = global.__E2E_SERVER__ as TestServer;
   api = createApi(server);
-}, 120000);
+});
 
 afterAll(async () => {
-  await server.close();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 }, 120000);
 

--- a/test/e2e/members.test.ts
+++ b/test/e2e/members.test.ts
@@ -1,9 +1,12 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
-import { type TestServer, startServer } from "./startServer";
+
+interface TestServer {
+  url: string;
+}
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
@@ -46,20 +49,11 @@ async function createCase(): Promise<string> {
   return data.caseId;
 }
 
-beforeAll(async () => {
+beforeAll(() => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  server = await startServer(3012, {
-    NEXTAUTH_SECRET: "secret",
-    NODE_ENV: "test",
-    SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
-  });
+  server = global.__E2E_SERVER__ as TestServer;
   api = createApi(server);
-}, 120000);
-
-afterAll(async () => {
-  await server.close();
-}, 120000);
+});
 
 describe("case members e2e", () => {
   it("invites and removes collaborators", async () => {

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -1,9 +1,12 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
-import { type TestServer, startServer } from "./startServer";
+
+interface TestServer {
+  url: string;
+}
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
@@ -46,20 +49,10 @@ async function createCase(): Promise<string> {
   return data.caseId;
 }
 
-beforeAll(async () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  server = await startServer(3011, {
-    NEXTAUTH_SECRET: "secret",
-    NODE_ENV: "test",
-    SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
-  });
+beforeAll(() => {
+  server = global.__E2E_SERVER__ as TestServer;
   api = createApi(server);
-}, 120000);
-
-afterAll(async () => {
-  await server.close();
-}, 120000);
+});
 
 describe("permissions", () => {
   it("hides admin actions for regular users", async () => {

--- a/test/e2e/point.test.ts
+++ b/test/e2e/point.test.ts
@@ -1,17 +1,14 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
+import { beforeAll, describe, expect, it } from "vitest";
+
+interface TestServer {
+  url: string;
+}
 
 let server: TestServer;
 
-beforeAll(async () => {
-  server = await startServer(3005, {
-    NEXTAUTH_SECRET: "secret",
-  });
-}, 120000);
-
-afterAll(async () => {
-  await server.close();
-}, 120000);
+beforeAll(() => {
+  server = global.__E2E_SERVER__ as TestServer;
+});
 
 describe("point and shoot", () => {
   it("serves the point page", async () => {

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -1,9 +1,12 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
-import { type TestServer, startServer } from "./startServer";
+
+interface TestServer {
+  url: string;
+}
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
@@ -46,20 +49,11 @@ async function createCase(): Promise<string> {
   return data.caseId;
 }
 
-beforeAll(async () => {
+beforeAll(() => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  server = await startServer(3021, {
-    NEXTAUTH_SECRET: "secret",
-    NODE_ENV: "test",
-    SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
-  });
+  server = global.__E2E_SERVER__ as TestServer;
   api = createApi(server);
-}, 120000);
-
-afterAll(async () => {
-  await server.close();
-}, 120000);
+});
 
 describe("anonymous access", () => {
   it("allows access to public case", async () => {

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -1,9 +1,12 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
-import { type TestServer, startServer } from "./startServer";
+
+interface TestServer {
+  url: string;
+}
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
@@ -25,20 +28,11 @@ async function signIn(email: string) {
   );
 }
 
-beforeAll(async () => {
+beforeAll(() => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  server = await startServer(3020, {
-    NEXTAUTH_SECRET: "secret",
-    NODE_ENV: "test",
-    SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
-  });
+  server = global.__E2E_SERVER__ as TestServer;
   api = createApi(server);
-}, 120000);
-
-afterAll(async () => {
-  await server.close();
-}, 120000);
+});
 
 describe("case visibility", () => {
   it("shows toggle for admins", async () => {

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
-import { type TestServer, startServer } from "./startServer";
+
+interface TestServer {
+  url: string;
+}
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
@@ -50,13 +53,12 @@ async function setup(responses: Array<import("./openaiStub").StubResponse>) {
       2,
     ),
   );
-  server = await startServer(3010, env);
+  server = global.__E2E_SERVER__ as TestServer;
   api = createApi(server);
   await signIn("user@example.com");
 }
 
 async function teardown() {
-  await server.close();
   await stub.close();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 }

--- a/test/e2e/signinEmptyDb.test.ts
+++ b/test/e2e/signinEmptyDb.test.ts
@@ -3,25 +3,22 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
-import { type TestServer, startServer } from "./startServer";
+
+interface TestServer {
+  url: string;
+}
 
 let server: TestServer;
 let dataDir: string;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
-beforeAll(async () => {
+beforeAll(() => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
-  server = await startServer(3013, {
-    CASE_STORE_FILE: path.join(dataDir, "cases.sqlite"),
-    NEXTAUTH_SECRET: "secret",
-    NODE_ENV: "test",
-    SMTP_FROM: "test@example.com",
-  });
+  server = global.__E2E_SERVER__ as TestServer;
   api = createApi(server);
-}, 120000);
+});
 
 afterAll(async () => {
-  await server.close();
   fs.rmSync(dataDir, { recursive: true, force: true });
 }, 120000);
 

--- a/test/e2e/snailmail.test.ts
+++ b/test/e2e/snailmail.test.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
-import { type TestServer, startServer } from "./startServer";
+
+interface TestServer {
+  url: string;
+}
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
@@ -82,13 +85,12 @@ beforeAll(async () => {
       2,
     ),
   );
-  server = await startServer(3008, env);
+  server = global.__E2E_SERVER__ as TestServer;
   api = createApi(server);
   await signIn("user@example.com");
 }, 120000);
 
 afterAll(async () => {
-  await server.close();
   await stub.close();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 }, 120000);

--- a/test/e2e/stream.test.ts
+++ b/test/e2e/stream.test.ts
@@ -1,17 +1,14 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
+import { beforeAll, describe, expect, it } from "vitest";
+
+interface TestServer {
+  url: string;
+}
 
 let server: TestServer;
 
-beforeAll(async () => {
-  server = await startServer(3004, {
-    NEXTAUTH_SECRET: "secret",
-  });
-}, 120000);
-
-afterAll(async () => {
-  await server.close();
-}, 120000);
+beforeAll(() => {
+  server = global.__E2E_SERVER__ as TestServer;
+});
 
 describe("case events", () => {
   it("streams updates", async () => {

--- a/test/e2e/thread.test.ts
+++ b/test/e2e/thread.test.ts
@@ -2,22 +2,20 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { type TestServer, startServer } from "./startServer";
+
+interface TestServer {
+  url: string;
+}
 
 let server: TestServer;
 let tmpDir: string;
 
-beforeAll(async () => {
+beforeAll(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  const env = {
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
-    NEXTAUTH_SECRET: "secret",
-  };
-  server = await startServer(3006, env);
-}, 120000);
+  server = global.__E2E_SERVER__ as TestServer;
+});
 
 afterAll(async () => {
-  await server.close();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 }, 120000);
 

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["test/e2e/*.test.ts"],
+    setupFiles: "./vitest.e2e.setup.ts",
     testTimeout: 30000,
     hookTimeout: 30000,
     maxConcurrency: 1,

--- a/vitest.e2e.setup.ts
+++ b/vitest.e2e.setup.ts
@@ -1,0 +1,105 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll } from "vitest";
+
+interface ServerInfo {
+  port: number;
+  url: string;
+  close: () => Promise<void>;
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __E2E_SERVER__: ServerInfo | undefined;
+}
+
+function waitForServer(port: number): Promise<void> {
+  return new Promise((resolve) => {
+    const attempt = () => {
+      http
+        .get(`http://localhost:${port}`, () => resolve())
+        .on("error", () => setTimeout(attempt, 200));
+    };
+    attempt();
+  });
+}
+
+async function run(cmd: string, args: string[]): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn(cmd, args, { stdio: "inherit" });
+    proc.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} ${args.join(" ")} exited with ${code}`));
+    });
+  });
+}
+
+beforeAll(async () => {
+  if (global.__E2E_SERVER__) return;
+  if (!fs.existsSync(".next")) {
+    await run(path.join("node_modules", ".bin", "next"), ["build"]);
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
+  const env = {
+    ...process.env,
+    NEXT_TELEMETRY_DISABLED: "1",
+    TEST_APIS: "1",
+    NODE_ENV: "test",
+    NEXTAUTH_URL: "http://localhost",
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
+    CI: "1",
+  } as NodeJS.ProcessEnv;
+
+  const proc = spawn(
+    path.join("node_modules", ".bin", "next"),
+    ["start", "-p", "0"],
+    {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  let port: number | undefined;
+  const parse = (data: Buffer) => {
+    const m = data.toString().match(/localhost:(\d+)/);
+    if (m) port = Number(m[1]);
+  };
+  proc.stdout.on("data", parse);
+  proc.stderr.on("data", parse);
+
+  await new Promise<void>((resolve, reject) => {
+    const check = () => {
+      if (port) {
+        waitForServer(port).then(resolve);
+      } else if (proc.exitCode != null) {
+        reject(new Error("next start failed"));
+      } else {
+        setTimeout(check, 100);
+      }
+    };
+    check();
+  });
+
+  if (!port) throw new Error("Server port not found");
+  const serverPort = port;
+  global.__E2E_SERVER__ = {
+    port: serverPort,
+    url: `http://localhost:${serverPort}`,
+    close: () =>
+      new Promise((resolve) => {
+        proc.once("exit", () => resolve());
+        proc.kill();
+      }),
+  };
+}, 120000);
+
+afterAll(async () => {
+  if (global.__E2E_SERVER__) {
+    await global.__E2E_SERVER__?.close();
+    global.__E2E_SERVER__ = undefined;
+  }
+});


### PR DESCRIPTION
## Summary
- add `vitest.e2e.setup.ts` to build and start Next.js once for e2e
- start server on an ephemeral port and expose it globally
- reference the shared server in e2e tests
- fix ownershipModules test to set env before importing modules

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e` *(failed: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6855808e832c832bb4947f68a81d2465