### PR TITLE
Implement thumbnail generation

### DIFF
--- a/src/app/api/cases/[id]/thread-images/route.ts
+++ b/src/app/api/cases/[id]/thread-images/route.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { withCaseAuthorization } from "@/lib/authz";
 import { addCaseThreadImage, getCase } from "@/lib/caseStore";
 import { ocrPaperwork } from "@/lib/openai";
+import { generateThumbnails } from "@/lib/thumbnails";
 import { NextResponse } from "next/server";
 
 export const POST = withCaseAuthorization(
@@ -32,6 +33,7 @@ export const POST = withCaseAuthorization(
     fs.mkdirSync(uploadDir, { recursive: true });
     const filename = `${crypto.randomUUID()}${ext}`;
     fs.writeFileSync(path.join(uploadDir, filename), buffer);
+    await generateThumbnails(buffer, filename);
     const mime =
       ext === ".png"
         ? "image/png"

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -6,6 +6,7 @@ import { analyzeCaseInBackground } from "@/lib/caseAnalysis";
 import { fetchCaseLocationInBackground } from "@/lib/caseLocation";
 import { addCasePhoto, createCase, getCase, updateCase } from "@/lib/caseStore";
 import { extractGps, extractTimestamp } from "@/lib/exif";
+import { generateThumbnails } from "@/lib/thumbnails";
 import { NextResponse } from "next/server";
 
 export const POST = withAuthorization(
@@ -36,6 +37,7 @@ export const POST = withAuthorization(
     const ext = path.extname(file.name || "jpg") || ".jpg";
     const filename = `${crypto.randomUUID()}${ext}`;
     fs.writeFileSync(path.join(uploadDir, filename), buffer);
+    await generateThumbnails(buffer, filename);
     const existing = clientId ? getCase(clientId) : null;
     if (existing) {
       const updated = addCasePhoto(

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -26,8 +26,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useNotify } from "../../components/NotificationProvider";
 import { FaShare } from "react-icons/fa";
+import { useNotify } from "../../components/NotificationProvider";
 
 function buildThreads(c: Case): SentEmail[] {
   const mails = c.sentEmails ?? [];

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default async function RootLayout({
             <NavBar />
             {children}
           </AuthProvider>
-        <NotificationProvider>
+        </NotificationProvider>
       </body>
     </html>
   );

--- a/src/lib/inboxScanner.ts
+++ b/src/lib/inboxScanner.ts
@@ -9,6 +9,7 @@ import { addCasePhoto, createCase } from "./caseStore";
 import { config } from "./config";
 import { extractGps, extractTimestamp } from "./exif";
 import { readJsonFile, writeJsonFile } from "./fileUtils";
+import { generateThumbnails } from "./thumbnails";
 
 const stateFile = config.INBOX_STATE_FILE
   ? path.resolve(config.INBOX_STATE_FILE)
@@ -58,6 +59,7 @@ export async function scanInbox(): Promise<void> {
           const filename = `${crypto.randomUUID()}${ext}`;
           const buffer = att.content as Buffer;
           fs.writeFileSync(path.join(uploadDir, filename), buffer);
+          await generateThumbnails(buffer, filename);
           const gps = extractGps(buffer);
           const takenAt = extractTimestamp(buffer);
           gpsList.push(gps);

--- a/src/lib/thumbnails.ts
+++ b/src/lib/thumbnails.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import path from "node:path";
+import sharp from "sharp";
+
+export const THUMB_SIZES = [64, 128, 256, 512];
+
+export async function generateThumbnails(
+  buffer: Buffer,
+  filename: string,
+): Promise<void> {
+  const base = path.basename(filename);
+  const uploadDir = path.join(process.cwd(), "public", "uploads", "thumbs");
+  await Promise.all(
+    THUMB_SIZES.map(async (size) => {
+      const dir = path.join(uploadDir, String(size));
+      fs.mkdirSync(dir, { recursive: true });
+      await sharp(buffer)
+        .resize(size, undefined, { fit: "inside" })
+        .toFile(path.join(dir, base));
+    }),
+  );
+}


### PR DESCRIPTION
## Summary
- generate image thumbnails at common powers of two when uploading
- fix NotificationProvider closing tag and import ordering
- ensure server scripts and thread image uploads generate thumbnails

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858bbb81b10832bb7511ac4024cf96b