### PR TITLE
feat: expose task completion events for e2e tests

### DIFF
--- a/src/app/api/test/wait-task/route.ts
+++ b/src/app/api/test/wait-task/route.ts
@@ -1,0 +1,40 @@
+import { caseEvents } from "@/lib/caseEvents";
+import { config } from "@/lib/config";
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  if (!config.TEST_APIS) {
+    return new NextResponse(null, { status: 404 });
+  }
+  const url = new URL(req.url);
+  const job = url.searchParams.get("job");
+  const caseId = url.searchParams.get("caseId");
+  if (!job || !caseId) {
+    return NextResponse.json(
+      { error: "job and caseId required" },
+      { status: 400 },
+    );
+  }
+  return new Promise<NextResponse>((resolve) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve(new NextResponse(null, { status: 202 }));
+    }, 30000);
+    function cleanup() {
+      clearTimeout(timer);
+      caseEvents.off("taskComplete", handler);
+    }
+    function handler(data: { job: string; data: unknown }) {
+      const id =
+        (data.data as { id?: string; caseData?: { id?: string } }).id ??
+        (data.data as { caseData?: { id?: string } }).caseData?.id;
+      if (data.job === job && id === caseId) {
+        cleanup();
+        resolve(new NextResponse(null, { status: 200 }));
+      }
+    }
+    caseEvents.on("taskComplete", handler);
+  });
+}

--- a/src/lib/jobScheduler.ts
+++ b/src/lib/jobScheduler.ts
@@ -11,6 +11,10 @@ export function runJob(name: string, jobData: unknown): Worker {
   worker.on("message", (msg) => {
     if (msg && msg.event === "update") {
       caseEvents.emit("update", msg.data);
+    } else if (msg === "done") {
+      caseEvents.emit("taskComplete", { job: name, data: jobData });
+    } else if (msg === "error") {
+      caseEvents.emit("taskError", { job: name, data: jobData });
     }
   });
   worker.on("error", (err) => {

--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -7,6 +7,7 @@ import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { poll } from "./poll";
 import { type TestServer, startServer } from "./startServer";
+import { waitForTask } from "./waitForTask";
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
@@ -89,15 +90,13 @@ describe("follow up", () => {
       20,
     );
     const data = (await res.json()) as { caseId: string };
-    return data.caseId;
+    const id = data.caseId;
+    await waitForTask(api, "analyzeCase", id);
+    return id;
   }
 
   async function fetchFollowup(id: string): Promise<Response> {
-    return poll(
-      () => api(`/api/cases/${id}/followup`),
-      (res) => res.status === 200,
-      20,
-    );
+    return api(`/api/cases/${id}/followup`);
   }
 
   it("passes prior emails to openai", async () => {

--- a/test/e2e/waitForTask.ts
+++ b/test/e2e/waitForTask.ts
@@ -1,0 +1,12 @@
+export async function waitForTask(
+  api: (path: string, opts?: RequestInit) => Promise<Response>,
+  job: string,
+  caseId: string,
+): Promise<void> {
+  const res = await api(
+    `/api/test/wait-task?job=${encodeURIComponent(job)}&caseId=${encodeURIComponent(caseId)}`,
+  );
+  if (res.status !== 200) {
+    throw new Error(`waitForTask failed: ${res.status}`);
+  }
+}


### PR DESCRIPTION
## Summary
- emit `taskComplete` and `taskError` from job scheduler
- add a test API endpoint for waiting on task completion
- support e2e tests with a `waitForTask` helper
- use event-based waiting in `followup` e2e test

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68586a3a8fc8832b9d7be9906a6a81e8