### PR TITLE
Update session defaults

### DIFF
--- a/src/lib/__tests__/ownershipModules.test.ts
+++ b/src/lib/__tests__/ownershipModules.test.ts
@@ -1,12 +1,13 @@
 import fs from "node:fs";
-import { ownershipModules } from "@/lib/ownershipModules";
-import * as snailMail from "@/lib/snailMail";
 import { describe, expect, it, vi } from "vitest";
 
 describe("ownershipModules.il.requestVin", () => {
   it("generates a PDF and mails it", async () => {
     process.env.RETURN_ADDRESS = "1 A St\nCity, IL 12345";
     process.env.SNAIL_MAIL_PROVIDER = "mock";
+    vi.resetModules();
+    const snailMail = await import("@/lib/snailMail");
+    const { ownershipModules } = await import("@/lib/ownershipModules");
     const sendMock = vi
       .spyOn(snailMail, "sendSnailMail")
       .mockResolvedValue({ id: "1", status: "saved" });

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -92,7 +92,8 @@ export function withCaseAuthorization<
 >(act: string, handler: (req: Request, ctx: C) => Promise<R> | R) {
   return async (req: Request, ctx: C): Promise<R | Response> => {
     const { id } = await ctx.params;
-    const { role, userId } = getSessionDetails(ctx, "user");
+    const { session } = ctx;
+    const { role, userId } = getSessionDetails({ session }, "anonymous");
     console.log("withCaseAuthorization", role, act, id, userId);
     if (!(await authorize(role, "cases", act, { caseId: id, userId }))) {
       return new Response(null, { status: 403 });


### PR DESCRIPTION
## Summary
- fix withCaseAuthorization to default anonymous role
- reload ownershipModules with env vars for test

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: expected 26 tests to pass, 26 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68557e521984832ba53b99a191d6dbb0