### PR TITLE
Enable concurrent e2e testing

### DIFF
--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -30,7 +30,7 @@ let signOut: () => Promise<void>;
 beforeAll(async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-admin-"));
   const case_store_file = path.join(tmpDir, "cases.sqlite");
-  server = await startServer(3021, {
+  server = await startServer(0, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
@@ -48,7 +48,6 @@ afterAll(async () => {
 });
 
 describe("admin actions", () => {
-  test.setTimeout(60000);
   it("promotes and demotes users", async () => {
     await signIn("admin@example.com");
     const adminUser = await setUserRoleAndLogIn({

--- a/test/e2e/analysisQueue.test.ts
+++ b/test/e2e/analysisQueue.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { Case } from "@/lib/caseStore";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { poll } from "./poll";
@@ -75,7 +75,7 @@ beforeAll(async () => {
     }),
   ]);
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  server = await startServer(3007, envFiles());
+  server = await startServer(0, envFiles());
   api = createApi(server);
   await signIn("user@example.com");
 });
@@ -87,7 +87,6 @@ afterAll(async () => {
 });
 
 describe("analysis queue", () => {
-  test.setTimeout(60000);
   it("processes additional photos sequentially", async () => {
     const file = await createPhoto("a");
     const form = new FormData();

--- a/test/e2e/auth.test.ts
+++ b/test/e2e/auth.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { createApi } from "./api";
 import { type TestServer, startServer } from "./startServer";
 
@@ -6,7 +6,7 @@ let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
 beforeAll(async () => {
-  server = await startServer(3010, {
+  server = await startServer(0, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
@@ -19,7 +19,6 @@ afterAll(async () => {
 });
 
 describe("auth flow", () => {
-  test.setTimeout(60000);
   it.skip("logs in and out", async () => {
     const csrf = await api("/api/auth/csrf").then((r) => r.json());
     const email = "user@example.com";

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -1,12 +1,12 @@
 import { getByRole } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 
 beforeAll(async () => {
-  server = await startServer(3002, {
+  server = await startServer(0, {
     NEXTAUTH_SECRET: "secret",
   });
 });
@@ -16,7 +16,6 @@ afterAll(async () => {
 });
 
 describe("end-to-end @smoke", () => {
-  test.setTimeout(60000);
   it("serves the homepage", async () => {
     const res = await fetch(`${server.url}/`);
     expect(res.status).toBe(200);

--- a/test/e2e/email.test.ts
+++ b/test/e2e/email.test.ts
@@ -30,7 +30,7 @@ async function signIn(email: string) {
 
 beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-email-"));
-  server = await startServer(3016, {
+  server = await startServer(0, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
@@ -48,7 +48,6 @@ afterAll(async () => {
 });
 
 describe("email sending", () => {
-  test.setTimeout(60000);
   async function createCase(): Promise<string> {
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -80,7 +80,7 @@ beforeAll(async () => {
       2,
     ),
   );
-  server = await startServer(3003, env);
+  server = await startServer(0, env);
   api = createApi(server);
   await signIn("admin@example.com");
   await signOut();
@@ -94,7 +94,6 @@ afterAll(async () => {
 });
 
 describe("e2e flows (unauthenticated)", () => {
-  test.setTimeout(60000);
   async function createCase(): Promise<string> {
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();

--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import Database from "better-sqlite3";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { poll } from "./poll";
@@ -63,7 +63,7 @@ beforeAll(async () => {
       2,
     ),
   );
-  server = await startServer(3005, env);
+  server = await startServer(0, env);
   api = createApi(server);
   await signIn("user@example.com");
 });
@@ -75,7 +75,6 @@ afterAll(async () => {
 });
 
 describe("follow up", () => {
-  test.setTimeout(60000);
   async function createCase(): Promise<string> {
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();

--- a/test/e2e/freshDatabase.test.ts
+++ b/test/e2e/freshDatabase.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { createApi } from "./api";
 import { type TestServer, startServer } from "./startServer";
 
@@ -28,7 +28,7 @@ async function signIn(email: string) {
 
 beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-auth-"));
-  server = await startServer(3022, {
+  server = await startServer(0, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
@@ -43,7 +43,6 @@ afterAll(async () => {
 });
 
 describe("fresh database @smoke", () => {
-  test.setTimeout(60000);
   it("grants superadmin to first user", async () => {
     await signIn("first@example.com");
     const session = await api("/api/auth/session").then((r) => r.json());

--- a/test/e2e/members.test.ts
+++ b/test/e2e/members.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { createApi } from "./api";
 import { type TestServer, startServer } from "./startServer";
 
@@ -48,7 +48,7 @@ async function createCase(): Promise<string> {
 
 beforeAll(async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  server = await startServer(3012, {
+  server = await startServer(0, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
@@ -62,7 +62,6 @@ afterAll(async () => {
 });
 
 describe("case members e2e", () => {
-  test.setTimeout(60000);
   it.skip("invites and removes collaborators", async () => {
     await signIn("admin@example.com");
     await signOut();

--- a/test/e2e/paperwork.test.ts
+++ b/test/e2e/paperwork.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 
 let ocrPaperwork: typeof import("@/lib/openai").ocrPaperwork;
@@ -20,7 +20,6 @@ afterAll(async () => {
 });
 
 describe("paperwork info", () => {
-  test.setTimeout(60000);
   it("extracts calls to action", async () => {
     const result = await ocrPaperwork({ url: "data:image/png;base64,foo" });
     expect(result).toEqual({

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -55,7 +55,7 @@ async function createCase(): Promise<string> {
 beforeAll(async () => {
   stub = await startOpenAIStub({ subject: "", body: "" });
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  server = await startServer(3011, {
+  server = await startServer(0, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
@@ -73,7 +73,6 @@ afterAll(async () => {
 });
 
 describe("permissions", () => {
-  test.setTimeout(60000);
   it("hides admin actions for regular users", async () => {
     await signIn("admin@example.com");
     await signOut();

--- a/test/e2e/point.test.ts
+++ b/test/e2e/point.test.ts
@@ -1,12 +1,12 @@
 import { getByRole } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 
 beforeAll(async () => {
-  server = await startServer(3005, {
+  server = await startServer(0, {
     NEXTAUTH_SECRET: "secret",
   });
 });
@@ -16,7 +16,6 @@ afterAll(async () => {
 });
 
 describe("point and shoot", () => {
-  test.setTimeout(60000);
   it("serves the point page", async () => {
     const res = await fetch(`${server.url}/point`);
     expect(res.status).toBe(200);

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { createApi } from "./api";
 import { type TestServer, startServer } from "./startServer";
 
@@ -48,7 +48,7 @@ async function createCase(): Promise<string> {
 
 beforeAll(async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  server = await startServer(3021, {
+  server = await startServer(0, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
@@ -62,7 +62,6 @@ afterAll(async () => {
 });
 
 describe("anonymous access", () => {
-  test.setTimeout(60000);
   it("allows access to public case", async () => {
     await signIn("user@example.com");
     const id = await createCase();

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { getByTestId } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { createApi } from "./api";
 import { type TestServer, startServer } from "./startServer";
 
@@ -29,7 +29,7 @@ async function signIn(email: string) {
 
 beforeAll(async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  server = await startServer(3020, {
+  server = await startServer(0, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
@@ -43,7 +43,6 @@ afterAll(async () => {
 });
 
 describe("case visibility @smoke", () => {
-  test.setTimeout(60000);
   it("shows toggle for admins", async () => {
     await signIn("admin@example.com");
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -65,7 +65,7 @@ async function setup(responses: Array<import("./openaiStub").StubResponse>) {
       2,
     ),
   );
-  server = await startServer(3010, env);
+  server = await startServer(0, env);
   api = createApi(server);
   await signIn("admin@example.com");
   await signOut();
@@ -79,9 +79,7 @@ async function teardown() {
 }
 
 describe("reanalysis", () => {
-  test.setTimeout(60000);
   describe("photo", () => {
-    test.setTimeout(60000);
     beforeAll(async () => {
       await setup([
         { violationType: "parking", details: "d", vehicle: {}, images: {} },
@@ -148,7 +146,6 @@ describe("reanalysis", () => {
   });
 
   describe("paperwork", () => {
-    test.setTimeout(60000);
     beforeAll(async () => {
       await setup([
         { violationType: "parking", details: "d", vehicle: {}, images: {} },

--- a/test/e2e/signinEmptyDb.test.ts
+++ b/test/e2e/signinEmptyDb.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { createApi } from "./api";
 import { type TestServer, startServer } from "./startServer";
 
@@ -11,7 +11,7 @@ let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
 beforeAll(async () => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
-  server = await startServer(3013, {
+  server = await startServer(0, {
     CASE_STORE_FILE: path.join(dataDir, "cases.sqlite"),
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
@@ -26,7 +26,6 @@ afterAll(async () => {
 });
 
 describe("sign in with empty db @smoke", () => {
-  test.setTimeout(60000);
   it("creates the first user and signs in", async () => {
     const csrf = await api("/api/auth/csrf").then((r) => r.json());
     const email = "first@example.com";

--- a/test/e2e/snailmail.test.ts
+++ b/test/e2e/snailmail.test.ts
@@ -96,7 +96,7 @@ beforeAll(async () => {
       2,
     ),
   );
-  server = await startServer(3008, env);
+  server = await startServer(0, env);
   api = createApi(server);
   await signIn("admin@example.com");
 });
@@ -108,7 +108,6 @@ afterAll(async () => {
 });
 
 describe("snail mail providers", () => {
-  test.setTimeout(60000);
   async function createCase(): Promise<string> {
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();

--- a/test/e2e/stream.test.ts
+++ b/test/e2e/stream.test.ts
@@ -1,10 +1,10 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 
 beforeAll(async () => {
-  server = await startServer(3004, {
+  server = await startServer(0, {
     NEXTAUTH_SECRET: "secret",
   });
 });
@@ -14,7 +14,6 @@ afterAll(async () => {
 });
 
 describe("case events", () => {
-  test.setTimeout(60000);
   it.skip("streams updates", async () => {
     // warm up the server to ensure the route is compiled
     await fetch(`${server.url}/`);

--- a/test/e2e/thread.test.ts
+++ b/test/e2e/thread.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { getByRole } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, test, vi } from "vitest";
 import { createApi } from "./api";
 import { type TestServer, startServer } from "./startServer";
 
@@ -34,7 +34,7 @@ beforeAll(async () => {
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     NEXTAUTH_SECRET: "secret",
   };
-  server = await startServer(3006, env);
+  server = await startServer(0, env);
   api = createApi(server);
   await signIn("user@example.com");
 });
@@ -45,7 +45,6 @@ afterAll(async () => {
 });
 
 describe("thread page", () => {
-  test.setTimeout(60000);
   async function createCase(): Promise<string> {
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -10,11 +10,10 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["test/e2e/*.test.ts"],
-    testTimeout: 30000,
-    hookTimeout: 30000,
-    maxConcurrency: 1,
+    testTimeout: 60000,
+    hookTimeout: 60000,
     isolate: false,
-    sequence: { concurrent: false },
-    fileParallelism: false,
+    globals: true,
+    sequence: { concurrent: true },
   },
 });


### PR DESCRIPTION
## Summary
- start e2e servers on random ports
- drop hard coded ports from tests
- run e2e test files concurrently

## Testing
- `npm test`
- `npm run e2e:smoke` *(fails: AssertionError in signinEmptyDb.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68586a178a54832bb3e112975658a408