### PR TITLE
fix: inline NEXT_PUBLIC variables

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -58,4 +58,12 @@ export type Config = z.infer<typeof envSchema>;
 export function getConfig(): Config {
   return envSchema.parse(process.env);
 }
-export const config = getConfig();
+// For NEXT_PUBLIC_* variables we must reference them directly so Next.js can
+// inline them for client-side usage. When using the dev server a full page
+// reload may be required to pick up changes.
+export const config: Config = {
+  ...getConfig(),
+  NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,
+  NEXT_PUBLIC_BROWSER_DEBUG: process.env.NEXT_PUBLIC_BROWSER_DEBUG === "true",
+  NEXT_PUBLIC_BASE_PATH: process.env.NEXT_PUBLIC_BASE_PATH || "",
+};


### PR DESCRIPTION
## Summary
- inline NEXT_PUBLIC variables in `src/lib/config.ts` so Next.js can embed them on the client

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68569d3cab80832b83e5302cf8dc185a