### PR TITLE
Use auth helpers across e2e tests

### DIFF
--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -3,8 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createAuthHelpers } from "./authHelpers";
 import { type TestServer, startServer } from "./startServer";
-import { createAuthHelpers} from "./authHelpers";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
@@ -18,12 +18,16 @@ async function createCase(): Promise<string> {
   return data.caseId;
 }
 
-let setUserRoleAndLogIn;
-let signIn;
-let signOut;
+let setUserRoleAndLogIn: (args: {
+  email: string;
+  role: string;
+  promoted_by: string;
+}) => Promise<void>;
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
 beforeAll(async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-admin-"));
-  const case_store_file = path.join(tmpDir, "cases.sqlite")
+  const case_store_file = path.join(tmpDir, "cases.sqlite");
   server = await startServer(3021, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
@@ -32,7 +36,7 @@ beforeAll(async () => {
     SUPER_ADMIN_EMAIL: "super@example.com",
   });
   api = createApi(server);
-  ({ setUserRoleAndLogIn , signIn, signOut} = createAuthHelpers(api, server));
+  ({ setUserRoleAndLogIn, signIn, signOut } = createAuthHelpers(api, server));
   await signIn("super@example.com");
   await signOut();
 }, 120000);
@@ -47,7 +51,7 @@ describe("admin actions", () => {
     const adminUser = await setUserRoleAndLogIn({
       email: "admin@example.com",
       role: "admin",
-      promoted_by: "super@example.com"
+      promoted_by: "super@example.com",
     });
     const invite = await api("/api/users/invite", {
       method: "POST",
@@ -66,7 +70,7 @@ describe("admin actions", () => {
     let found = list.find((u) => u.id === invited.id);
     expect(found?.role).toBe("user");
 
-    const signInResponse = await signIn("super@example.com")
+    const signInResponse = await signIn("super@example.com");
     expect(signInResponse.status).toBe(302);
     const promote = await api(`/api/users/${invited.id}/role`, {
       method: "PUT",

--- a/test/e2e/analysisQueue.test.ts
+++ b/test/e2e/analysisQueue.test.ts
@@ -4,27 +4,12 @@ import path from "node:path";
 import type { Case } from "@/lib/caseStore";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createAuthHelpers } from "./authHelpers";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-
-async function signIn(email: string) {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
+let signIn: (email: string) => Promise<Response>;
 
 let server: TestServer;
 let stub: OpenAIStub;
@@ -77,6 +62,7 @@ beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   server = await startServer(3007, envFiles());
   api = createApi(server);
+  ({ signIn } = createAuthHelpers(api, server));
   await signIn("user@example.com");
 }, 120000);
 

--- a/test/e2e/email.test.ts
+++ b/test/e2e/email.test.ts
@@ -3,28 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createAuthHelpers } from "./authHelpers";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 let tmpDir: string;
-
-async function signIn(email: string) {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
+let signIn: (email: string) => Promise<Response>;
 
 beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-email-"));
@@ -37,6 +22,7 @@ beforeAll(async () => {
     MOCK_EMAIL_TO: "",
   });
   api = createApi(server);
+  ({ signIn } = createAuthHelpers(api, server));
   await signIn("user@example.com");
 }, 120000);
 

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -5,48 +5,13 @@ import { getByRole } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createAuthHelpers } from "./authHelpers";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-
-async function signIn(email: string) {
-  const csrfRes = await api("/api/auth/csrf");
-  expect(csrfRes.status).toBe(200);
-  const csrf = (await csrfRes.json()) as { csrfToken: string };
-  const signInRes = await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  expect(signInRes.status).toBeLessThan(400);
-  const verRes = await api("/api/test/verification-url");
-  expect(verRes.status).toBe(200);
-  const ver = (await verRes.json()) as { url: string };
-  const verifyRes = await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-  expect(verifyRes.status).toBeLessThan(400);
-}
-
-async function signOut() {
-  const csrfRes = await api("/api/auth/csrf");
-  expect(csrfRes.status).toBe(200);
-  const csrf = (await csrfRes.json()) as { csrfToken: string };
-  const res = await api("/api/auth/signout", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      callbackUrl: server.url,
-    }),
-  });
-  expect(res.status).toBeLessThan(400);
-}
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
 
 let server: TestServer;
 let stub: OpenAIStub;
