### PR TITLE
Restrict VIN source updates

### DIFF
--- a/src/app/api/vin-sources/[id]/route.ts
+++ b/src/app/api/vin-sources/[id]/route.ts
@@ -1,20 +1,25 @@
-import { withAuthorization } from "@/lib/authz";
+import { getSessionDetails, withAuthorization } from "@/lib/authz";
 import { getVinSourceStatuses, setVinSourceEnabled } from "@/lib/vinSources";
 import { NextResponse } from "next/server";
 
 export const PUT = withAuthorization(
-  "admin",
-  "update",
+  "cases",
+  "read",
   async (
     req: Request,
     {
       params,
+      session,
     }: {
       params: Promise<{ id: string }>;
       session?: { user?: { role?: string } };
     },
   ) => {
     const { id } = await params;
+    const { role } = getSessionDetails({ session }, "anonymous");
+    if (role !== "admin" && role !== "superadmin") {
+      return new Response(null, { status: 403 });
+    }
     const { enabled } = (await req.json()) as { enabled: boolean };
     const result = setVinSourceEnabled(id, enabled);
     if (!result) {

--- a/src/app/api/vin-sources/route.ts
+++ b/src/app/api/vin-sources/route.ts
@@ -2,7 +2,7 @@ import { withAuthorization } from "@/lib/authz";
 import { getVinSourceStatuses } from "@/lib/vinSources";
 import { NextResponse } from "next/server";
 
-export const GET = withAuthorization("admin", "read", async () => {
+export const GET = withAuthorization("cases", "read", async () => {
   const sources = getVinSourceStatuses();
   return NextResponse.json(sources);
 });

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -229,20 +229,29 @@ describe("e2e flows (unauthenticated)", () => {
     expect(nf2.status).toBe(404);
   }, 60000);
 
-  it.skip("toggles vin source modules", async () => {
+  it("toggles vin source modules", async () => {
     const listRes = await api("/api/vin-sources");
     expect(listRes.status).toBe(200);
-    const list = (await listRes.json()) as Array<{
-      id: string;
-      enabled: boolean;
-    }>;
-    expect(Array.isArray(list)).toBe(true);
-    const id = list[0].id;
-    const update = await api(`/api/vin-sources/${id}`, {
+    const update = await api("/api/vin-sources/edmunds", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ enabled: false }),
     });
     expect(update.status).toBe(403);
+  }, 60000);
+
+  it("allows admin to toggle vin source modules", async () => {
+    await signOut();
+    await signIn("admin@example.com");
+    const listRes = await api("/api/vin-sources");
+    expect(listRes.status).toBe(200);
+    const update = await api("/api/vin-sources/edmunds", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled: true }),
+    });
+    expect(update.status).toBe(200);
+    await signOut();
+    await signIn("user@example.com");
   }, 60000);
 });

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -232,7 +232,13 @@ describe("e2e flows (unauthenticated)", () => {
   it("toggles vin source modules", async () => {
     const listRes = await api("/api/vin-sources");
     expect(listRes.status).toBe(200);
-    const update = await api("/api/vin-sources/edmunds", {
+    const list = (await listRes.json()) as Array<{
+      id: string;
+      enabled: boolean;
+    }>;
+    expect(Array.isArray(list)).toBe(true);
+    const id = list[0].id;
+    const update = await api(`/api/vin-sources/${id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ enabled: false }),
@@ -245,12 +251,24 @@ describe("e2e flows (unauthenticated)", () => {
     await signIn("admin@example.com");
     const listRes = await api("/api/vin-sources");
     expect(listRes.status).toBe(200);
-    const update = await api("/api/vin-sources/edmunds", {
+    const list = (await listRes.json()) as Array<{
+      id: string;
+      enabled: boolean;
+    }>;
+    const id = list[0].id;
+    const before = list[0].enabled;
+    const update = await api(`/api/vin-sources/${id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ enabled: true }),
+      body: JSON.stringify({ enabled: !before }),
     });
     expect(update.status).toBe(200);
+    const afterList = (await update.json()) as Array<{
+      id: string;
+      enabled: boolean;
+    }>;
+    const updated = afterList.find((s) => s.id === id);
+    expect(updated?.enabled).toBe(!before);
     await signOut();
     await signIn("user@example.com");
   }, 60000);

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -65,11 +65,15 @@ describe("anonymous access", () => {
   it.skip("allows access to public case", async () => {
     await signIn("user@example.com");
     const id = await createCase();
-    expect((await api(`/api/cases/${id}/public`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ public: true }),
-    })).status).toBe(200);
+    expect(
+      (
+        await api(`/api/cases/${id}/public`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ public: true }),
+        })
+      ).status,
+    ).toBe(200);
     expect(makePublicResponse.status).toBe(200);
     await signOut();
 

--- a/test/vinSources.test.ts
+++ b/test/vinSources.test.ts
@@ -42,13 +42,13 @@ describe("vin source health", () => {
 });
 
 describe("vin source API authorization", () => {
-  it("rejects listing without admin role", async () => {
+  it("allows listing with user role", async () => {
     const mod = await import("@/app/api/vin-sources/route");
     const res = await mod.GET(new Request("http://test"), {
       params: Promise.resolve({}) as Promise<Record<string, string>>,
       session: { user: { role: "user" } },
     });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
   });
 
   it("rejects update without admin role", async () => {
@@ -63,5 +63,19 @@ describe("vin source API authorization", () => {
       session: { user: { role: "user" } },
     });
     expect(res.status).toBe(403);
+  });
+
+  it("allows update with admin role", async () => {
+    const mod = await import("@/app/api/vin-sources/[id]/route");
+    const req = new Request("http://test", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled: false }),
+    });
+    const res = await mod.PUT(req, {
+      params: Promise.resolve({ id: "edmunds" }) as Promise<{ id: string }>,
+      session: { user: { role: "admin" } },
+    });
+    expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary
- let regular users list VIN sources
- block PUT requests unless the session user is admin or superadmin
- update tests for VIN source permissions
- verify admin can toggle VIN source modules

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6856bde44178832b9964e8ce98c66e62