### PR TITLE
Add marketing website link

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -26,8 +26,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useNotify } from "../../components/NotificationProvider";
 import { FaShare } from "react-icons/fa";
+import { useNotify } from "../../components/NotificationProvider";
 
 function buildThreads(c: Case): SentEmail[] {
   const mails = c.sentEmails ?? [];

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default async function RootLayout({
             <NavBar />
             {children}
           </AuthProvider>
-        <NotificationProvider>
+        </NotificationProvider>
       </body>
     </html>
   );

--- a/src/app/signin/__tests__/SignInPage.test.tsx
+++ b/src/app/signin/__tests__/SignInPage.test.tsx
@@ -29,4 +29,14 @@ describe("SignInPage", () => {
       screen.getByText(/Sign-in failed. The link may have expired./i),
     ).toBeInTheDocument();
   });
+
+  it("links to marketing website", () => {
+    mockGet.mockReturnValueOnce(null);
+    render(<SignInPage />);
+    const link = screen.getByRole("link", { name: /back to website/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://antialias.github.io/photo-to-citation/website/",
+    );
+  });
 });

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -4,6 +4,8 @@ import { withBasePath } from "@/basePath";
 import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 
+const MARKETING_URL = "https://antialias.github.io/photo-to-citation/website/";
+
 export default function SignInPage() {
   const [email, setEmail] = useState("");
   const params = useSearchParams();
@@ -43,6 +45,9 @@ export default function SignInPage() {
           Sign In
         </button>
       </form>
+      <a href={MARKETING_URL} className="underline mt-2">
+        Back to Website
+      </a>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- link to marketing website from the sign-in page
- fix closing tag in layout
- fix import orders
- test that marketing link is rendered with absolute URL

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858b90443d0832b9aa568bcbb7890b9