### PR TITLE
chore: centralize auth helpers in e2e tests

### DIFF
--- a/test/e2e/analysisQueue.test.ts
+++ b/test/e2e/analysisQueue.test.ts
@@ -6,25 +6,11 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
+import { createAuthHelpers } from "./authHelpers";
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-
-async function signIn(email: string) {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
 
 let server: TestServer;
 let stub: OpenAIStub;
@@ -77,6 +63,7 @@ beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   server = await startServer(3007, envFiles());
   api = createApi(server);
+  ({ signIn, signOut } = createAuthHelpers(api, server));
   await signIn("user@example.com");
 }, 120000);
 

--- a/test/e2e/members.test.ts
+++ b/test/e2e/members.test.ts
@@ -4,38 +4,12 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type TestServer, startServer } from "./startServer";
+import { createAuthHelpers } from "./authHelpers";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-
-async function signIn(email: string) {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
-
-async function signOut() {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signout", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      callbackUrl: server.url,
-    }),
-  });
-}
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
 
 async function createCase(): Promise<string> {
   const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
@@ -55,6 +29,7 @@ beforeAll(async () => {
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);
+  ({ signIn, signOut } = createAuthHelpers(api, server));
 }, 120000);
 
 afterAll(async () => {

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -7,39 +7,13 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
+import { createAuthHelpers } from "./authHelpers";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 let stub: OpenAIStub;
-
-async function signIn(email: string) {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
-
-async function signOut() {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signout", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      callbackUrl: server.url,
-    }),
-  });
-}
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
 
 async function createCase(): Promise<string> {
   const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
@@ -61,6 +35,7 @@ beforeAll(async () => {
     OPENAI_BASE_URL: stub.url,
   });
   api = createApi(server);
+  ({ signIn, signOut } = createAuthHelpers(api, server));
   await signIn("admin@example.com");
   await signOut();
 }, 120000);

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -4,38 +4,12 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type TestServer, startServer } from "./startServer";
+import { createAuthHelpers } from "./authHelpers";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-
-async function signIn(email: string) {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
-
-async function signOut() {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signout", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      callbackUrl: server.url,
-    }),
-  });
-}
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
 
 async function createCase(): Promise<string> {
   const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
@@ -55,6 +29,7 @@ beforeAll(async () => {
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);
+  ({ signIn, signOut } = createAuthHelpers(api, server));
 }, 120000);
 
 afterAll(async () => {

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -6,26 +6,12 @@ import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type TestServer, startServer } from "./startServer";
+import { createAuthHelpers } from "./authHelpers";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-
-async function signIn(email: string) {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
 
 beforeAll(async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
@@ -36,6 +22,7 @@ beforeAll(async () => {
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);
+  ({ signIn, signOut } = createAuthHelpers(api, server));
 }, 120000);
 
 afterAll(async () => {

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -5,37 +5,11 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
+import { createAuthHelpers } from "./authHelpers";
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-
-async function signIn(email: string) {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
-
-async function signOut() {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signout", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      callbackUrl: server.url,
-    }),
-  });
-}
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
 
 let server: TestServer;
 let stub: OpenAIStub;
@@ -64,6 +38,7 @@ async function setup(responses: Array<import("./openaiStub").StubResponse>) {
   );
   server = await startServer(3010, env);
   api = createApi(server);
+  ({ signIn, signOut } = createAuthHelpers(api, server));
   await signIn("admin@example.com");
   await signOut();
   await signIn("user@example.com");

--- a/test/e2e/snailmail.test.ts
+++ b/test/e2e/snailmail.test.ts
@@ -5,37 +5,11 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
+import { createAuthHelpers } from "./authHelpers";
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-
-async function signIn(email: string) {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
-
-async function signOut() {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signout", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      callbackUrl: server.url,
-    }),
-  });
-}
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
 
 let server: TestServer;
 let stub: OpenAIStub;
@@ -96,6 +70,7 @@ beforeAll(async () => {
   );
   server = await startServer(3008, env);
   api = createApi(server);
+  ({ signIn, signOut } = createAuthHelpers(api, server));
   await signIn("admin@example.com");
 }, 120000);
 

--- a/test/e2e/thread.test.ts
+++ b/test/e2e/thread.test.ts
@@ -6,27 +6,13 @@ import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type TestServer, startServer } from "./startServer";
+import { createAuthHelpers } from "./authHelpers";
 
 let server: TestServer;
 let tmpDir: string;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-
-async function signIn(email: string) {
-  const csrf = await api("/api/auth/csrf").then((r) => r.json());
-  await api("/api/auth/signin/email", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      csrfToken: csrf.csrfToken,
-      email,
-      callbackUrl: server.url,
-    }),
-  });
-  const ver = await api("/api/test/verification-url").then((r) => r.json());
-  await api(
-    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
-  );
-}
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
 
 beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
@@ -36,6 +22,7 @@ beforeAll(async () => {
   };
   server = await startServer(3006, env);
   api = createApi(server);
+  ({ signIn, signOut } = createAuthHelpers(api, server));
   await signIn("user@example.com");
 }, 120000);
 


### PR DESCRIPTION
## Summary
- import and use `createAuthHelpers` in all e2e tests
- remove duplicated signIn/signOut logic

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685864facde4832b899c5ccbfa291da3