### PR TITLE
feat: add migration squashing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ Generate new migration files from the Drizzle schema with:
 npm run generate:migrations
 ```
 
+To consolidate old migrations into a single baseline, keep only the most recent
+files using:
+
+```bash
+npm run squash:migrations -- --keep 5
+```
+
+Omit the `--keep` option to retain the latest 10 migrations. Pass `--help` for
+usage details.
+
 Migrations are stored as SQL files under the `migrations` folder and applied at runtime. The default SQLite database is `data/cases.sqlite`. Per-photo analysis results now live in the `case_photo_analysis` table instead of the JSON `analysis.images` field.
 
 ## Administration

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "generate:schemas": "ts-to-zod --skipValidation --all && npm run validate:generated",
     "validate:generated": "tsc --noEmit -p tsconfig.generated.json",
     "generate:migrations": "drizzle-kit generate:sqlite",
+    "squash:migrations": "ts-node --transpile-only scripts/squashMigrations.ts",
     "website": "ts-node --transpile-only scripts/generateWebsiteImages.ts && eleventy",
     "typecheck": "tsc --noEmit"
   },

--- a/scripts/squashMigrations.ts
+++ b/scripts/squashMigrations.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const DEFAULT_KEEP = 10;
+const migrationsDir = path.join(process.cwd(), "migrations");
+
+function usage(): void {
+  console.log(`Usage: npm run squash:migrations -- [options]
+
+Squash old migration files into a single baseline migration.
+
+Options:
+  --keep <n>  Number of latest migrations to keep (default ${DEFAULT_KEEP})
+  --help      Show this help message
+`);
+}
+
+function parseArgs(): number {
+  const args = process.argv.slice(2);
+  let keep = DEFAULT_KEEP;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--help") {
+      usage();
+      process.exit(0);
+    } else if (arg === "--keep") {
+      const value = args[i + 1];
+      if (!value) {
+        console.error("--keep requires a number");
+        process.exit(1);
+      }
+      keep = Number.parseInt(value, 10);
+      if (Number.isNaN(keep) || keep < 0) {
+        console.error("Invalid keep value");
+        process.exit(1);
+      }
+      i++;
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      usage();
+      process.exit(1);
+    }
+  }
+  return keep;
+}
+
+function main(): void {
+  const keep = parseArgs();
+  fs.mkdirSync(migrationsDir, { recursive: true });
+  const files = fs
+    .readdirSync(migrationsDir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+
+  if (files.length <= keep) {
+    console.log("No migrations to squash");
+    return;
+  }
+
+  const toSquash = files.slice(0, files.length - keep);
+  const baselineParts = toSquash.map((f) => {
+    const content = fs.readFileSync(path.join(migrationsDir, f), "utf8");
+    return `-- ${f}\n${content.trim()}\n`;
+  });
+  const baseline = baselineParts.join("\n");
+  const baselinePath = path.join(migrationsDir, "0000_baseline.sql");
+  fs.writeFileSync(baselinePath, `${baseline}\n`);
+
+  for (const f of toSquash) {
+    fs.unlinkSync(path.join(migrationsDir, f));
+  }
+
+  console.log(
+    `Squashed ${toSquash.length} migrations into ${path.basename(baselinePath)}`,
+  );
+}
+
+main();

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -65,11 +65,15 @@ describe("anonymous access", () => {
   it.skip("allows access to public case", async () => {
     await signIn("user@example.com");
     const id = await createCase();
-    expect((await api(`/api/cases/${id}/public`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ public: true }),
-    })).status).toBe(200);
+    expect(
+      (
+        await api(`/api/cases/${id}/public`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ public: true }),
+        })
+      ).status,
+    ).toBe(200);
     expect(makePublicResponse.status).toBe(200);
     await signOut();
 

--- a/test/squashMigrations.test.ts
+++ b/test/squashMigrations.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const nodeBin = process.execPath;
+const scriptPath = path.resolve("scripts/squashMigrations.ts");
+
+const tsNodeReg = require.resolve("ts-node/register/transpile-only");
+const tsconfig = path.resolve("tsconfig.json");
+
+function run(args: string[], cwd: string) {
+  return spawnSync(nodeBin, ["-r", tsNodeReg, scriptPath, ...args], {
+    cwd,
+    env: { ...process.env, TS_NODE_PROJECT: tsconfig },
+    encoding: "utf8",
+  });
+}
+
+describe("squashMigrations script", () => {
+  it("squashes older migrations into a baseline", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "migrate-"));
+    const migDir = path.join(dir, "migrations");
+    fs.mkdirSync(migDir);
+    for (let i = 0; i < 5; i++) {
+      const fname = `${String(i).padStart(4, "0")}_m${i}.sql`;
+      fs.writeFileSync(path.join(migDir, fname), `SELECT ${i};\n`);
+    }
+
+    const result = run(["--keep", "2"], dir);
+    expect(result.status).toBe(0);
+
+    const files = fs.readdirSync(migDir).sort();
+    expect(files).toEqual(["0000_baseline.sql", "0003_m3.sql", "0004_m4.sql"]);
+    const baseline = fs.readFileSync(
+      path.join(migDir, "0000_baseline.sql"),
+      "utf8",
+    );
+    expect(baseline).toContain("-- 0000_m0.sql");
+    expect(baseline).toContain("-- 0002_m2.sql");
+  });
+
+  it("shows help with --help", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "migrate-"));
+    const { status, stdout } = run(["--help"], dir);
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/Usage:/);
+  });
+});


### PR DESCRIPTION
## Summary
- add `squash:migrations` script
- document how to squash older migrations
- add unit test for migration squashing

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856b7a88540832bbc3a9ed2c80f4ad2