### PR TITLE
Enable bail in CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 20
           cache: "npm"
       - run: npm ci
-      - run: npm test
+      - run: npm test -- --bail 1
 
   e2e:
     runs-on: ubuntu-latest
@@ -41,7 +41,7 @@ jobs:
           node-version: 20
           cache: "npm"
       - run: npm ci
-      - run: npm run e2e
+      - run: npm run e2e -- --bail 1
 
   storybook:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- revert bail flag from developer scripts
- run tests with `--bail 1` only in CI

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685898f08530832ba258e19b35909cc0