### PR TITLE
Add helper for role updates in tests

### DIFF
--- a/test/authHelpers.test.ts
+++ b/test/authHelpers.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAuthHelpers } from "./e2e/authHelpers";
+
+function makeApi() {
+  const calls: Array<{ path: string; opts: RequestInit | undefined }> = [];
+  const api = vi.fn(async (path: string, opts?: RequestInit) => {
+    calls.push({ path, opts });
+    if (path === "/api/auth/csrf") {
+      return new Response(JSON.stringify({ csrfToken: "tok" }));
+    }
+    if (path === "/api/test/verification-url") {
+      return new Response(JSON.stringify({ url: "http://x/verify" }));
+    }
+    if (path === "/api/users") {
+      return new Response(
+        JSON.stringify([{ id: "u1", email: "user@example.com" }]),
+      );
+    }
+    return new Response(null);
+  });
+  return { api, calls };
+}
+
+describe("setUserRoleAndLogIn", () => {
+  it("updates role and logs in as target user", async () => {
+    const { api, calls } = makeApi();
+    const { setUserRoleAndLogIn } = createAuthHelpers(api, { url: "http://x" });
+    await setUserRoleAndLogIn({
+      email: "user@example.com",
+      role: "admin",
+      promoted_by: "super@example.com",
+    });
+    const paths = calls.map((c) => c.path);
+    expect(paths).toContain("/api/users");
+    expect(paths).toContain("/api/users/u1/role");
+    const updateCall = calls.find((c) => c.path === "/api/users/u1/role");
+    expect(updateCall?.opts?.method).toBe("PUT");
+  });
+});

--- a/test/e2e/authHelpers.ts
+++ b/test/e2e/authHelpers.ts
@@ -1,0 +1,59 @@
+export function createAuthHelpers(
+  api: (path: string, opts?: RequestInit) => Promise<Response>,
+  server: { url: string },
+) {
+  async function signIn(email: string) {
+    const csrf = await api("/api/auth/csrf").then((r) => r.json());
+    await api("/api/auth/signin/email", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        csrfToken: csrf.csrfToken,
+        email,
+        callbackUrl: server.url,
+      }),
+    });
+    const ver = await api("/api/test/verification-url").then((r) => r.json());
+    await api(`${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`);
+  }
+
+  async function signOut() {
+    const csrf = await api("/api/auth/csrf").then((r) => r.json());
+    await api("/api/auth/signout", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        csrfToken: csrf.csrfToken,
+        callbackUrl: server.url,
+      }),
+    });
+  }
+
+  async function setUserRoleAndLogIn({
+    email,
+    role,
+    promoted_by,
+  }: {
+    email: string;
+    role: string;
+    promoted_by: string;
+  }) {
+    await signOut();
+    await signIn(promoted_by);
+    const users = (await api("/api/users").then((r) => r.json())) as Array<{
+      id: string;
+      email: string;
+    }>;
+    const found = users.find((u) => u.email === email);
+    if (!found) throw new Error(`User not found: ${email}`);
+    await api(`/api/users/${found.id}/role`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role }),
+    });
+    await signOut();
+    await signIn(email);
+  }
+
+  return { signIn, signOut, setUserRoleAndLogIn };
+}


### PR DESCRIPTION
## Summary
- add `createAuthHelpers` module for E2E tests
- include `setUserRoleAndLogIn` helper and basic unit test

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f5266c1c832b9963e61141fb5db2