### PR TITLE
Fix NEXT_PUBLIC env handling

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -55,7 +55,25 @@ const envSchema = z
   .passthrough();
 
 export type Config = z.infer<typeof envSchema>;
+
 export function getConfig(): Config {
   return envSchema.parse(process.env);
 }
-export const config = getConfig();
+
+const baseConfig = getConfig();
+
+// Next.js only inlines variables prefixed with NEXT_PUBLIC_ when they are
+// referenced literally. These assignments ensure the client bundle receives the
+// current values. A page reload may be needed to see updates while the dev
+// server is running.
+export const config: Config = {
+  ...baseConfig,
+  NEXT_PUBLIC_GOOGLE_MAPS_API_KEY:
+    process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ??
+    baseConfig.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,
+  NEXT_PUBLIC_BROWSER_DEBUG: process.env.NEXT_PUBLIC_BROWSER_DEBUG
+    ? process.env.NEXT_PUBLIC_BROWSER_DEBUG === "true"
+    : baseConfig.NEXT_PUBLIC_BROWSER_DEBUG,
+  NEXT_PUBLIC_BASE_PATH:
+    process.env.NEXT_PUBLIC_BASE_PATH ?? baseConfig.NEXT_PUBLIC_BASE_PATH,
+};


### PR DESCRIPTION
## Summary
- parse env vars dynamically with `getConfig`
- expose `config` with literal NEXT_PUBLIC references so Next.js inlines them
- document why a page reload might be required

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68569d3cab80832b83e5302cf8dc185a