### PR TITLE
Fix lint errors for Docker build

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,14 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_" },
+      ],
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { withBasePath } from "@/basePath";
 import Link from "next/link";
 import { useEffect } from "react";
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -5,7 +5,7 @@ export default function NotFound() {
   return (
     <div className="p-8 text-center">
       <h1 className="text-2xl font-bold mb-4">Page Not Found</h1>
-      <p className="mb-4">Sorry, we couldn't find that page.</p>
+      <p className="mb-4">Sorry, we couldn&apos;t find that page.</p>
       <Link href={withBasePath("/")} className="underline">
         Back to home
       </Link>

--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -168,8 +168,8 @@ export default function PointAndShootPage() {
             className="pointer-events-none text-white text-sm text-center"
             data-testid="instructions"
           >
-            Point your camera at the vehicle. We'll guess the plate or violation
-            below.
+            Point your camera at the vehicle. We&apos;ll guess the plate or
+            violation below.
           </div>
         )}
         {analysisHint && (


### PR DESCRIPTION
## Summary
- adjust eslint to allow unused args prefixed with `_`
- remove unused `withBasePath` import from error page
- escape single quotes in messages

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685877111618832b910461869dd9481d