### PR TITLE
test: stabilize auth in e2e

### DIFF
--- a/test/e2e/email.test.ts
+++ b/test/e2e/email.test.ts
@@ -24,6 +24,11 @@ async function signIn(email: string) {
   await api(
     `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
   );
+  for (let i = 0; i < 20; i++) {
+    const session = await api("/api/auth/session").then((r) => r.json());
+    if (session?.user?.email === email) break;
+    await new Promise((r) => setTimeout(r, 250));
+  }
 }
 
 beforeAll(async () => {
@@ -36,6 +41,7 @@ beforeAll(async () => {
     EMAIL_FILE: path.join(tmpDir, "emails.json"),
   });
   api = createApi(server);
+  await api("/");
   await signIn("user@example.com");
 }, 120000);
 
@@ -54,7 +60,7 @@ describe("email sending", () => {
     return data.caseId;
   }
 
-  it.skip("stores emails instead of sending", async () => {
+  it("stores emails instead of sending", async () => {
     const id = await createCase();
     const res = await api(`/api/cases/${id}/report`, {
       method: "POST",

--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -24,6 +24,11 @@ async function signIn(email: string) {
   await api(
     `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
   );
+  for (let i = 0; i < 20; i++) {
+    const session = await api("/api/auth/session").then((r) => r.json());
+    if (session?.user?.email === email) break;
+    await new Promise((r) => setTimeout(r, 250));
+  }
 }
 
 let server: TestServer;
@@ -60,6 +65,7 @@ beforeAll(async () => {
   );
   server = await startServer(3005, env);
   api = createApi(server);
+  await api("/");
   await signIn("user@example.com");
 }, 120000);
 
@@ -102,7 +108,7 @@ describe("follow up", () => {
     return api(`/api/cases/${id}/followup`);
   }
 
-  it.skip("passes prior emails to openai", async () => {
+  it("passes prior emails to openai", async () => {
     const id = await createCase();
     const caseFile = path.join(tmpDir, "cases.sqlite");
     const db = new Database(caseFile);

--- a/test/e2e/freshDatabase.test.ts
+++ b/test/e2e/freshDatabase.test.ts
@@ -24,6 +24,11 @@ async function signIn(email: string) {
   await api(
     `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
   );
+  for (let i = 0; i < 20; i++) {
+    const session = await api("/api/auth/session").then((r) => r.json());
+    if (session?.user?.email === email) break;
+    await new Promise((r) => setTimeout(r, 250));
+  }
 }
 
 beforeAll(async () => {
@@ -35,6 +40,7 @@ beforeAll(async () => {
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);
+  await api("/");
 }, 120000);
 
 afterAll(async () => {
@@ -43,7 +49,7 @@ afterAll(async () => {
 }, 120000);
 
 describe("fresh database @smoke", () => {
-  it.skip("grants superadmin to first user", async () => {
+  it("grants superadmin to first user", async () => {
     await signIn("first@example.com");
     const session = await api("/api/auth/session").then((r) => r.json());
     expect(session?.user?.email).toBe("first@example.com");

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -27,6 +27,11 @@ async function signIn(email: string) {
   await api(
     `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
   );
+  for (let i = 0; i < 20; i++) {
+    const session = await api("/api/auth/session").then((r) => r.json());
+    if (session?.user?.email === email) break;
+    await new Promise((r) => setTimeout(r, 250));
+  }
 }
 
 async function signOut() {
@@ -61,6 +66,7 @@ beforeAll(async () => {
     OPENAI_BASE_URL: stub.url,
   });
   api = createApi(server);
+  await api("/");
   await signIn("admin@example.com");
   await signOut();
 }, 120000);
@@ -89,7 +95,7 @@ describe("permissions", () => {
     expect(sendButton.hasAttribute("disabled")).toBe(true);
   }, 60000);
 
-  it.skip("shows admin actions for admins", async () => {
+  it("shows admin actions for admins", async () => {
     await signOut();
     await signIn("admin@example.com");
     const id = await createCase();

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -43,7 +43,7 @@ afterAll(async () => {
 }, 120000);
 
 describe("case visibility @smoke", () => {
-  it.skip("shows toggle for admins", async () => {
+  it("shows toggle for admins", async () => {
     await signIn("admin@example.com");
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();


### PR DESCRIPTION
## Summary
- wait for auth session to be established in sign-in helper for followup and empty DB tests

## Testing
- `npm test`
- `npx vitest run -c vitest.e2e.config.ts test/e2e/followup.test.ts test/e2e/signinEmptyDb.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6856dc036eb0832bb0f4625e247d06a4