### PR TITLE
Ensure NODE_ENV set for e2e

### DIFF
--- a/src/lib/__tests__/ownershipModules.test.ts
+++ b/src/lib/__tests__/ownershipModules.test.ts
@@ -1,16 +1,16 @@
 import fs from "node:fs";
-import { ownershipModules } from "@/lib/ownershipModules";
-import * as snailMail from "@/lib/snailMail";
 import { describe, expect, it, vi } from "vitest";
 
 describe("ownershipModules.il.requestVin", () => {
   it("generates a PDF and mails it", async () => {
     process.env.RETURN_ADDRESS = "1 A St\nCity, IL 12345";
     process.env.SNAIL_MAIL_PROVIDER = "mock";
+    vi.resetModules();
+    const snailMail = await import("@/lib/snailMail");
+    const { ownershipModules } = await import("@/lib/ownershipModules");
     const sendMock = vi
       .spyOn(snailMail, "sendSnailMail")
       .mockResolvedValue({ id: "1", status: "saved" });
-
     await ownershipModules.il.requestVin?.({
       plate: "ABC123",
       state: "IL",

--- a/test/e2e/analysisQueue.test.ts
+++ b/test/e2e/analysisQueue.test.ts
@@ -47,6 +47,7 @@ function envFiles() {
     VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
     OPENAI_BASE_URL: stub.url,
     NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
   };
 }
 

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -6,6 +6,7 @@ let server: TestServer;
 beforeAll(async () => {
   server = await startServer(3002, {
     NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
   });
 }, 120000);
 

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -42,6 +42,7 @@ beforeAll(async () => {
     VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
     OPENAI_BASE_URL: stub.url,
     NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
   };
   fs.writeFileSync(
     env.VIN_SOURCE_FILE,

--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -46,6 +46,7 @@ beforeAll(async () => {
     VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
     OPENAI_BASE_URL: stub.url,
     NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
   };
   fs.writeFileSync(
     env.VIN_SOURCE_FILE,

--- a/test/e2e/point.test.ts
+++ b/test/e2e/point.test.ts
@@ -6,6 +6,7 @@ let server: TestServer;
 beforeAll(async () => {
   server = await startServer(3005, {
     NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
   });
 }, 120000);
 

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -38,6 +38,7 @@ async function setup(responses: Array<import("./openaiStub").StubResponse>) {
     VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
     OPENAI_BASE_URL: stub.url,
     NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
   };
   fs.writeFileSync(
     env.VIN_SOURCE_FILE,

--- a/test/e2e/stream.test.ts
+++ b/test/e2e/stream.test.ts
@@ -6,6 +6,7 @@ let server: TestServer;
 beforeAll(async () => {
   server = await startServer(3004, {
     NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
   });
 }, 120000);
 

--- a/test/e2e/thread.test.ts
+++ b/test/e2e/thread.test.ts
@@ -12,6 +12,7 @@ beforeAll(async () => {
   const env = {
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
   };
   server = await startServer(3006, env);
 }, 120000);


### PR DESCRIPTION
## Summary
- add `NODE_ENV: "test"` to all test servers
- reload ownership modules after setting env in unit test

## Testing
- `npm test`
- `npm run e2e` *(fails: Unexpected end of JSON input)*

------
https://chatgpt.com/codex/tasks/task_e_68557e5cb00c832b802f9bcaf27c8b77