### PR TITLE
Fix email e2e test isolation

### DIFF
--- a/test/e2e/email.test.ts
+++ b/test/e2e/email.test.ts
@@ -34,6 +34,7 @@ beforeAll(async () => {
     SMTP_FROM: "test@example.com",
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     EMAIL_FILE: path.join(tmpDir, "emails.json"),
+    MOCK_EMAIL_TO: "",
   });
   api = createApi(server);
   await signIn("user@example.com");
@@ -54,7 +55,7 @@ describe("email sending", () => {
     return data.caseId;
   }
 
-  it.skip("stores emails instead of sending", async () => {
+  it("stores emails instead of sending", async () => {
     const id = await createCase();
     const res = await api(`/api/cases/${id}/report`, {
       method: "POST",


### PR DESCRIPTION
## Summary
- unskip the email test
- ensure the dev server ignores `MOCK_EMAIL_TO` so the email is stored correctly

## Testing
- `npm run format`
- `npm run lint`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_68572ff1b5f8832b8492db8129467e29