### PR TITLE
Update API authorization

### DIFF
--- a/src/app/api/snail-mail-providers/[id]/route.ts
+++ b/src/app/api/snail-mail-providers/[id]/route.ts
@@ -6,7 +6,7 @@ import {
 import { NextResponse } from "next/server";
 
 export const PUT = withAuthorization(
-  { obj: "admin" },
+  { obj: "snail_mail_providers" },
   async (
     _req: Request,
     {

--- a/src/app/api/snail-mail-providers/route.ts
+++ b/src/app/api/snail-mail-providers/route.ts
@@ -2,7 +2,7 @@ import { withAuthorization } from "@/lib/authz";
 import { getSnailMailProviderStatuses } from "@/lib/snailMailProviders";
 import { NextResponse } from "next/server";
 
-export const GET = withAuthorization({ obj: "admin" }, async () => {
+export const GET = withAuthorization({ obj: "snail_mail_providers" }, async () => {
   const providers = getSnailMailProviderStatuses();
   return NextResponse.json(providers);
 });

--- a/src/app/api/vin-sources/[id]/route.ts
+++ b/src/app/api/vin-sources/[id]/route.ts
@@ -1,24 +1,19 @@
-import { getSessionDetails, withAuthorization } from "@/lib/authz";
+import { withAuthorization } from "@/lib/authz";
 import { getVinSourceStatuses, setVinSourceEnabled } from "@/lib/vinSources";
 import { NextResponse } from "next/server";
 
 export const PUT = withAuthorization(
-  { obj: "cases" },
+  { obj: "vin_sources" },
   async (
     req: Request,
     {
       params,
-      session,
     }: {
       params: Promise<{ id: string }>;
       session?: { user?: { role?: string } };
     },
   ) => {
     const { id } = await params;
-    const { role } = getSessionDetails({ session }, "anonymous");
-    if (role !== "admin" && role !== "superadmin") {
-      return new Response(null, { status: 403 });
-    }
     const { enabled } = (await req.json()) as { enabled: boolean };
     const result = setVinSourceEnabled(id, enabled);
     if (!result) {

--- a/src/app/api/vin-sources/route.ts
+++ b/src/app/api/vin-sources/route.ts
@@ -2,7 +2,7 @@ import { withAuthorization } from "@/lib/authz";
 import { getVinSourceStatuses } from "@/lib/vinSources";
 import { NextResponse } from "next/server";
 
-export const GET = withAuthorization({ obj: "cases" }, async () => {
+export const GET = withAuthorization({ obj: "vin_sources" }, async () => {
   const sources = getVinSourceStatuses();
   return NextResponse.json(sources);
 });

--- a/test/snailMailProviders.test.ts
+++ b/test/snailMailProviders.test.ts
@@ -51,13 +51,13 @@ describe("snail mail provider store", () => {
 });
 
 describe("snail mail provider API authorization", () => {
-  it("rejects listing without admin role", async () => {
+  it("allows listing with user role", async () => {
     const mod = await import("@/app/api/snail-mail-providers/route");
     const res = await mod.GET(new Request("http://test"), {
       params: Promise.resolve({}) as Promise<Record<string, string>>,
       session: { user: { role: "user" } },
     });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
   });
 
   it("rejects update without admin role", async () => {


### PR DESCRIPTION
## Summary
- use `snail_mail_providers` resource for snail mail provider APIs
- authorize vin source APIs with `vin_sources`
- expect listing snail mail providers to succeed for regular users
- rely on HTTP method mapping for authorization actions

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582af2b778832b86cf9180b6fcf819