### PR TITLE
Fix sign-in e2e test

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -14,10 +14,15 @@ export function authAdapter() {
   return {
     ...base,
     async createUser(data: AdapterUser & { id?: string }) {
-      console.log("authAdapter.createUser", data.email);
       if (!data.id) data.id = crypto.randomUUID();
       if (!base.createUser) throw new Error("createUser not implemented");
-      return base.createUser(data);
+      const user = await base.createUser(data);
+      await seedSuperAdmin({ id: user.id, email: user.email ?? null });
+      if (base.getUser) {
+        const updated = await base.getUser(user.id);
+        if (updated) return updated;
+      }
+      return user;
     },
   };
 }
@@ -44,7 +49,6 @@ export async function seedSuperAdmin(newUser?: {
       newUser ?? orm.select().from(users).orderBy(sql`rowid`).limit(1).get();
   }
   if (target) {
-    console.log("seeding super admin", newUser?.email);
     orm
       .update(users)
       .set({ role: "superadmin" })

--- a/test/e2e/signinEmptyDb.test.ts
+++ b/test/e2e/signinEmptyDb.test.ts
@@ -26,7 +26,7 @@ afterAll(async () => {
 }, 120000);
 
 describe("sign in with empty db @smoke", () => {
-  it.skip("creates the first user and signs in", async () => {
+  it("creates the first user and signs in", async () => {
     const csrf = await api("/api/auth/csrf").then((r) => r.json());
     const email = "first@example.com";
     await api("/api/auth/signin/email", {


### PR DESCRIPTION
## Summary
- promote the first created user to superadmin in the auth adapter
- remove console debugging
- enable the `signinEmptyDb` e2e test

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npx vitest -c vitest.e2e.config.ts run test/e2e/signinEmptyDb.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6856d77b2198832ba26dd5392ef89ca9