### PR TITLE
Fix thumbnail worker for invalid images

### DIFF
--- a/src/lib/thumbnails.ts
+++ b/src/lib/thumbnails.ts
@@ -11,6 +11,12 @@ export async function generateThumbnails(
 ): Promise<void> {
   const base = path.basename(filename);
   const uploadDir = path.join(process.cwd(), "public", "uploads", "thumbs");
+  try {
+    await sharp(buffer).metadata();
+  } catch (err) {
+    console.warn("Skipping thumbnail generation for invalid image", err);
+    return;
+  }
   await Promise.all(
     THUMB_SIZES.map(async (size) => {
       const dir = path.join(uploadDir, String(size));


### PR DESCRIPTION
## Summary
- handle invalid images in `generateThumbnails`

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6859519554cc832b94cdf624fa1f9daf