### PR TITLE
Fix TypeScript errors

### DIFF
--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { createApi } from "./api";
 import { createAuthHelpers } from "./authHelpers";
 import { type TestServer, startServer } from "./startServer";
@@ -9,7 +9,7 @@ import { type TestServer, startServer } from "./startServer";
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
-test.setTimeout(60000);
+vi.setConfig({ testTimeout: 60000 });
 
 async function createCase(): Promise<string> {
   const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
@@ -61,7 +61,11 @@ describe("admin actions", () => {
       body: JSON.stringify({ email: "user1@example.com" }),
     });
     expect(invite.status).toBe(200);
-    const invited = (await invite.json()) as { id: string; role: string };
+    const invited = (await invite.json()) as {
+      id: string;
+      role: string;
+      email: string;
+    };
     expect(invited.role).toBe("user");
     expect(invited.email).toBe("user1@example.com");
 

--- a/test/e2e/email.test.ts
+++ b/test/e2e/email.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { createApi } from "./api";
 import { type TestServer, startServer } from "./startServer";
 
@@ -9,7 +9,7 @@ let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 let tmpDir: string;
 
-test.setTimeout(60000);
+vi.setConfig({ testTimeout: 60000 });
 
 async function signIn(email: string) {
   const csrf = await api("/api/auth/csrf").then((r) => r.json());

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { getByRole } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
-import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { poll } from "./poll";
@@ -53,7 +53,7 @@ let server: TestServer;
 let stub: OpenAIStub;
 let tmpDir: string;
 
-test.setTimeout(60000);
+vi.setConfig({ testTimeout: 60000 });
 
 beforeAll(async () => {
   stub = await startOpenAIStub({

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { getByTestId } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
-import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
@@ -12,7 +12,7 @@ let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 let stub: OpenAIStub;
 
-test.setTimeout(60000);
+vi.setConfig({ testTimeout: 60000 });
 
 async function signIn(email: string) {
   const csrf = await api("/api/auth/csrf").then((r) => r.json());

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { poll } from "./poll";
@@ -43,7 +43,7 @@ let stub: OpenAIStub;
 let tmpDir: string;
 let photoName = "";
 
-test.setTimeout(60000);
+vi.setConfig({ testTimeout: 60000 });
 
 async function setup(responses: Array<import("./openaiStub").StubResponse>) {
   stub = await startOpenAIStub(responses);

--- a/test/e2e/snailmail.test.ts
+++ b/test/e2e/snailmail.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
@@ -41,7 +41,7 @@ let server: TestServer;
 let stub: OpenAIStub;
 let tmpDir: string;
 
-test.setTimeout(60000);
+vi.setConfig({ testTimeout: 60000 });
 
 beforeAll(async () => {
   stub = await startOpenAIStub({


### PR DESCRIPTION
## Summary
- update Vitest setup in e2e tests
- fix adminActions types

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858699e01e8832bbbb99fef60d9ce85