### PR TITLE
Reduce e2e test delays

### DIFF
--- a/test/e2e/analysisQueue.test.ts
+++ b/test/e2e/analysisQueue.test.ts
@@ -55,10 +55,10 @@ async function createPhoto(name: string): Promise<File> {
 }
 
 async function fetchCase(id: string): Promise<Case> {
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < 10; i++) {
     const res = await api(`/api/cases/${id}`);
     if (res.status === 200) return (await res.json()) as Case;
-    await new Promise((r) => setTimeout(r, 500));
+    await new Promise((r) => setTimeout(r, 75));
   }
   const res = await api(`/api/cases/${id}`);
   return (await res.json()) as Case;
@@ -111,10 +111,10 @@ describe("analysis queue", () => {
     });
     expect(addRes.status).toBe(200);
 
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 10; i++) {
       data = await fetchCase(caseId);
       if (data.photos.length === 2) break;
-      await new Promise((r) => setTimeout(r, 500));
+      await new Promise((r) => setTimeout(r, 75));
     }
     expect(data.photos).toHaveLength(2);
   }, 30000);
@@ -139,10 +139,10 @@ describe("analysis queue", () => {
     add.append("caseId", caseId);
     await api("/api/upload", { method: "POST", body: add });
 
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 10; i++) {
       data = await fetchCase(caseId);
       if (data.photos.length === 2) break;
-      await new Promise((r) => setTimeout(r, 500));
+      await new Promise((r) => setTimeout(r, 75));
     }
 
     const del = await api(`/api/cases/${caseId}/photos`, {

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -80,36 +80,36 @@ describe("e2e flows (unauthenticated)", () => {
   }
 
   async function fetchCase(id: string): Promise<Response> {
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 5; i++) {
       const res = await api(`/api/cases/${id}`);
       if (res.status === 200) return res;
-      await new Promise((r) => setTimeout(r, 500));
+      await new Promise((r) => setTimeout(r, 50));
     }
     return api(`/api/cases/${id}`);
   }
 
   async function waitForPhotos(id: string, count: number) {
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 10; i++) {
       const res = await fetchCase(id);
       if (res.status === 200) {
         const json = await res.json();
         if (json.photos.length === count) return json;
       }
-      await new Promise((r) => setTimeout(r, 500));
+      await new Promise((r) => setTimeout(r, 50));
     }
     const res = await fetchCase(id);
     return res.json();
   }
 
   async function putVin(id: string, vin: string): Promise<Response> {
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 5; i++) {
       const res = await api(`/api/cases/${id}/vin`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ vin }),
       });
       if (res.status === 200) return res;
-      await new Promise((r) => setTimeout(r, 500));
+      await new Promise((r) => setTimeout(r, 50));
     }
     return api(`/api/cases/${id}/vin`, {
       method: "PUT",

--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -74,7 +74,7 @@ describe("follow up", () => {
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();
     form.append("photo", file);
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 10; i++) {
       const res = await api("/api/upload", {
         method: "POST",
         body: form,
@@ -83,7 +83,7 @@ describe("follow up", () => {
         const data = (await res.json()) as { caseId: string };
         return data.caseId;
       }
-      await new Promise((r) => setTimeout(r, 500));
+      await new Promise((r) => setTimeout(r, 50));
     }
     const final = await api("/api/upload", {
       method: "POST",
@@ -94,10 +94,10 @@ describe("follow up", () => {
   }
 
   async function fetchFollowup(id: string): Promise<Response> {
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 10; i++) {
       const res = await api(`/api/cases/${id}/followup`);
       if (res.status === 200) return res;
-      await new Promise((r) => setTimeout(r, 500));
+      await new Promise((r) => setTimeout(r, 50));
     }
     return api(`/api/cases/${id}/followup`);
   }

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -100,13 +100,13 @@ describe("reanalysis", () => {
         };
       };
       let json: CaseData | undefined;
-      for (let i = 0; i < 10; i++) {
+      for (let i = 0; i < 5; i++) {
         const check = await api(`/api/cases/${caseId}`);
         if (check.status === 200) {
           json = (await check.json()) as CaseData;
           break;
         }
-        await new Promise((r) => setTimeout(() => r(undefined), 500));
+        await new Promise((r) => setTimeout(() => r(undefined), 75));
       }
       expect(json).toBeDefined();
       if (!json) throw new Error("case data not found");
@@ -119,10 +119,10 @@ describe("reanalysis", () => {
         { method: "POST" },
       );
       expect(re.status).toBe(200);
-      for (let i = 0; i < 10; i++) {
+      for (let i = 0; i < 5; i++) {
         const check = await api(`/api/cases/${caseId}`);
         if (check.status === 200) break;
-        await new Promise((r) => setTimeout(() => r(undefined), 500));
+        await new Promise((r) => setTimeout(() => r(undefined), 75));
       }
       expect(stub.requests.length).toBeGreaterThanOrEqual(1);
     }, 30000);
@@ -167,13 +167,13 @@ describe("reanalysis", () => {
         };
       };
       let json: CaseData | undefined;
-      for (let i = 0; i < 10; i++) {
+      for (let i = 0; i < 5; i++) {
         const check = await api(`/api/cases/${caseId}`);
         if (check.status === 200) {
           json = (await check.json()) as CaseData;
           break;
         }
-        await new Promise((r) => setTimeout(() => r(undefined), 500));
+        await new Promise((r) => setTimeout(() => r(undefined), 75));
       }
       expect(json).toBeDefined();
       if (!json) throw new Error("case data not found");
@@ -186,10 +186,10 @@ describe("reanalysis", () => {
         { method: "POST" },
       );
       expect(re.status).toBe(200);
-      for (let i = 0; i < 10; i++) {
+      for (let i = 0; i < 5; i++) {
         const check = await api(`/api/cases/${caseId}`);
         if (check.status === 200) break;
-        await new Promise((r) => setTimeout(() => r(undefined), 500));
+        await new Promise((r) => setTimeout(() => r(undefined), 75));
       }
       expect(stub.requests.length).toBeGreaterThanOrEqual(1);
     }, 30000);


### PR DESCRIPTION
## Summary
- shorten retry intervals and loop counts in e2e tests

## Testing
- `npm run format`
- `npm run lint`
- `RETURN_ADDRESS="1 A St" npm test`
- `RETURN_ADDRESS="1 A St" npx vitest run -c vitest.e2e.config.ts test/e2e/analysisQueue.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6855807f85a4832b8410c2fb7c7c03e0