### PR TITLE
Implement thumbnail worker

### DIFF
--- a/src/app/api/cases/[id]/thread-images/route.ts
+++ b/src/app/api/cases/[id]/thread-images/route.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { withCaseAuthorization } from "@/lib/authz";
 import { addCaseThreadImage, getCase } from "@/lib/caseStore";
 import { ocrPaperwork } from "@/lib/openai";
+import { generateThumbnailsInBackground } from "@/lib/thumbnails";
 import { NextResponse } from "next/server";
 
 export const POST = withCaseAuthorization(
@@ -32,6 +33,7 @@ export const POST = withCaseAuthorization(
     fs.mkdirSync(uploadDir, { recursive: true });
     const filename = `${crypto.randomUUID()}${ext}`;
     fs.writeFileSync(path.join(uploadDir, filename), buffer);
+    generateThumbnailsInBackground(buffer, filename);
     const mime =
       ext === ".png"
         ? "image/png"

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -6,6 +6,7 @@ import { analyzeCaseInBackground } from "@/lib/caseAnalysis";
 import { fetchCaseLocationInBackground } from "@/lib/caseLocation";
 import { addCasePhoto, createCase, getCase, updateCase } from "@/lib/caseStore";
 import { extractGps, extractTimestamp } from "@/lib/exif";
+import { generateThumbnailsInBackground } from "@/lib/thumbnails";
 import { NextResponse } from "next/server";
 
 export const POST = withAuthorization(
@@ -36,6 +37,7 @@ export const POST = withAuthorization(
     const ext = path.extname(file.name || "jpg") || ".jpg";
     const filename = `${crypto.randomUUID()}${ext}`;
     fs.writeFileSync(path.join(uploadDir, filename), buffer);
+    generateThumbnailsInBackground(buffer, filename);
     const existing = clientId ? getCase(clientId) : null;
     if (existing) {
       const updated = addCasePhoto(

--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -6,6 +6,7 @@ import useNewCaseFromFiles from "@/app/useNewCaseFromFiles";
 import type { Case } from "@/lib/caseStore";
 import { getOfficialCaseGps, getRepresentativePhoto } from "@/lib/caseUtils";
 import { distanceBetween } from "@/lib/distance";
+import { getThumbnailUrl } from "@/lib/thumbnails";
 import Image from "next/image";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -198,7 +199,7 @@ export default function ClientCasesPage({
                   const photo = getRepresentativePhoto(c);
                   return photo ? (
                     <Image
-                      src={photo}
+                      src={getThumbnailUrl(photo, 128)}
                       alt="case thumbnail"
                       width={80}
                       height={60}

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -22,12 +22,13 @@ import {
   getRepresentativePhoto,
   hasViolation,
 } from "@/lib/caseUtils";
+import { getThumbnailUrl } from "@/lib/thumbnails";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useNotify } from "../../components/NotificationProvider";
 import { FaShare } from "react-icons/fa";
+import { useNotify } from "../../components/NotificationProvider";
 
 function buildThreads(c: Case): SentEmail[] {
   const mails = c.sentEmails ?? [];
@@ -710,7 +711,7 @@ export default function ClientCasePage({
                       >
                         <div className="relative w-20 aspect-[4/3]">
                           <Image
-                            src={p}
+                            src={getThumbnailUrl(p, 128)}
                             alt="case photo"
                             fill
                             className="object-cover"
@@ -806,7 +807,7 @@ export default function ClientCasePage({
                         >
                           <div className="relative w-20 aspect-[4/3]">
                             <Image
-                              src={url}
+                              src={getThumbnailUrl(url, 128)}
                               alt="paperwork"
                               fill
                               className="object-cover"

--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -4,6 +4,7 @@ import { useSession } from "@/app/useSession";
 import type { EmailDraft } from "@/lib/caseReport";
 import type { Case } from "@/lib/caseStore";
 import type { ReportModule } from "@/lib/reportModules";
+import { getThumbnailUrl } from "@/lib/thumbnails";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -144,7 +145,7 @@ export default function DraftEditor({
         {attachments.map((p) => (
           <Image
             key={p}
-            src={p}
+            src={getThumbnailUrl(p, 128)}
             alt="email attachment"
             width={120}
             height={90}

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
@@ -2,6 +2,7 @@
 import { apiFetch } from "@/apiClient";
 import type { EmailDraft } from "@/lib/caseReport";
 import type { Case } from "@/lib/caseStore";
+import { getThumbnailUrl } from "@/lib/thumbnails";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -336,7 +337,7 @@ export default function NotifyOwnerEditor({
         {attachments.map((p) => (
           <Image
             key={p}
-            src={p}
+            src={getThumbnailUrl(p, 128)}
             alt="email attachment"
             width={120}
             height={90}

--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { apiEventSource, apiFetch } from "@/apiClient";
 import type { Case, SentEmail, ThreadImage } from "@/lib/caseStore";
+import { getThumbnailUrl } from "@/lib/thumbnails";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
@@ -140,7 +141,7 @@ export default function ClientThreadPage({
         {images.map((img) => (
           <li key={img.id} className="border p-2 rounded flex gap-2">
             <Image
-              src={img.url}
+              src={getThumbnailUrl(img.url, 256)}
               alt="scan"
               width={150}
               height={100}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default async function RootLayout({
             <NavBar />
             {children}
           </AuthProvider>
-        <NotificationProvider>
+        </NotificationProvider>
       </body>
     </html>
   );

--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 import * as L from "leaflet";
 import "leaflet/dist/leaflet.css";
+import { getThumbnailUrl } from "@/lib/thumbnails";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
@@ -89,7 +90,7 @@ export default function MapPageClient({ cases }: { cases: MapCase[] }) {
               }}
             >
               <Image
-                src={c.photo}
+                src={getThumbnailUrl(c.photo, 256)}
                 alt={`Case ${c.id}`}
                 width={160}
                 height={120}

--- a/src/jobs/generateThumbnails.ts
+++ b/src/jobs/generateThumbnails.ts
@@ -1,0 +1,14 @@
+import { parentPort, workerData } from "node:worker_threads";
+import { generateThumbnails } from "@/lib/thumbnails";
+
+(async () => {
+  const { jobData } = workerData as {
+    jobData: { buffer: ArrayBuffer; filename: string };
+  };
+  const buffer = Buffer.from(jobData.buffer);
+  await generateThumbnails(buffer, jobData.filename);
+  if (parentPort) parentPort.postMessage("done");
+})().catch((err) => {
+  console.error("generateThumbnails job failed", err);
+  if (parentPort) parentPort.postMessage("error");
+});

--- a/src/lib/inboxScanner.ts
+++ b/src/lib/inboxScanner.ts
@@ -9,6 +9,7 @@ import { addCasePhoto, createCase } from "./caseStore";
 import { config } from "./config";
 import { extractGps, extractTimestamp } from "./exif";
 import { readJsonFile, writeJsonFile } from "./fileUtils";
+import { generateThumbnailsInBackground } from "./thumbnails";
 
 const stateFile = config.INBOX_STATE_FILE
   ? path.resolve(config.INBOX_STATE_FILE)
@@ -58,6 +59,7 @@ export async function scanInbox(): Promise<void> {
           const filename = `${crypto.randomUUID()}${ext}`;
           const buffer = att.content as Buffer;
           fs.writeFileSync(path.join(uploadDir, filename), buffer);
+          generateThumbnailsInBackground(buffer, filename);
           const gps = extractGps(buffer);
           const takenAt = extractTimestamp(buffer);
           gpsList.push(gps);

--- a/src/lib/thumbnails.ts
+++ b/src/lib/thumbnails.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import path from "node:path";
+import sharp from "sharp";
+import { runJob } from "./jobScheduler";
+
+export const THUMB_SIZES = [64, 128, 256, 512];
+
+export async function generateThumbnails(
+  buffer: Buffer,
+  filename: string,
+): Promise<void> {
+  const base = path.basename(filename);
+  const uploadDir = path.join(process.cwd(), "public", "uploads", "thumbs");
+  await Promise.all(
+    THUMB_SIZES.map(async (size) => {
+      const dir = path.join(uploadDir, String(size));
+      fs.mkdirSync(dir, { recursive: true });
+      await sharp(buffer)
+        .resize(size, undefined, { fit: "inside" })
+        .toFile(path.join(dir, base));
+    }),
+  );
+}
+
+export function getThumbnailUrl(url: string, size: number): string {
+  const base = path.basename(url);
+  return `/uploads/thumbs/${size}/${base}`;
+}
+
+export function generateThumbnailsInBackground(
+  buffer: Buffer,
+  filename: string,
+): void {
+  runJob("generateThumbnails", { buffer, filename });
+}


### PR DESCRIPTION
## Summary
- spawn a worker when generating thumbnails so uploads aren't blocked
- use smaller thumbnails across the UI

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858bbb81b10832bb7511ac4024cf96b