### PR TITLE
Enable public visibility e2e test

### DIFF
--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -43,7 +43,7 @@ afterAll(async () => {
 }, 120000);
 
 describe("case visibility @smoke", () => {
-  it.skip("shows toggle for admins", async () => {
+  it("shows toggle for admins", async () => {
     await signIn("admin@example.com");
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();


### PR DESCRIPTION
## Summary
- enable the public visibility test now that auth works

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_e_6856dc036eb0832bb0f4625e247d06a4