### PR TITLE
Update case members endpoint auth

### DIFF
--- a/src/app/api/cases/[id]/members/route.ts
+++ b/src/app/api/cases/[id]/members/route.ts
@@ -1,11 +1,20 @@
-import { withAuthorization } from "@/lib/authz";
+import { withCaseAuthorization } from "@/lib/authz";
 import { listCaseMembers } from "@/lib/caseMembers";
 import { getCase } from "@/lib/caseStore";
 import { NextResponse } from "next/server";
 
-export const GET = withAuthorization(
+export const GET = withCaseAuthorization(
   { obj: "cases" },
-  async (_req: Request, { params }: { params: Promise<{ id: string }> }) => {
+  async (
+    _req: Request,
+    {
+      params,
+      session,
+    }: {
+      params: Promise<{ id: string }>;
+      session?: { user?: { id?: string; role?: string } };
+    },
+  ) => {
     const { id } = await params;
     const c = getCase(id);
     if (!c) {

--- a/test/caseMembers.test.ts
+++ b/test/caseMembers.test.ts
@@ -123,4 +123,35 @@ describe("case members", () => {
     });
     expect(res.status).toBe(403);
   });
+
+  it("rejects listing members for non-member", async () => {
+    const c = caseStore.createCase("/h.jpg", null, undefined, null, "u1");
+    const { GET } = await import("@/app/api/cases/[id]/members/route");
+    const res = await GET(new Request("http://test"), {
+      params: Promise.resolve({ id: c.id }),
+      session: { user: { id: "u2", role: "user" } },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("allows case member to list members", async () => {
+    const c = caseStore.createCase("/i.jpg", null, undefined, null, "u1");
+    members.addCaseMember(c.id, "u2", "collaborator");
+    const { GET } = await import("@/app/api/cases/[id]/members/route");
+    const res = await GET(new Request("http://test"), {
+      params: Promise.resolve({ id: c.id }),
+      session: { user: { id: "u2", role: "user" } },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("allows admin to list members", async () => {
+    const c = caseStore.createCase("/j.jpg", null, undefined, null, "u1");
+    const { GET } = await import("@/app/api/cases/[id]/members/route");
+    const res = await GET(new Request("http://test"), {
+      params: Promise.resolve({ id: c.id }),
+      session: { user: { id: "u3", role: "admin" } },
+    });
+    expect(res.status).toBe(200);
+  });
 });


### PR DESCRIPTION
## Summary
- restrict case members route with `withCaseAuthorization`
- unit test access control for case members listing

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68582b2ee6a8832b90eb035f3e3ada03