### PR TITLE
Add smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,12 @@ thresholds with:
 npm run test:coverage
 ```
 
+Run just the essential end-to-end smoke tests with:
+
+```bash
+npm run e2e:smoke
+```
+
 ## Docker
 
 To run the app in containers, install Docker and Docker Compose then build the stack:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "e2e": "vitest run -c vitest.e2e.config.ts",
+    "e2e:smoke": "vitest run -c vitest.e2e.config.ts --testNamePattern \"@smoke\"",
     "reanalyze": "ts-node --transpile-only scripts/updateMissingAnalysis.ts",
     "poll:snailmail": "ts-node --transpile-only scripts/pollSnailMail.ts",
     "scan:inbox": "ts-node --transpile-only scripts/scanInbox.ts",

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -13,7 +13,7 @@ afterAll(async () => {
   await server.close();
 }, 120000);
 
-describe("end-to-end", () => {
+describe("end-to-end @smoke", () => {
   it("serves the homepage", async () => {
     const res = await fetch(`${server.url}/`);
     expect(res.status).toBe(200);

--- a/test/e2e/freshDatabase.test.ts
+++ b/test/e2e/freshDatabase.test.ts
@@ -42,7 +42,7 @@ afterAll(async () => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 }, 120000);
 
-describe("fresh database", () => {
+describe("fresh database @smoke", () => {
   it("grants superadmin to first user", async () => {
     await signIn("first@example.com");
     const session = await api("/api/auth/session").then((r) => r.json());

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -40,7 +40,7 @@ afterAll(async () => {
   await server.close();
 }, 120000);
 
-describe("case visibility", () => {
+describe("case visibility @smoke", () => {
   it("shows toggle for admins", async () => {
     await signIn("admin@example.com");
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });

--- a/test/e2e/signinEmptyDb.test.ts
+++ b/test/e2e/signinEmptyDb.test.ts
@@ -25,7 +25,7 @@ afterAll(async () => {
   fs.rmSync(dataDir, { recursive: true, force: true });
 }, 120000);
 
-describe("sign in with empty db", () => {
+describe("sign in with empty db @smoke", () => {
   it("creates the first user and signs in", async () => {
     const csrf = await api("/api/auth/csrf").then((r) => r.json());
     const email = "first@example.com";


### PR DESCRIPTION
## Summary
- mark essential e2e tests with @smoke tag
- run them quickly via new `e2e:smoke` script
- document smoke tests in README
- update script to use `--testNamePattern`

## Testing
- `npm run format`
- `npm run lint`
- `RETURN_ADDRESS='1 Test Ln' npm test`
- `npm run e2e:smoke` *(fails: shows toggle for admins)*
- `npm run e2e` *(fails: same assertion failure)*

------
https://chatgpt.com/codex/tasks/task_e_68558075a2d8832b9320f69678ab5e2f