### PR TITLE
Fix cookie handling in e2e API

### DIFF
--- a/test/apiHelper.test.ts
+++ b/test/apiHelper.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApi } from "./e2e/api";
+
+describe("createApi cookie jar", () => {
+  const responses: Response[] = [
+    new Response(null, { headers: { "set-cookie": "a=1" } }),
+    new Response(null, { headers: { "set-cookie": "b=2" } }),
+    new Response(null, { headers: { "set-cookie": "a=3" } }),
+    new Response(null, {}),
+  ];
+  const calls: RequestInit[] = [];
+
+  beforeEach(() => {
+    calls.length = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        calls.push(init || {});
+        return responses.shift() as Response;
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("preserves cookies across requests", async () => {
+    const api = createApi({ url: "http://test" });
+    await api("/first");
+    await api("/second");
+    await api("/third");
+    await api("/fourth");
+
+    const headers0 = calls[0].headers as Record<string, string>;
+    const headers1 = calls[1].headers as Record<string, string>;
+    const headers2 = calls[2].headers as Record<string, string>;
+    const headers3 = calls[3].headers as Record<string, string>;
+    expect(headers0.cookie).toBe("");
+    expect(headers1.cookie).toBe("a=1");
+    expect(headers2.cookie).toBe("a=1; b=2");
+    expect(headers3.cookie).toBe("a=3; b=2");
+  });
+});

--- a/test/e2e/api.ts
+++ b/test/e2e/api.ts
@@ -7,20 +7,30 @@ export function createApi(server: { url: string }): (
   path: string,
   opts?: RequestInit,
 ) => Promise<Response> {
-  let cookie = "";
+  const jar = new Map<string, string>();
+  const buildCookie = (): string =>
+    Array.from(jar.entries())
+      .map(([k, v]) => `${k}=${v}`)
+      .join("; ");
+
   return async (path: string, opts: RequestInit = {}): Promise<Response> => {
     const res = await fetch(`${server.url}${path}`, {
       ...opts,
-      headers: { ...(opts.headers || {}), cookie },
+      headers: { ...(opts.headers || {}), cookie: buildCookie() },
       redirect: "manual",
     });
+
     const set =
       res.headers.getSetCookie?.() ??
       (res.headers.has("set-cookie")
         ? [res.headers.get("set-cookie") as string]
         : []);
-    if (set.length > 0) {
-      cookie = set.map((c) => c.split(";")[0]).join("; ");
+    for (const c of set) {
+      const [pair] = c.split(";");
+      const eq = pair.indexOf("=");
+      if (eq > -1) {
+        jar.set(pair.slice(0, eq), pair.slice(eq + 1));
+      }
     }
     return res;
   };


### PR DESCRIPTION
## Summary
- keep previously set cookies when new cookies are received in e2e API helper

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856ed13b490832b9fe4682ab2c6ca98