### PR TITLE
Add global E2E server lifecycle

### DIFF
--- a/test/e2e/serverLifecycle.ts
+++ b/test/e2e/serverLifecycle.ts
@@ -12,3 +12,8 @@ export async function globalTeardown() {
     await server.close();
   }
 }
+
+export async function setup() {
+  await globalSetup();
+  return globalTeardown;
+}

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -11,7 +11,6 @@ export default defineConfig({
     environment: "node",
     include: ["test/e2e/*.test.ts"],
     globalSetup: "./test/e2e/serverLifecycle.ts",
-    globalTeardown: "./test/e2e/serverLifecycle.ts",
     testTimeout: 30000,
     hookTimeout: 30000,
     maxConcurrency: 1,


### PR DESCRIPTION
## Summary
- add a global setup/teardown helper for E2E tests
- register global setup/teardown in Vitest config

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856d7e3fdf0832b85b25ed5fc51c29f