### PR TITLE
Enable concurrent e2e tests

### DIFF
--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -12,9 +12,9 @@ export default defineConfig({
     include: ["test/e2e/*.test.ts"],
     testTimeout: 30000,
     hookTimeout: 30000,
-    maxConcurrency: 1,
+    maxConcurrency: 5,
     isolate: false,
-    sequence: { concurrent: false },
-    fileParallelism: false,
+    sequence: { concurrent: true },
+    fileParallelism: true,
   },
 });


### PR DESCRIPTION
## Summary
- run e2e test files concurrently so they finish faster

## Testing
- `npm test`
- `npm run e2e:smoke` *(fails: connection issues with fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_685866e1539c832b8cae5b147b2e199a