### PR TITLE
Improve DOM querying in e2e tests

### DIFF
--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -1,3 +1,5 @@
+import { getByRole } from "@testing-library/dom";
+import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { type TestServer, startServer } from "./startServer";
 
@@ -17,7 +19,11 @@ describe("end-to-end", () => {
   it("serves the homepage", async () => {
     const res = await fetch(`${server.url}/`);
     expect(res.status).toBe(200);
-    const text = await res.text();
-    expect(text).toContain("Photo To Citation");
+    const html = await res.text();
+    const dom = new JSDOM(html);
+    const heading = getByRole(dom.window.document, "heading", {
+      name: /photo to citation/i,
+    });
+    expect(heading).toBeTruthy();
   }, 30000);
 });

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { getByRole } from "@testing-library/dom";
+import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
@@ -194,8 +196,12 @@ describe("e2e flows (unauthenticated)", () => {
     const id2 = await createCase();
     const res = await api(`/cases?ids=${id1},${id2}`);
     expect(res.status).toBe(200);
-    const text = await res.text();
-    expect(text).toContain("Case Summary");
+    const html = await res.text();
+    const dom = new JSDOM(html);
+    const heading = getByRole(dom.window.document, "heading", {
+      name: /case summary/i,
+    });
+    expect(heading).toBeTruthy();
   }, 60000);
 
   it.skip("deletes a case", async () => {

--- a/test/e2e/point.test.ts
+++ b/test/e2e/point.test.ts
@@ -1,3 +1,5 @@
+import { getByRole } from "@testing-library/dom";
+import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { type TestServer, startServer } from "./startServer";
 
@@ -17,7 +19,11 @@ describe("point and shoot", () => {
   it("serves the point page", async () => {
     const res = await fetch(`${server.url}/point`);
     expect(res.status).toBe(200);
-    const text = await res.text();
-    expect(text).toContain("Take Picture");
+    const html = await res.text();
+    const dom = new JSDOM(html);
+    const button = getByRole(dom.window.document, "button", {
+      name: /take picture/i,
+    });
+    expect(button).toBeTruthy();
   }, 30000);
 });

--- a/test/e2e/thread.test.ts
+++ b/test/e2e/thread.test.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { getByRole } from "@testing-library/dom";
+import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { type TestServer, startServer } from "./startServer";
 
@@ -40,7 +42,11 @@ describe("thread page", () => {
     const id = await createCase();
     const res = await fetch(`${server.url}/cases/${id}/thread/start`);
     expect(res.status).toBe(200);
-    const text = await res.text();
-    expect(text).toContain("Thread");
+    const html = await res.text();
+    const dom = new JSDOM(html);
+    const heading = getByRole(dom.window.document, "heading", {
+      name: /thread/i,
+    });
+    expect(heading).toBeTruthy();
   }, 30000);
 });


### PR DESCRIPTION
## Summary
- use `jsdom` and `@testing-library/dom` selectors in e2e tests
- check for headings and buttons via DOM queries rather than string search

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856a9e84194832bab617d3facc31079