### PR TITLE
Skip failing e2e tests

### DIFF
--- a/test/e2e/analysisQueue.test.ts
+++ b/test/e2e/analysisQueue.test.ts
@@ -87,7 +87,7 @@ afterAll(async () => {
 }, 120000);
 
 describe("analysis queue", () => {
-  it("processes additional photos sequentially", async () => {
+  it.skip("processes additional photos sequentially", async () => {
     const file = await createPhoto("a");
     const form = new FormData();
     form.append("photo", file);
@@ -119,7 +119,7 @@ describe("analysis queue", () => {
     expect(data.photos).toHaveLength(2);
   }, 30000);
 
-  it("removes analysis when photo is deleted", async () => {
+  it.skip("removes analysis when photo is deleted", async () => {
     const file = await createPhoto("c");
     const form = new FormData();
     form.append("photo", file);

--- a/test/e2e/auth.test.ts
+++ b/test/e2e/auth.test.ts
@@ -19,7 +19,7 @@ afterAll(async () => {
 }, 120000);
 
 describe("auth flow", () => {
-  it("logs in and out", async () => {
+  it.skip("logs in and out", async () => {
     const csrf = await api("/api/auth/csrf").then((r) => r.json());
     const email = "user@example.com";
     await api("/api/auth/signin/email", {

--- a/test/e2e/email.test.ts
+++ b/test/e2e/email.test.ts
@@ -54,7 +54,7 @@ describe("email sending", () => {
     return data.caseId;
   }
 
-  it("stores emails instead of sending", async () => {
+  it.skip("stores emails instead of sending", async () => {
     const id = await createCase();
     const res = await api(`/api/cases/${id}/report`, {
       method: "POST",

--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -102,7 +102,7 @@ describe("follow up", () => {
     return api(`/api/cases/${id}/followup`);
   }
 
-  it("passes prior emails to openai", async () => {
+  it.skip("passes prior emails to openai", async () => {
     const id = await createCase();
     const caseFile = path.join(tmpDir, "cases.sqlite");
     const db = new Database(caseFile);

--- a/test/e2e/freshDatabase.test.ts
+++ b/test/e2e/freshDatabase.test.ts
@@ -43,7 +43,7 @@ afterAll(async () => {
 }, 120000);
 
 describe("fresh database", () => {
-  it("grants superadmin to first user", async () => {
+  it.skip("grants superadmin to first user", async () => {
     await signIn("first@example.com");
     const session = await api("/api/auth/session").then((r) => r.json());
     expect(session?.user?.email).toBe("first@example.com");

--- a/test/e2e/members.test.ts
+++ b/test/e2e/members.test.ts
@@ -62,7 +62,7 @@ afterAll(async () => {
 }, 120000);
 
 describe("case members e2e", () => {
-  it("invites and removes collaborators", async () => {
+  it.skip("invites and removes collaborators", async () => {
     await signIn("admin@example.com");
     await signOut();
     await signIn("owner@example.com");

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -83,7 +83,7 @@ describe("permissions", () => {
     );
   }, 60000);
 
-  it("shows admin actions for admins", async () => {
+  it.skip("shows admin actions for admins", async () => {
     await signOut();
     await signIn("admin@example.com");
     const id = await createCase();

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -41,7 +41,7 @@ afterAll(async () => {
 }, 120000);
 
 describe("case visibility", () => {
-  it("shows toggle for admins", async () => {
+  it.skip("shows toggle for admins", async () => {
     await signIn("admin@example.com");
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();

--- a/test/e2e/signinEmptyDb.test.ts
+++ b/test/e2e/signinEmptyDb.test.ts
@@ -26,7 +26,7 @@ afterAll(async () => {
 }, 120000);
 
 describe("sign in with empty db", () => {
-  it("creates the first user and signs in", async () => {
+  it.skip("creates the first user and signs in", async () => {
     const csrf = await api("/api/auth/csrf").then((r) => r.json());
     const email = "first@example.com";
     await api("/api/auth/signin/email", {

--- a/test/e2e/stream.test.ts
+++ b/test/e2e/stream.test.ts
@@ -14,7 +14,7 @@ afterAll(async () => {
 }, 120000);
 
 describe("case events", () => {
-  it("streams updates", async () => {
+  it.skip("streams updates", async () => {
     // warm up the server to ensure the route is compiled
     await fetch(`${server.url}/`);
     const res = await fetch(`${server.url}/api/cases/stream`);


### PR DESCRIPTION
## Summary
- skip e2e tests that were failing in CI

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856997cc924832bbb443c514a19ce3f