### PR TITLE
Add triage view

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -26,8 +26,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useNotify } from "../../components/NotificationProvider";
 import { FaShare } from "react-icons/fa";
+import { useNotify } from "../../components/NotificationProvider";
 
 function buildThreads(c: Case): SentEmail[] {
   const mails = c.sentEmails ?? [];

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -62,6 +62,12 @@ export default function NavBar() {
         >
           Map View
         </Link>
+        <Link
+          href="/triage"
+          className="hover:text-gray-600 dark:hover:text-gray-300"
+        >
+          Triage
+        </Link>
         {session?.user?.role === "admin" ||
         session?.user?.role === "superadmin" ? (
           <Link

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default async function RootLayout({
             <NavBar />
             {children}
           </AuthProvider>
-        <NotificationProvider>
+        </NotificationProvider>
       </body>
     </html>
   );

--- a/src/app/triage/page.tsx
+++ b/src/app/triage/page.tsx
@@ -1,0 +1,75 @@
+import type { Case } from "@/lib/caseStore";
+import { getCases } from "@/lib/caseStore";
+import {
+  getCaseOwnerContact,
+  getCaseOwnerContactInfo,
+  getCasePlateNumber,
+  getCasePlateState,
+  hasViolation,
+} from "@/lib/caseUtils";
+import { reportModules } from "@/lib/reportModules";
+
+export const dynamic = "force-dynamic";
+
+function computeSeverity(c: Case): number {
+  const imgs = c.analysis?.images ? Object.values(c.analysis.images) : [];
+  let max = 0;
+  for (const info of imgs) {
+    if (info.violation && info.representationScore > max) {
+      max = info.representationScore;
+    }
+  }
+  return max;
+}
+
+function nextAction(c: Case): string {
+  if (c.analysisStatus === "pending") return "Awaiting image analysis.";
+  if (c.analysisStatus === "failed" || !c.analysis)
+    return "Re-run analysis with clearer photos.";
+  if (!hasViolation(c.analysis)) return "No violation detected.";
+  if (!getCasePlateNumber(c) && !getCasePlateState(c))
+    return "Identify the license plate.";
+  if (!getCaseOwnerContact(c)) return "Request ownership information.";
+  const ownerInfo = getCaseOwnerContactInfo(c);
+  if (
+    ownerInfo?.email &&
+    !(c.sentEmails ?? []).some((e) => e.to === ownerInfo.email)
+  ) {
+    return "Notify the registered owner.";
+  }
+  const authority = reportModules["oak-park"].authorityEmail;
+  if (!(c.sentEmails ?? []).some((e) => e.to === authority)) {
+    return "Notify the authorities.";
+  }
+  return "Await further updates.";
+}
+
+export default async function TriagePage() {
+  const cases = getCases();
+  const triage = cases
+    .map((c) => ({ case: c, severity: computeSeverity(c) }))
+    .filter((t) => t.severity > 0)
+    .sort((a, b) => b.severity - a.severity)
+    .slice(0, 5);
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">Case Triage</h1>
+      {triage.length === 0 ? (
+        <p>No open violations.</p>
+      ) : (
+        <ul className="grid gap-4">
+          {triage.map(({ case: c, severity }) => (
+            <li key={c.id} className="border p-4">
+              <p className="font-semibold">Case {c.id}</p>
+              {c.analysis?.violationType ? (
+                <p>Violation: {c.analysis.violationType}</p>
+              ) : null}
+              <p>Severity: {(severity * 100).toFixed(0)}%</p>
+              <p className="mt-2">{nextAction(c)}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/test/e2e/triage.test.ts
+++ b/test/e2e/triage.test.ts
@@ -1,0 +1,34 @@
+import { getByRole } from "@testing-library/dom";
+import { JSDOM } from "jsdom";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createApi } from "./api";
+import { createAuthHelpers } from "./authHelpers";
+import { type TestServer, startServer } from "./startServer";
+
+let server: TestServer;
+let api: (path: string, opts?: RequestInit) => Promise<Response>;
+let signIn: (email: string) => Promise<Response>;
+
+beforeAll(async () => {
+  server = await startServer(3040, { NEXTAUTH_SECRET: "secret" });
+  api = createApi(server);
+  ({ signIn } = createAuthHelpers(api, server));
+  await signIn("user@example.com");
+});
+
+afterAll(async () => {
+  await server.close();
+});
+
+describe("triage page @smoke", () => {
+  it("shows triage heading", async () => {
+    const res = await api("/triage");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    const dom = new JSDOM(html);
+    const heading = getByRole(dom.window.document, "heading", {
+      name: /case triage/i,
+    });
+    expect(heading).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- create `/triage` page to highlight severe cases
- link Triage page from the navigation bar
- adjust import order in `ClientCasePage`
- fix closing tag in layout
- add end-to-end test for triage page

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`

------
https://chatgpt.com/codex/tasks/task_e_6858ba8c0cb8832b99b7768294b58128