### PR TITLE
fix: stub openai for e2e tests

### DIFF
--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -4,10 +4,12 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createApi } from "./api";
 import { createAuthHelpers } from "./authHelpers";
+import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
+let stub: OpenAIStub;
 
 vi.setConfig({ testTimeout: 60000 });
 
@@ -28,6 +30,12 @@ let setUserRoleAndLogIn: (opts: {
 let signIn: (email: string) => Promise<Response>;
 let signOut: () => Promise<void>;
 beforeAll(async () => {
+  stub = await startOpenAIStub({
+    violationType: "parking",
+    details: "car parked illegally",
+    vehicle: {},
+    images: {},
+  });
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-admin-"));
   const case_store_file = path.join(tmpDir, "cases.sqlite");
   server = await startServer(3021, {
@@ -36,6 +44,7 @@ beforeAll(async () => {
     SMTP_FROM: "test@example.com",
     CASE_STORE_FILE: case_store_file,
     SUPER_ADMIN_EMAIL: "super@example.com",
+    OPENAI_BASE_URL: stub.url,
   });
   api = createApi(server);
   ({ setUserRoleAndLogIn, signIn, signOut } = createAuthHelpers(api, server));
@@ -45,6 +54,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await server.close();
+  await stub.close();
 });
 
 describe("admin actions", () => {

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -3,10 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
+let stub: OpenAIStub;
 
 async function signIn(email: string) {
   const csrf = await api("/api/auth/csrf").then((r) => r.json());
@@ -47,18 +49,26 @@ async function createCase(): Promise<string> {
 }
 
 beforeAll(async () => {
+  stub = await startOpenAIStub({
+    violationType: "parking",
+    details: "car parked illegally",
+    vehicle: {},
+    images: {},
+  });
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   server = await startServer(3021, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
+    OPENAI_BASE_URL: stub.url,
   });
   api = createApi(server);
 });
 
 afterAll(async () => {
   await server.close();
+  await stub.close();
 });
 
 describe("anonymous access", () => {

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -5,10 +5,12 @@ import { getByTestId } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
+let stub: OpenAIStub;
 
 async function signIn(email: string) {
   const csrf = await api("/api/auth/csrf").then((r) => r.json());
@@ -28,18 +30,26 @@ async function signIn(email: string) {
 }
 
 beforeAll(async () => {
+  stub = await startOpenAIStub({
+    violationType: "parking",
+    details: "car parked illegally",
+    vehicle: {},
+    images: {},
+  });
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   server = await startServer(3020, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
+    OPENAI_BASE_URL: stub.url,
   });
   api = createApi(server);
 });
 
 afterAll(async () => {
   await server.close();
+  await stub.close();
 });
 
 describe("case visibility @smoke", () => {

--- a/test/e2e/thread.test.ts
+++ b/test/e2e/thread.test.ts
@@ -5,11 +5,13 @@ import { getByRole } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let tmpDir: string;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
+let stub: OpenAIStub;
 
 async function signIn(email: string) {
   const csrf = await api("/api/auth/csrf").then((r) => r.json());
@@ -29,10 +31,17 @@ async function signIn(email: string) {
 }
 
 beforeAll(async () => {
+  stub = await startOpenAIStub({
+    violationType: "parking",
+    details: "car parked illegally",
+    vehicle: {},
+    images: {},
+  });
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   const env = {
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     NEXTAUTH_SECRET: "secret",
+    OPENAI_BASE_URL: stub.url,
   };
   server = await startServer(3006, env);
   api = createApi(server);
@@ -41,6 +50,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await server.close();
+  await stub.close();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary
- ensure e2e tests use the OpenAI stub

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685951dcf238832ba32aff5ed6f78416