### PR TITLE
test: enable passing e2e cases

### DIFF
--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -102,7 +102,7 @@ describe("follow up", () => {
     return api(`/api/cases/${id}/followup`);
   }
 
-  it.skip("passes prior emails to openai", async () => {
+  it("passes prior emails to openai", async () => {
     const id = await createCase();
     const caseFile = path.join(tmpDir, "cases.sqlite");
     const db = new Database(caseFile);

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -43,7 +43,7 @@ afterAll(async () => {
 }, 120000);
 
 describe("case visibility @smoke", () => {
-  it.skip("shows toggle for admins", async () => {
+  it("shows toggle for admins", async () => {
     await signIn("admin@example.com");
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();

--- a/test/e2e/signinEmptyDb.test.ts
+++ b/test/e2e/signinEmptyDb.test.ts
@@ -26,7 +26,7 @@ afterAll(async () => {
 }, 120000);
 
 describe("sign in with empty db @smoke", () => {
-  it.skip("creates the first user and signs in", async () => {
+  it("creates the first user and signs in", async () => {
     const csrf = await api("/api/auth/csrf").then((r) => r.json());
     const email = "first@example.com";
     await api("/api/auth/signin/email", {


### PR DESCRIPTION
## Summary
- enable three e2e tests that now pass

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856dc036eb0832bb0f4625e247d06a4