### PR TITLE
Add case and photo notes

### DIFF
--- a/src/app/api/cases/[id]/note/route.ts
+++ b/src/app/api/cases/[id]/note/route.ts
@@ -1,0 +1,17 @@
+import { withCaseAuthorization } from "@/lib/authz";
+import { getCase, setCaseNote } from "@/lib/caseStore";
+import { NextResponse } from "next/server";
+
+export const PUT = withCaseAuthorization(
+  { obj: "cases", act: "update" },
+  async (req: Request, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const { note } = (await req.json()) as { note: string | null };
+    const updated = setCaseNote(id, note);
+    if (!updated) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const layered = getCase(id);
+    return NextResponse.json(layered);
+  },
+);

--- a/src/app/api/cases/[id]/photo-note/route.ts
+++ b/src/app/api/cases/[id]/photo-note/route.ts
@@ -1,0 +1,20 @@
+import { withCaseAuthorization } from "@/lib/authz";
+import { getCase, setPhotoNote } from "@/lib/caseStore";
+import { NextResponse } from "next/server";
+
+export const PUT = withCaseAuthorization(
+  { obj: "cases", act: "update" },
+  async (req: Request, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const { photo, note } = (await req.json()) as {
+      photo: string;
+      note: string | null;
+    };
+    const updated = setPhotoNote(id, photo, note);
+    if (!updated) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const layered = getCase(id);
+    return NextResponse.json(layered);
+  },
+);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default async function RootLayout({
             <NavBar />
             {children}
           </AuthProvider>
-        <NotificationProvider>
+        </NotificationProvider>
       </body>
     </html>
   );

--- a/src/generated/zod/caseStore.ts
+++ b/src/generated/zod/caseStore.ts
@@ -43,6 +43,7 @@ export const caseSchema = z.object({
     .optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
+  public: z.boolean(),
   gps: z
     .object({
       lat: z.number(),
@@ -76,4 +77,6 @@ export const caseSchema = z.object({
   sentEmails: z.array(sentEmailSchema).optional(),
   ownershipRequests: z.array(ownershipRequestSchema).optional(),
   threadImages: z.array(threadImageSchema).optional(),
+  note: z.string().optional().nullable(),
+  photoNotes: z.record(z.string().nullable()).optional(),
 });

--- a/src/lib/apiContract.ts
+++ b/src/lib/apiContract.ts
@@ -106,6 +106,30 @@ export const apiContract = c.router({
     summary: "Remove VIN override",
     description: "Clear any VIN override from a case.",
   }),
+  setCaseNote: c.mutation({
+    method: "PUT",
+    path: "/api/cases/:id/note",
+    pathParams: idParams,
+    body: c.type<{ note: string | null }>(),
+    responses: c.responses({
+      200: caseSchema,
+      404: errorSchema,
+    }),
+    summary: "Set case note",
+    description: "Update the note for a case.",
+  }),
+  setPhotoNote: c.mutation({
+    method: "PUT",
+    path: "/api/cases/:id/photo-note",
+    pathParams: idParams,
+    body: c.type<{ photo: string; note: string | null }>(),
+    responses: c.responses({
+      200: caseSchema,
+      404: errorSchema,
+    }),
+    summary: "Set photo note",
+    description: "Update the note for a case photo.",
+  }),
   caseStream: c.query({
     method: "GET",
     path: "/api/cases/stream",

--- a/test/caseAnalysis.test.ts
+++ b/test/caseAnalysis.test.ts
@@ -39,6 +39,8 @@ describe("analyzeCaseInBackground", () => {
       sentEmails: [],
       ownershipRequests: [],
       threadImages: [],
+      note: null,
+      photoNotes: { "/a.jpg": null },
     };
     analyzeCaseInBackground(c);
     expect(runJobMock).toHaveBeenCalledTimes(1);

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -156,4 +156,22 @@ describe("caseStore", () => {
     const stored = getCase(c.id);
     expect(stored?.public).toBe(true);
   });
+
+  it("sets case note", () => {
+    const { createCase, setCaseNote, getCase } = caseStore;
+    const c = createCase("/note.jpg", null);
+    const updated = setCaseNote(c.id, "hello");
+    expect(updated?.note).toBe("hello");
+    const stored = getCase(c.id);
+    expect(stored?.note).toBe("hello");
+  });
+
+  it("sets photo note", () => {
+    const { createCase, setPhotoNote, getCase } = caseStore;
+    const c = createCase("/p.jpg", null);
+    const updated = setPhotoNote(c.id, "/p.jpg", "foo");
+    expect(updated?.photoNotes?.["/p.jpg"]).toBe("foo");
+    const stored = getCase(c.id);
+    expect(stored?.photoNotes?.["/p.jpg"]).toBe("foo");
+  });
 });

--- a/test/e2e/notes.test.ts
+++ b/test/e2e/notes.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createApi } from "./api";
+import { type TestServer, startServer } from "./startServer";
+
+let server: TestServer;
+let api: (path: string, opts?: RequestInit) => Promise<Response>;
+
+async function signIn(email: string) {
+  const csrf = await api("/api/auth/csrf").then((r) => r.json());
+  await api("/api/auth/signin/email", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      csrfToken: csrf.csrfToken,
+      email,
+      callbackUrl: server.url,
+    }),
+  });
+  const ver = await api("/api/test/verification-url").then((r) => r.json());
+  await api(
+    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
+  );
+}
+
+async function createCase(): Promise<string> {
+  const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+  const form = new FormData();
+  form.append("photo", file);
+  const res = await api("/api/upload", { method: "POST", body: form });
+  const data = (await res.json()) as { caseId: string };
+  return data.caseId;
+}
+
+beforeAll(async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
+  server = await startServer(3023, {
+    NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
+  });
+  api = createApi(server);
+});
+
+afterAll(async () => {
+  await server.close();
+});
+
+describe("notes e2e", () => {
+  it("sets case and photo notes", async () => {
+    await signIn("user@example.com");
+    const id = await createCase();
+    let res = await api(`/api/cases/${id}/note`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ note: "hello" }),
+    });
+    expect(res.status).toBe(200);
+    let data = (await res.json()) as {
+      note?: string;
+      photos: string[];
+      photoNotes?: Record<string, string | null>;
+    };
+    expect(data.note).toBe("hello");
+    const photo = data.photos[0];
+    res = await api(`/api/cases/${id}/photo-note`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ photo, note: "img" }),
+    });
+    expect(res.status).toBe(200);
+    data = (await res.json()) as { photoNotes?: Record<string, string | null> };
+    expect(data.photoNotes?.[photo]).toBe("img");
+  });
+});


### PR DESCRIPTION
## Summary
- add editable text fields for case notes and per-photo notes
- sync note state with backend via new API routes
- include end-to-end tests verifying note updates

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858bb0087dc832bacfa429825c77d2b