@@ -79,6 +44,7 @@ beforeAll(async () => {
   );
   server = await startServer(3003, env);
   api = createApi(server);
+  ({ signIn, signOut } = createAuthHelpers(api, server));
   await signIn("admin@example.com");
   await signOut();
   await signIn("user@example.com");

--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -4,31 +4,12 @@ import path from "node:path";
 import Database from "better-sqlite3";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createAuthHelpers } from "./authHelpers";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-
-async function signIn(email: string) {
-  const csrfRequest = await api("/api/auth/csrf");
-  if (csrfRequest.status !== 200) {
-    throw new Error("Failed to get CSRF token");
-  }
-  const csrf = await csrfRequest.json();
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
+let signIn: (email: string) => Promise<Response>;
 
 let server: TestServer;
 let stub: OpenAIStub;
@@ -64,6 +45,7 @@ beforeAll(async () => {
   );
   server = await startServer(3005, env);
   api = createApi(server);
+  ({ signIn } = createAuthHelpers(api, server));
   await signIn("user@example.com");
 }, 120000);
 

--- a/test/e2e/freshDatabase.test.ts
+++ b/test/e2e/freshDatabase.test.ts
@@ -3,28 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createAuthHelpers } from "./authHelpers";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let tmpDir: string;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-
-async function signIn(email: string) {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
+let signIn: (email: string) => Promise<Response>;
 
 beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-auth-"));
@@ -35,6 +20,7 @@ beforeAll(async () => {
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);
+  ({ signIn } = createAuthHelpers(api, server));
 }, 120000);
 
 afterAll(async () => {

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -5,41 +5,15 @@ import { getByTestId } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createAuthHelpers } from "./authHelpers";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 let stub: OpenAIStub;
-
-async function signIn(email: string) {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
-
-async function signOut() {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signout", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      callbackUrl: server.url,
-    }),
-  });
-}
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
 
 async function createCase(): Promise<string> {
   const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
@@ -61,6 +35,7 @@ beforeAll(async () => {
     OPENAI_BASE_URL: stub.url,
   });
   api = createApi(server);
+  ({ signIn, signOut } = createAuthHelpers(api, server));
   await signIn("admin@example.com");
   await signOut();
 }, 120000);

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -5,27 +5,12 @@ import { getByTestId } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createAuthHelpers } from "./authHelpers";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-
-async function signIn(email: string) {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
+let signIn: (email: string) => Promise<Response>;
 
 beforeAll(async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
@@ -36,6 +21,7 @@ beforeAll(async () => {
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);
+  ({ signIn } = createAuthHelpers(api, server));
 }, 120000);
 
 afterAll(async () => {

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -3,39 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createAuthHelpers } from "./authHelpers";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-
-async function signIn(email: string) {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
-
-async function signOut() {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signout", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      callbackUrl: server.url,
-    }),
-  });
-}
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
 
 let server: TestServer;
 let stub: OpenAIStub;
@@ -64,6 +38,7 @@ async function setup(responses: Array<import("./openaiStub").StubResponse>) {
   );
   server = await startServer(3010, env);
   api = createApi(server);
+  ({ signIn, signOut } = createAuthHelpers(api, server));
   await signIn("admin@example.com");
   await signOut();
   await signIn("user@example.com");

--- a/test/e2e/snailmail.test.ts
+++ b/test/e2e/snailmail.test.ts
@@ -3,39 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createAuthHelpers } from "./authHelpers";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-
-async function signIn(email: string) {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
-
-async function signOut() {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signout", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      callbackUrl: server.url,
-    }),
-  });
-}
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
 
 let server: TestServer;
 let stub: OpenAIStub;
@@ -96,6 +70,7 @@ beforeAll(async () => {
   );
   server = await startServer(3008, env);
   api = createApi(server);
+  ({ signIn, signOut } = createAuthHelpers(api, server));
   await signIn("admin@example.com");
 }, 120000);
 


### PR DESCRIPTION
## Summary
- unify sign-in/out logic via `createAuthHelpers`
- clean up import ordering after applying helpers
- add explicit types in `adminActions.test.ts`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685864facde4832b899c5ccbfa291da3