### PR TITLE
Add ESLint and NODE_ENV defaults in e2e server

### DIFF
--- a/test/e2e/startServer.ts
+++ b/test/e2e/startServer.ts
@@ -27,6 +27,8 @@ export async function startServer(
     env: {
       ...process.env,
       NEXT_TELEMETRY_DISABLED: "1",
+      NEXT_DISABLE_ESLINT: "1",
+      NODE_ENV: env.NODE_ENV ?? "test",
       TEST_APIS: "1",
       NEXTAUTH_URL: `http://localhost:${port}`,
       ...env,


### PR DESCRIPTION
## Summary
- disable Next.js ESLint and set default `NODE_ENV` for test server

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856d7b31a84832b96c007b73536ff0f