### PR TITLE
Fix typecheck errors in e2e tests

### DIFF
--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createApi } from "./api";
 import { createAuthHelpers } from "./authHelpers";
 import { type TestServer, startServer } from "./startServer";
@@ -48,7 +48,6 @@ afterAll(async () => {
 });
 
 describe("admin actions", () => {
-  test.setTimeout(60000);
   it("promotes and demotes users", async () => {
     await signIn("admin@example.com");
     const adminUser = await setUserRoleAndLogIn({

--- a/test/e2e/analysisQueue.test.ts
+++ b/test/e2e/analysisQueue.test.ts
@@ -87,7 +87,6 @@ afterAll(async () => {
 });
 
 describe("analysis queue", () => {
-  test.setTimeout(60000);
   it("processes additional photos sequentially", async () => {
     const file = await createPhoto("a");
     const form = new FormData();

--- a/test/e2e/auth.test.ts
+++ b/test/e2e/auth.test.ts
@@ -19,7 +19,6 @@ afterAll(async () => {
 });
 
 describe("auth flow", () => {
-  test.setTimeout(60000);
   it.skip("logs in and out", async () => {
     const csrf = await api("/api/auth/csrf").then((r) => r.json());
     const email = "user@example.com";

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -16,7 +16,6 @@ afterAll(async () => {
 });
 
 describe("end-to-end @smoke", () => {
-  test.setTimeout(60000);
   it("serves the homepage", async () => {
     const res = await fetch(`${server.url}/`);
     expect(res.status).toBe(200);

--- a/test/e2e/email.test.ts
+++ b/test/e2e/email.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createApi } from "./api";
 import { type TestServer, startServer } from "./startServer";
 
@@ -48,7 +48,6 @@ afterAll(async () => {
 });
 
 describe("email sending", () => {
-  test.setTimeout(60000);
   async function createCase(): Promise<string> {
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { getByRole } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
-import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { poll } from "./poll";
@@ -94,7 +94,6 @@ afterAll(async () => {
 });
 
 describe("e2e flows (unauthenticated)", () => {
-  test.setTimeout(60000);
   async function createCase(): Promise<string> {
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();
@@ -159,7 +158,7 @@ describe("e2e flows (unauthenticated)", () => {
     const data2 = (await res2.json()) as { caseId: string };
     expect(data2.caseId).toBe(caseId);
 
-    let json = await waitForPhotos(caseId);
+    let json = await waitForPhotos(caseId, 2);
     expect(json.photos).toHaveLength(2);
 
     const delRes = await api(`/api/cases/${caseId}/photos`, {
@@ -168,7 +167,7 @@ describe("e2e flows (unauthenticated)", () => {
       body: JSON.stringify({ photo: json.photos[0] }),
     });
     expect(delRes.status).toBe(200);
-    json = await waitForPhotos(caseId);
+    json = await waitForPhotos(caseId, 1);
     expect(json.photos).toHaveLength(1);
 
     const overrideRes = await api(`/api/cases/${caseId}/override`, {

--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -75,7 +75,6 @@ afterAll(async () => {
 });
 
 describe("follow up", () => {
-  test.setTimeout(60000);
   async function createCase(): Promise<string> {
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();

--- a/test/e2e/freshDatabase.test.ts
+++ b/test/e2e/freshDatabase.test.ts
@@ -43,7 +43,6 @@ afterAll(async () => {
 });
 
 describe("fresh database @smoke", () => {
-  test.setTimeout(60000);
   it("grants superadmin to first user", async () => {
     await signIn("first@example.com");
     const session = await api("/api/auth/session").then((r) => r.json());

--- a/test/e2e/members.test.ts
+++ b/test/e2e/members.test.ts
@@ -62,7 +62,6 @@ afterAll(async () => {
 });
 
 describe("case members e2e", () => {
-  test.setTimeout(60000);
   it.skip("invites and removes collaborators", async () => {
     await signIn("admin@example.com");
     await signOut();

--- a/test/e2e/paperwork.test.ts
+++ b/test/e2e/paperwork.test.ts
@@ -20,7 +20,6 @@ afterAll(async () => {
 });
 
 describe("paperwork info", () => {
-  test.setTimeout(60000);
   it("extracts calls to action", async () => {
     const result = await ocrPaperwork({ url: "data:image/png;base64,foo" });
     expect(result).toEqual({

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { getByTestId } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
-import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
@@ -73,7 +73,6 @@ afterAll(async () => {
 });
 
 describe("permissions", () => {
-  test.setTimeout(60000);
   it("hides admin actions for regular users", async () => {
     await signIn("admin@example.com");
     await signOut();

--- a/test/e2e/point.test.ts
+++ b/test/e2e/point.test.ts
@@ -16,7 +16,6 @@ afterAll(async () => {
 });
 
 describe("point and shoot", () => {
-  test.setTimeout(60000);
   it("serves the point page", async () => {
     const res = await fetch(`${server.url}/point`);
     expect(res.status).toBe(200);

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -62,7 +62,6 @@ afterAll(async () => {
 });
 
 describe("anonymous access", () => {
-  test.setTimeout(60000);
   it("allows access to public case", async () => {
     await signIn("user@example.com");
     const id = await createCase();

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -43,7 +43,6 @@ afterAll(async () => {
 });
 
 describe("case visibility @smoke", () => {
-  test.setTimeout(60000);
   it("shows toggle for admins", async () => {
     await signIn("admin@example.com");
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { poll } from "./poll";
@@ -79,9 +79,7 @@ async function teardown() {
 }
 
 describe("reanalysis", () => {
-  test.setTimeout(60000);
   describe("photo", () => {
-    test.setTimeout(60000);
     beforeAll(async () => {
       await setup([
         { violationType: "parking", details: "d", vehicle: {}, images: {} },
@@ -148,7 +146,6 @@ describe("reanalysis", () => {
   });
 
   describe("paperwork", () => {
-    test.setTimeout(60000);
     beforeAll(async () => {
       await setup([
         { violationType: "parking", details: "d", vehicle: {}, images: {} },

--- a/test/e2e/signinEmptyDb.test.ts
+++ b/test/e2e/signinEmptyDb.test.ts
@@ -26,7 +26,6 @@ afterAll(async () => {
 });
 
 describe("sign in with empty db @smoke", () => {
-  test.setTimeout(60000);
   it("creates the first user and signs in", async () => {
     const csrf = await api("/api/auth/csrf").then((r) => r.json());
     const email = "first@example.com";

--- a/test/e2e/snailmail.test.ts
+++ b/test/e2e/snailmail.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
@@ -108,7 +108,6 @@ afterAll(async () => {
 });
 
 describe("snail mail providers", () => {
-  test.setTimeout(60000);
   async function createCase(): Promise<string> {
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();

--- a/test/e2e/stream.test.ts
+++ b/test/e2e/stream.test.ts
@@ -14,7 +14,6 @@ afterAll(async () => {
 });
 
 describe("case events", () => {
-  test.setTimeout(60000);
   it.skip("streams updates", async () => {
     // warm up the server to ensure the route is compiled
     await fetch(`${server.url}/`);

--- a/test/e2e/thread.test.ts
+++ b/test/e2e/thread.test.ts
@@ -45,7 +45,6 @@ afterAll(async () => {
 });
 
 describe("thread page", () => {
-  test.setTimeout(60000);
   async function createCase(): Promise<string> {
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();


### PR DESCRIPTION
## Summary
- remove `test.setTimeout` calls from e2e tests
- fix `waitForPhotos` invocation in flows test

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68586c0bdef0832ba898b1147500c9c5