### PR TITLE
Add share button for public cases

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -11,6 +11,7 @@ import ImageHighlights from "@/app/components/ImageHighlights";
 import MapPreview from "@/app/components/MapPreview";
 import useCloseOnOutsideClick from "@/app/useCloseOnOutsideClick";
 import { useSession } from "@/app/useSession";
+import { withBasePath } from "@/basePath";
 import type { Case, SentEmail } from "@/lib/caseStore";
 import {
   getCaseOwnerContact,
@@ -25,6 +26,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+import { FiShare } from "react-icons/fi";
 
 function buildThreads(c: Case): SentEmail[] {
   const mails = c.sentEmails ?? [];
@@ -76,6 +78,7 @@ export default function ClientCasePage({
     Array<{ userId: string; role: string }>
   >([]);
   const [inviteUserId, setInviteUserId] = useState("");
+  const [copied, setCopied] = useState(false);
   const { data: session } = useSession();
   const isAdmin =
     session?.user?.role === "admin" || session?.user?.role === "superadmin";
@@ -248,6 +251,13 @@ export default function ClientCasePage({
       return;
     }
     await refreshCase();
+  }
+
+  async function copyShareUrl() {
+    const url = `${window.location.origin}${withBasePath(`/cases/${caseId}`)}`;
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   }
 
   async function reanalyzePhoto(
@@ -497,19 +507,34 @@ export default function ClientCasePage({
                   <span className="font-semibold">Created:</span>{" "}
                   {new Date(caseData.createdAt).toLocaleString()}
                 </p>
-                <p>
-                  <span className="font-semibold">Visibility:</span>{" "}
-                  {caseData.public ? "Public" : "Private"}
+                <p className="flex items-center gap-2">
+                  <span>
+                    <span className="font-semibold">Visibility:</span>{" "}
+                    {caseData.public ? "Public" : "Private"}
+                  </span>
                   {(isAdmin || session?.user) && (
                     <button
                       type="button"
                       onClick={togglePublic}
-                      className="ml-2 text-blue-500 underline"
+                      className="text-blue-500 underline"
                       data-testid="toggle-public-button"
                     >
                       Make {caseData.public ? "Private" : "Public"}
                     </button>
                   )}
+                  {caseData.public ? (
+                    <button
+                      type="button"
+                      onClick={copyShareUrl}
+                      className="text-blue-500 underline flex items-center"
+                      data-testid="share-case-button"
+                    >
+                      <FiShare />
+                    </button>
+                  ) : null}
+                  {copied ? (
+                    <span className="text-green-600 text-sm">Copied</span>
+                  ) : null}
                 </p>
                 {caseData.streetAddress ? (
                   <p>

--- a/test/e2e/shareButton.test.ts
+++ b/test/e2e/shareButton.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getByTestId } from "@testing-library/dom";
+import { JSDOM } from "jsdom";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createApi } from "./api";
+import { createAuthHelpers } from "./authHelpers";
+import { type TestServer, startServer } from "./startServer";
+
+let server: TestServer;
+let api: (path: string, opts?: RequestInit) => Promise<Response>;
+let signIn: (email: string) => Promise<Response>;
+let signOut: () => Promise<void>;
+
+async function createCase(): Promise<string> {
+  const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+  const form = new FormData();
+  form.append("photo", file);
+  const res = await api("/api/upload", { method: "POST", body: form });
+  const data = (await res.json()) as { caseId: string };
+  return data.caseId;
+}
+
+beforeAll(async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
+  server = await startServer(3023, {
+    NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
+    SMTP_FROM: "test@example.com",
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
+  });
+  api = createApi(server);
+  ({ signIn, signOut } = createAuthHelpers(api, server));
+});
+
+afterAll(async () => {
+  await server.close();
+});
+
+describe("share button", () => {
+  it("shows share button for public case", async () => {
+    await signIn("user@example.com");
+    const id = await createCase();
+    await api(`/api/cases/${id}/public`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ public: true }),
+    });
+    await signOut();
+
+    const html = await api(`/cases/${id}`).then((r) => r.text());
+    const dom = new JSDOM(html);
+    const btn = getByTestId(dom.window.document, "share-case-button");
+    expect(btn).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add clipboard share icon on case pages
- show ephemeral copy notification
- test share button visibility

## Testing
- `npm test`
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_e_685897ff71d8832ba028d202d2a6a4e8