### PR TITLE
Fix E2E thumbnail error

### DIFF
--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createApi } from "./api";
 import { createAuthHelpers } from "./authHelpers";
+import { createPhoto } from "./photo";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
@@ -12,7 +13,7 @@ let api: (path: string, opts?: RequestInit) => Promise<Response>;
 vi.setConfig({ testTimeout: 60000 });
 
 async function createCase(): Promise<string> {
-  const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+  const file = createPhoto("a");
   const form = new FormData();
   form.append("photo", file);
   const res = await api("/api/upload", { method: "POST", body: form });

--- a/test/e2e/analysisQueue.test.ts
+++ b/test/e2e/analysisQueue.test.ts
@@ -5,6 +5,7 @@ import type { Case } from "@/lib/caseStore";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
+import { createPhoto } from "./photo";
 import { poll } from "./poll";
 import { type TestServer, startServer } from "./startServer";
 
@@ -49,10 +50,6 @@ function envFiles() {
     OPENAI_BASE_URL: stub.url,
     NEXTAUTH_SECRET: "secret",
   };
-}
-
-async function createPhoto(name: string): Promise<File> {
-  return new File([Buffer.from(name)], `${name}.jpg`, { type: "image/jpeg" });
 }
 
 async function fetchCase(id: string): Promise<Case> {

--- a/test/e2e/email.test.ts
+++ b/test/e2e/email.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createApi } from "./api";
+import { createPhoto } from "./photo";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
@@ -49,7 +50,7 @@ afterAll(async () => {
 
 describe("email sending", () => {
   async function createCase(): Promise<string> {
-    const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+    const file = createPhoto("a");
     const form = new FormData();
     form.append("photo", file);
     const res = await api("/api/upload", { method: "POST", body: form });

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -6,6 +6,7 @@ import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
+import { createPhoto } from "./photo";
 import { poll } from "./poll";
 import { type TestServer, startServer } from "./startServer";
 
@@ -95,7 +96,7 @@ afterAll(async () => {
 
 describe("e2e flows (unauthenticated)", () => {
   async function createCase(): Promise<string> {
-    const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+    const file = createPhoto("a");
     const form = new FormData();
     form.append("photo", file);
     const res = await api("/api/upload", {
@@ -144,9 +145,7 @@ describe("e2e flows (unauthenticated)", () => {
   it("handles case lifecycle", async () => {
     const caseId = await createCase();
 
-    const second = new File([Buffer.from("b")], "b.jpg", {
-      type: "image/jpeg",
-    });
+    const second = createPhoto("b");
     const add = new FormData();
     add.append("photo", second);
     add.append("caseId", caseId);

--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -5,6 +5,7 @@ import Database from "better-sqlite3";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
+import { createPhoto } from "./photo";
 import { poll } from "./poll";
 import { type TestServer, startServer } from "./startServer";
 
@@ -76,7 +77,7 @@ afterAll(async () => {
 
 describe("follow up", () => {
   async function createCase(): Promise<string> {
-    const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+    const file = createPhoto("a");
     const form = new FormData();
     form.append("photo", file);
     const res = await poll(

--- a/test/e2e/members.test.ts
+++ b/test/e2e/members.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createPhoto } from "./photo";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
@@ -38,7 +39,7 @@ async function signOut() {
 }
 
 async function createCase(): Promise<string> {
-  const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+  const file = createPhoto("a");
   const form = new FormData();
   form.append("photo", file);
   const res = await api("/api/upload", { method: "POST", body: form });

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -6,6 +6,7 @@ import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
+import { createPhoto } from "./photo";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
@@ -44,7 +45,7 @@ async function signOut() {
 }
 
 async function createCase(): Promise<string> {
-  const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+  const file = createPhoto("a");
   const form = new FormData();
   form.append("photo", file);
   const res = await api("/api/upload", { method: "POST", body: form });

--- a/test/e2e/photo.ts
+++ b/test/e2e/photo.ts
@@ -1,0 +1,6 @@
+export function createPhoto(name: string): File {
+  const base64 =
+    "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf///////////////////////////////////////////////////////////////////////////////////////wAARCAAaACkDAREAAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQBAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhADEAAAAP8A/9k=";
+  const buffer = Buffer.from(base64, "base64");
+  return new File([buffer], `${name}.jpg`, { type: "image/jpeg" });
+}

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createPhoto } from "./photo";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
@@ -38,7 +39,7 @@ async function signOut() {
 }
 
 async function createCase(): Promise<string> {
-  const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+  const file = createPhoto("a");
   const form = new FormData();
   form.append("photo", file);
   const res = await api("/api/upload", { method: "POST", body: form });

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -5,6 +5,7 @@ import { getByTestId } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createPhoto } from "./photo";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
@@ -45,7 +46,7 @@ afterAll(async () => {
 describe("case visibility @smoke", () => {
   it("shows toggle for admins", async () => {
     await signIn("admin@example.com");
-    const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+    const file = createPhoto("a");
     const form = new FormData();
     form.append("photo", file);
     const upload = await api("/api/upload", { method: "POST", body: form });

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
+import { createPhoto } from "./photo";
 import { poll } from "./poll";
 import { type TestServer, startServer } from "./startServer";
 
@@ -97,9 +98,7 @@ describe("reanalysis", () => {
     });
 
     it("adds vehicle info on reanalysis", async () => {
-      const file = new File([Buffer.from("a")], "a.jpg", {
-        type: "image/jpeg",
-      });
+      const file = createPhoto("a");
       const form = new FormData();
       form.append("photo", file);
       const res = await api("/api/upload", {
@@ -165,9 +164,7 @@ describe("reanalysis", () => {
     });
 
     it("extracts paperwork text on reanalysis", async () => {
-      const file = new File([Buffer.from("b")], "b.jpg", {
-        type: "image/jpeg",
-      });
+      const file = createPhoto("b");
       const form = new FormData();
       form.append("photo", file);
       const res = await api("/api/upload", {

--- a/test/e2e/snailmail.test.ts
+++ b/test/e2e/snailmail.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
+import { createPhoto } from "./photo";
 import { type TestServer, startServer } from "./startServer";
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
@@ -109,7 +110,7 @@ afterAll(async () => {
 
 describe("snail mail providers", () => {
   async function createCase(): Promise<string> {
-    const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+    const file = createPhoto("a");
     const form = new FormData();
     form.append("photo", file);
     const res = await api("/api/upload", {

--- a/test/e2e/stream.test.ts
+++ b/test/e2e/stream.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createPhoto } from "./photo";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
@@ -24,7 +25,7 @@ describe("case events", () => {
     if (!reader) throw new Error("no reader");
     const decoder = new TextDecoder();
 
-    const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+    const file = createPhoto("a");
     const form = new FormData();
     form.append("photo", file);
     await fetch(`${server.url}/api/upload`, { method: "POST", body: form });

--- a/test/e2e/thread.test.ts
+++ b/test/e2e/thread.test.ts
@@ -5,6 +5,7 @@ import { getByRole } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { createPhoto } from "./photo";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
@@ -46,7 +47,7 @@ afterAll(async () => {
 
 describe("thread page", () => {
   async function createCase(): Promise<string> {
-    const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+    const file = createPhoto("a");
     const form = new FormData();
     form.append("photo", file);
     const res = await api("/api/upload", { method: "POST", body: form });


### PR DESCRIPTION
## Summary
- ensure e2e tests use a valid jpeg buffer
- reorder imports to satisfy Biome

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859519554cc832b94cdf624fa1f9daf