### PR TITLE
Consolidate e2e test timeouts

### DIFF
--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -1,13 +1,15 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
 import { createApi } from "./api";
 import { createAuthHelpers } from "./authHelpers";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
+
+test.setTimeout(60000);
 
 async function createCase(): Promise<string> {
   const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
@@ -97,7 +99,7 @@ describe("admin actions", () => {
     }>;
     found = list.find((u) => u.id === invited.id);
     expect(found?.role).toBe("user");
-  }, 60000);
+  });
 
   it("edits casbin rules", async () => {
     await signIn("super@example.com");
@@ -113,7 +115,7 @@ describe("admin actions", () => {
     expect(res.status).toBe(200);
     const updated = (await res.json()) as Array<{ v2?: string }>;
     expect(updated.some((r) => r.v2 === "extra")).toBe(true);
-  }, 60000);
+  });
 
   it("requires admin role to modify a case", async () => {
     await signIn("owner1@example.com");
@@ -139,5 +141,5 @@ describe("admin actions", () => {
       body: JSON.stringify({ vin: "1" }),
     });
     expect(ok.status).toBe(200);
-  }, 60000);
+  });
 });

--- a/test/e2e/email.test.ts
+++ b/test/e2e/email.test.ts
@@ -1,13 +1,15 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
 import { createApi } from "./api";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 let tmpDir: string;
+
+test.setTimeout(60000);
 
 async function signIn(email: string) {
   const csrf = await api("/api/auth/csrf").then((r) => r.json());
@@ -68,5 +70,5 @@ describe("email sending", () => {
     );
     expect(emails).toHaveLength(1);
     expect(emails[0].to).toBe("police@oak-park.us");
-  }, 60000);
+  });
 });

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { getByRole } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
@@ -51,6 +51,8 @@ async function signOut() {
 let server: TestServer;
 let stub: OpenAIStub;
 let tmpDir: string;
+
+test.setTimeout(60000);
 
 beforeAll(async () => {
   stub = await startOpenAIStub({
@@ -198,7 +200,7 @@ describe("e2e flows (unauthenticated)", () => {
     expect(delCase.status).toBe(200);
     const notFound = await api(`/api/cases/${caseId}`);
     expect(notFound.status).toBe(404);
-  }, 60000);
+  });
 
   it("shows summary for multiple cases", async () => {
     const id1 = await createCase();
@@ -211,7 +213,7 @@ describe("e2e flows (unauthenticated)", () => {
       name: /case summary/i,
     });
     expect(heading).toBeTruthy();
-  }, 60000);
+  });
 
   it("deletes a case", async () => {
     const id = await createCase();
@@ -221,7 +223,7 @@ describe("e2e flows (unauthenticated)", () => {
     expect(del.status).toBe(200);
     const notFound = await api(`/api/cases/${id}`);
     expect(notFound.status).toBe(404);
-  }, 60000);
+  });
 
   it("deletes multiple cases", async () => {
     const id1 = await createCase();
@@ -236,7 +238,7 @@ describe("e2e flows (unauthenticated)", () => {
     const nf2 = await api(`/api/cases/${id2}`);
     expect(nf1.status).toBe(404);
     expect(nf2.status).toBe(404);
-  }, 60000);
+  });
 
   it("toggles vin source modules", async () => {
     const listRes = await api("/api/vin-sources");
@@ -253,7 +255,7 @@ describe("e2e flows (unauthenticated)", () => {
       body: JSON.stringify({ enabled: false }),
     });
     expect(update.status).toBe(403);
-  }, 60000);
+  });
 
   it("allows admin to toggle vin source modules", async () => {
     await signOut();
@@ -280,5 +282,5 @@ describe("e2e flows (unauthenticated)", () => {
     expect(updated?.enabled).toBe(!before);
     await signOut();
     await signIn("user@example.com");
-  }, 60000);
+  });
 });

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { getByTestId } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
@@ -11,6 +11,8 @@ import { type TestServer, startServer } from "./startServer";
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 let stub: OpenAIStub;
+
+test.setTimeout(60000);
 
 async function signIn(email: string) {
   const csrf = await api("/api/auth/csrf").then((r) => r.json());
@@ -87,7 +89,7 @@ describe("permissions", () => {
     const draftDom = new JSDOM(draft);
     const sendButton = getByTestId(draftDom.window.document, "send-button");
     expect(sendButton.hasAttribute("disabled")).toBe(true);
-  }, 60000);
+  });
 
   it("shows admin actions for admins", async () => {
     await signOut();
@@ -104,5 +106,5 @@ describe("permissions", () => {
     const draftDom = new JSDOM(draft);
     const sendButton = getByTestId(draftDom.window.document, "send-button");
     expect(sendButton.hasAttribute("disabled")).toBe(false);
-  }, 60000);
+  });
 });

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
@@ -41,6 +41,8 @@ let server: TestServer;
 let stub: OpenAIStub;
 let tmpDir: string;
 let photoName = "";
+
+test.setTimeout(60000);
 
 async function setup(responses: Array<import("./openaiStub").StubResponse>) {
   stub = await startOpenAIStub(responses);
@@ -143,7 +145,7 @@ describe("reanalysis", () => {
         await new Promise((r) => setTimeout(() => r(undefined), 500));
       }
       expect(stub.requests.length).toBeGreaterThanOrEqual(1);
-    }, 60000);
+    });
   });
 
   describe("paperwork", () => {
@@ -214,6 +216,6 @@ describe("reanalysis", () => {
         await new Promise((r) => setTimeout(() => r(undefined), 500));
       }
       expect(stub.requests.length).toBeGreaterThanOrEqual(1);
-    }, 60000);
+    });
   });
 });

--- a/test/e2e/snailmail.test.ts
+++ b/test/e2e/snailmail.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
@@ -40,6 +40,8 @@ async function signOut() {
 let server: TestServer;
 let stub: OpenAIStub;
 let tmpDir: string;
+
+test.setTimeout(60000);
 
 beforeAll(async () => {
   stub = await startOpenAIStub({
@@ -125,7 +127,7 @@ describe("snail mail providers", () => {
     const list = (await res.json()) as Array<{ id: string; active: boolean }>;
     expect(Array.isArray(list)).toBe(true);
     expect(list.some((p) => p.id === "file")).toBe(true);
-  }, 60000);
+  });
 
   it("activates a provider", async () => {
     const res = await api("/api/snail-mail-providers/mock", {
@@ -135,14 +137,14 @@ describe("snail mail providers", () => {
     const list = (await res.json()) as Array<{ id: string; active: boolean }>;
     const active = list.find((p) => p.active);
     expect(active?.id).toBe("mock");
-  }, 60000);
+  });
 
   it("returns 404 for unknown provider", async () => {
     const res = await api("/api/snail-mail-providers/none", {
       method: "PUT",
     });
     expect(res.status).toBe(404);
-  }, 60000);
+  });
 
   it("sends snail mail followup", async () => {
     const id = await createCase();
@@ -163,5 +165,5 @@ describe("snail mail providers", () => {
       fs.readFileSync(path.join(tmpDir, "snailMail.json"), "utf8"),
     );
     expect(stored).toHaveLength(1);
-  }, 60000);
+  });
 });


### PR DESCRIPTION
## Summary
- avoid repeating 60 second timeouts across e2e tests
- apply `test.setTimeout(60000)` at the start of each affected file

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68586509efac832b93b3f6d291f449b1