### PR TITLE
Fix storybook build

### DIFF
--- a/.storybook/StatsStub.ts
+++ b/.storybook/StatsStub.ts
@@ -1,0 +1,15 @@
+export interface LandingStats {
+  casesLastWeek: number;
+  authorityNotifications: number;
+  avgDaysToNotification: number;
+  notificationSuccessRate: number;
+}
+
+export function getLandingStats(): LandingStats {
+  return {
+    casesLastWeek: 0,
+    authorityNotifications: 0,
+    avgDaysToNotification: 0,
+    notificationSuccessRate: 0,
+  };
+}

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,12 +13,13 @@ const config: StorybookConfig = {
     config.resolve = config.resolve ?? { alias: {}, modules: [] };
     config.resolve.alias = {
       ...(config.resolve.alias ?? {}),
-      "@": path.resolve(process.cwd(), "src"),
+      "@/lib/stats": path.resolve(process.cwd(), ".storybook", "StatsStub.ts"),
       "@/app/components/MapPreview": path.resolve(
         process.cwd(),
         ".storybook",
         "MapPreviewStub.tsx",
       ),
+      "@": path.resolve(process.cwd(), "src"),
     };
     config.resolve.fallback = {
       ...(config.resolve.fallback ?? {}),

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@/lib/stats": ["./StatsStub.ts"]
+    }
+  },
   "include": ["../src/**/*.ts", "../src/**/*.tsx", "./**/*.ts"],
   "exclude": ["../node_modules"]
 }


### PR DESCRIPTION
## Summary
- create a stub for landing page stats for Storybook
- alias the stub in Storybook config and tsconfig

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run storybook` *(fails to open browser due to xdg-open but compilation succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_685874c42df0832b8baf1c20d6226cba