### PR TITLE
Fix e2e auth setup

### DIFF
--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -53,6 +53,7 @@ beforeAll(async () => {
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
+    SUPER_ADMIN_EMAIL: "super@example.com",
   });
   api = createApi(server);
 }, 120000);
@@ -63,6 +64,8 @@ afterAll(async () => {
 
 describe("admin actions", () => {
   it("promotes and demotes users", async () => {
+    await signIn("super@example.com");
+    await signOut();
     await signIn("super@example.com");
     const invite = await api("/api/users/invite", {
       method: "POST",
@@ -108,6 +111,8 @@ describe("admin actions", () => {
   }, 30000);
 
   it("edits casbin rules", async () => {
+    await signIn("super2@example.com");
+    await signOut();
     await signIn("super2@example.com");
     const rules = (await api("/api/casbin-rules").then((r) =>
       r.json(),

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -72,7 +72,7 @@ describe("anonymous access", () => {
     });
     await signOut();
 
-    const res = await api(`/api/cases/${id}`);
+    const res = await api(`/api/public/cases/${id}`);
     expect(res.status).toBe(200);
   }, 30000);
 

--- a/test/e2e/snailmail.test.ts
+++ b/test/e2e/snailmail.test.ts
@@ -25,6 +25,18 @@ async function signIn(email: string) {
   );
 }
 
+async function signOut() {
+  const csrf = await api("/api/auth/csrf").then((r) => r.json());
+  await api("/api/auth/signout", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      csrfToken: csrf.csrfToken,
+      callbackUrl: server.url,
+    }),
+  });
+}
+
 let server: TestServer;
 let stub: OpenAIStub;
 let tmpDir: string;
@@ -58,6 +70,7 @@ beforeAll(async () => {
     RETURN_ADDRESS: "Me\n1 A St\nTown, ST 12345",
     SNAIL_MAIL_PROVIDER: "file",
     NODE_ENV: "test",
+    SUPER_ADMIN_EMAIL: "admin@example.com",
     NEXTAUTH_SECRET: "secret",
   };
   fs.writeFileSync(
@@ -84,7 +97,9 @@ beforeAll(async () => {
   );
   server = await startServer(3008, env);
   api = createApi(server);
-  await signIn("user@example.com");
+  await signIn("admin@example.com");
+  await signOut();
+  await signIn("admin@example.com");
 }, 120000);
 
 afterAll(async () => {


### PR DESCRIPTION
## Summary
- patch e2e tests for admin session setup
- check public cases via `/api/public/cases`

## Testing
- `npm test`
- `npm run e2e` *(fails: snail mail, admin actions, reanalysis, and others)*

------
https://chatgpt.com/codex/tasks/task_e_6855cab4532c832bae0fee7344c92172