### PR TITLE
Fix case membership deletion

### DIFF
--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -136,7 +136,13 @@ function saveCase(c: Case) {
     (rest.analysis as Partial<ViolationReport>).images = undefined;
   }
   const stmt = db.prepare(
-    "INSERT OR REPLACE INTO cases (id, data, public) VALUES (?, ?, ?)",
+    [
+      "INSERT INTO cases (id, data, public)",
+      "VALUES (?, ?, ?)",
+      "ON CONFLICT(id) DO UPDATE SET",
+      "  data = excluded.data,",
+      "  public = excluded.public",
+    ].join(" "),
   );
   stmt.run(c.id, JSON.stringify(rest), c.public ? 1 : 0);
   orm.delete(casePhotos).where(eq(casePhotos.caseId, c.id)).run();

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -62,7 +62,7 @@ afterAll(async () => {
 }, 120000);
 
 describe("anonymous access", () => {
-  it.skip("allows access to public case", async () => {
+  it("allows access to public case", async () => {
     await signIn("user@example.com");
     const id = await createCase();
     expect(


### PR DESCRIPTION
## Summary
- avoid deleting case member rows when saving a case

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856dd608db8832b9e9a9573c25e2e0f