### PR TITLE
Update spawn args for e2e server

### DIFF
--- a/test/e2e/startServer.ts
+++ b/test/e2e/startServer.ts
@@ -23,7 +23,7 @@ export async function startServer(
   env: Partial<NodeJS.ProcessEnv> = {},
 ): Promise<TestServer> {
   const nextBin = path.join("node_modules", ".bin", "next");
-  const proc = spawn(nextBin, ["dev", "-p", String(port)], {
+  const proc = spawn(nextBin, ["dev", "-p", String(port), "--turbo"], {
     env: {
       ...process.env,
       NEXT_TELEMETRY_DISABLED: "1",


### PR DESCRIPTION
## Summary
- update startServer to pass `--turbo` when starting Next.js dev server

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d7e05198832baac6c757834c5d7f