### PR TITLE
Fix email env leak in e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ EMAIL_FILE=emails.json
 If `MOCK_EMAIL_TO` is set, all outgoing email will be directed there instead of
 the authority's address. Omit the variable in production to send to the real
 recipient.
+When running end-to-end tests, `startServer` automatically assigns
+`EMAIL_FILE` to a temporary path so that all emails are captured rather than
+sent.
 
 ## Snail Mail Provider
 

--- a/test/e2e/startServer.ts
+++ b/test/e2e/startServer.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import http from "node:http";
+import os from "node:os";
 import path from "node:path";
 
 export interface TestServer {
@@ -23,6 +24,10 @@ export async function startServer(
   env: Partial<NodeJS.ProcessEnv> = {},
 ): Promise<TestServer> {
   const nextBin = path.join("node_modules", ".bin", "next");
+  // Using EMAIL_FILE activates the mock email store defined in src/lib/email.ts
+  // so no real messages are sent during tests.
+  const emailFile =
+    env.EMAIL_FILE ?? path.join(os.tmpdir(), `e2e-emails-${port}.json`);
   const proc = spawn(nextBin, ["dev", "-p", String(port), "--turbo"], {
     env: {
       ...process.env,
@@ -32,6 +37,14 @@ export async function startServer(
       TEST_APIS: "1",
       NEXTAUTH_URL: `http://localhost:${port}`,
       SUPER_ADMIN_EMAIL: "",
+      SMTP_HOST: "",
+      SMTP_PORT: "",
+      SMTP_SECURE: "",
+      SMTP_USER: "",
+      SMTP_PASS: "",
+      SMTP_FROM: "",
+      EMAIL_FILE: emailFile,
+      MOCK_EMAIL_TO: "",
       ...env,
       CI: "1",
     },


### PR DESCRIPTION
## Summary
- avoid leaking real SMTP credentials when running e2e tests
- add explicit types in admin actions test so lint passes
- document how EMAIL_FILE enables mock emailer

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: fetch to fonts.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685854bf4570832bad92401adc08f123