### PR TITLE
Fix TypeScript errors

### DIFF
--- a/src/lib/fileSnailMailProvider.ts
+++ b/src/lib/fileSnailMailProvider.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { config } from "./config";
+import { config as appConfig } from "./config";
 import type {
   SnailMailOptions,
   SnailMailProvider,
@@ -15,11 +15,11 @@ const provider: SnailMailProvider = {
   docs: "Save snail mail PDFs and a manifest locally.",
   async send(
     opts: SnailMailOptions,
-    config?: Record<string, unknown>,
+    cfg?: Record<string, unknown>,
   ): Promise<SnailMailStatus> {
     const dir =
-      (config?.dir as string) ||
-      config.SNAIL_MAIL_OUT_DIR ||
+      (cfg?.dir as string | undefined) ??
+      (appConfig.SNAIL_MAIL_OUT_DIR as string | undefined) ??
       path.join(process.cwd(), "data", "snailmail_out");
     fs.mkdirSync(dir, { recursive: true });
     const id = crypto.randomUUID();

--- a/src/lib/geocode.ts
+++ b/src/lib/geocode.ts
@@ -6,10 +6,10 @@ export interface Coordinates {
 }
 
 async function fetchGeocode(params: Record<string, string>): Promise<unknown> {
-  const query = new URLSearchParams({
-    key: config.GOOGLE_MAPS_API_KEY,
-    ...params,
-  });
+  const query = new URLSearchParams(params);
+  if (config.GOOGLE_MAPS_API_KEY) {
+    query.set("key", config.GOOGLE_MAPS_API_KEY);
+  }
   const res = await fetch(
     `https://maps.googleapis.com/maps/api/geocode/json?${query}`,
   );

--- a/src/lib/violationCodes.ts
+++ b/src/lib/violationCodes.ts
@@ -9,7 +9,7 @@ export interface ViolationCodeMap {
 }
 
 const dataFile = config.VIOLATION_CODE_FILE
-  ? path.resolve(config.VIOLATION_CODE_FILE)
+  ? path.resolve(config.VIOLATION_CODE_FILE as string)
   : path.join(process.cwd(), "data", "violationCodes.json");
 
 function loadCodes(): ViolationCodeMap {


### PR DESCRIPTION
## Summary
- fix snail mail provider config parameter type usage
- add optional API key check for geocoding
- ensure violation code file path type is string

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856affe58c0832bb2e32eb519909bfd