### PR TITLE
Fix Storybook build hang in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run build-storybook
+        env:
+          STORYBOOK_DISABLE_TELEMETRY: "1"
       - name: Deploy Storybook to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
## Summary
- disable Storybook telemetry prompts in CI workflow to avoid hanging the build

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685865aeffc8832b8eb8215ff9ebfccc