### PR TITLE
Refactor sign-in/sign-out logic

### DIFF
--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -3,8 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createAuthHelpers } from "./authHelpers";
 import { type TestServer, startServer } from "./startServer";
-import { createAuthHelpers} from "./authHelpers";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
@@ -18,12 +18,16 @@ async function createCase(): Promise<string> {
   return data.caseId;
 }
 
-let setUserRoleAndLogIn;
-let signIn;
-let signOut;
+let setUserRoleAndLogIn: (args: {
+  email: string;
+  role: string;
+  promoted_by: string;
+}) => Promise<void>;
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
 beforeAll(async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-admin-"));
-  const case_store_file = path.join(tmpDir, "cases.sqlite")
+  const case_store_file = path.join(tmpDir, "cases.sqlite");
   server = await startServer(3021, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
@@ -32,7 +36,7 @@ beforeAll(async () => {
     SUPER_ADMIN_EMAIL: "super@example.com",
   });
   api = createApi(server);
-  ({ setUserRoleAndLogIn , signIn, signOut} = createAuthHelpers(api, server));
+  ({ setUserRoleAndLogIn, signIn, signOut } = createAuthHelpers(api, server));
   await signIn("super@example.com");
   await signOut();
 }, 120000);
@@ -47,7 +51,7 @@ describe("admin actions", () => {
     const adminUser = await setUserRoleAndLogIn({
       email: "admin@example.com",
       role: "admin",
-      promoted_by: "super@example.com"
+      promoted_by: "super@example.com",
     });
     const invite = await api("/api/users/invite", {
       method: "POST",
@@ -66,7 +70,7 @@ describe("admin actions", () => {
     let found = list.find((u) => u.id === invited.id);
     expect(found?.role).toBe("user");
 
-    const signInResponse = await signIn("super@example.com")
+    const signInResponse = await signIn("super@example.com");
     expect(signInResponse.status).toBe(302);
     const promote = await api(`/api/users/${invited.id}/role`, {
       method: "PUT",

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -5,48 +5,13 @@ import { getByRole } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createAuthHelpers } from "./authHelpers";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-
-async function signIn(email: string) {
-  const csrfRes = await api("/api/auth/csrf");
-  expect(csrfRes.status).toBe(200);
-  const csrf = (await csrfRes.json()) as { csrfToken: string };
-  const signInRes = await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  expect(signInRes.status).toBeLessThan(400);
-  const verRes = await api("/api/test/verification-url");
-  expect(verRes.status).toBe(200);
-  const ver = (await verRes.json()) as { url: string };
-  const verifyRes = await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-  expect(verifyRes.status).toBeLessThan(400);
-}
-
-async function signOut() {
-  const csrfRes = await api("/api/auth/csrf");
-  expect(csrfRes.status).toBe(200);
-  const csrf = (await csrfRes.json()) as { csrfToken: string };
-  const res = await api("/api/auth/signout", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      callbackUrl: server.url,
-    }),
-  });
-  expect(res.status).toBeLessThan(400);
-}
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
 
 let server: TestServer;
 let stub: OpenAIStub;
@@ -79,6 +44,7 @@ beforeAll(async () => {
   );
   server = await startServer(3003, env);
   api = createApi(server);
+  ({ signIn, signOut } = createAuthHelpers(api, server));
   await signIn("admin@example.com");
   await signOut();
   await signIn("user@example.com");


### PR DESCRIPTION
## Summary
- remove duplicate sign-in/out helpers in `flows.test.ts`
- use shared helpers from `authHelpers.ts`
- type auth helper variables in `adminActions.test.ts`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685864dc3850832b8dcfa943b27ce35c