### PR TITLE
Improve Casbin rules editor

### DIFF
--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -27,8 +27,8 @@ describe("AdminPageClient", () => {
   it("renders users and rules", () => {
     render(<AdminPageClient initialUsers={users} initialRules={rules} />);
     expect(screen.getByText("a@example.com")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("admin")).toBeInTheDocument();
-    expect(screen.getByText(/p, admin, users/)).toBeInTheDocument();
+    expect(screen.getAllByDisplayValue("admin")[0]).toBeInTheDocument();
+    expect(screen.getByDisplayValue("users")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /save rules/i })).toBeDisabled();
   });
 
@@ -54,7 +54,7 @@ describe("AdminPageClient", () => {
       ],
     } as Response);
     render(<AdminPageClient initialUsers={users} initialRules={rules} />);
-    fireEvent.change(screen.getByDisplayValue("admin"), {
+    fireEvent.change(screen.getAllByDisplayValue("admin")[0], {
       target: { value: "user" },
     });
     await waitFor(() =>
@@ -73,14 +73,12 @@ describe("AdminPageClient", () => {
       json: async () => newRules,
     } as Response);
     render(<AdminPageClient initialUsers={users} initialRules={rules} />);
-    fireEvent.change(screen.getAllByRole("textbox")[1], {
-      target: { value: JSON.stringify(newRules, null, 2) },
+    fireEvent.change(screen.getAllByDisplayValue("admin")[1], {
+      target: { value: "user" },
     });
     fireEvent.click(screen.getByRole("button", { name: /save rules/i }));
     await waitFor(() =>
-      expect(
-        screen.getByText((t) => t.includes("user") && t.includes("cases")),
-      ).toBeInTheDocument(),
+      expect(screen.getByDisplayValue("user")).toBeInTheDocument(),
     );
   });
 });

--- a/src/app/api/casbin-rules/route.ts
+++ b/src/app/api/casbin-rules/route.ts
@@ -1,7 +1,10 @@
 import {
   type CasbinRule,
+  addCasbinRule,
+  deleteCasbinRule,
   getCasbinRules,
   replaceCasbinRules,
+  updateCasbinRule,
 } from "@/lib/adminStore";
 import { withAuthorization } from "@/lib/authz";
 import { NextResponse } from "next/server";
@@ -28,6 +31,54 @@ export const PUT = withAuthorization(
   ) => {
     const rules = (await req.json()) as CasbinRule[];
     const updated = await replaceCasbinRules(rules);
+    return NextResponse.json(updated);
+  },
+);
+
+export const POST = withAuthorization(
+  { obj: "superadmin", act: "update" },
+  async (
+    req: Request,
+    _ctx: {
+      params: Promise<Record<string, string>>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
+    const rule = (await req.json()) as CasbinRule;
+    const updated = await addCasbinRule(rule);
+    return NextResponse.json(updated);
+  },
+);
+
+export const PATCH = withAuthorization(
+  { obj: "superadmin", act: "update" },
+  async (
+    req: Request,
+    _ctx: {
+      params: Promise<Record<string, string>>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
+    const { oldRule, newRule } = (await req.json()) as {
+      oldRule: CasbinRule;
+      newRule: CasbinRule;
+    };
+    const updated = await updateCasbinRule(oldRule, newRule);
+    return NextResponse.json(updated);
+  },
+);
+
+export const DELETE = withAuthorization(
+  { obj: "superadmin", act: "update" },
+  async (
+    req: Request,
+    _ctx: {
+      params: Promise<Record<string, string>>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
+    const rule = (await req.json()) as CasbinRule;
+    const updated = await deleteCasbinRule(rule);
     return NextResponse.json(updated);
   },
 );

--- a/src/lib/adminStore.ts
+++ b/src/lib/adminStore.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { reloadEnforcer } from "./authz";
 import { orm } from "./orm";
 import { casbinRules, users } from "./schema";
@@ -60,6 +60,75 @@ export async function replaceCasbinRules(
 ): Promise<CasbinRule[]> {
   orm.delete(casbinRules).run();
   if (rules.length) orm.insert(casbinRules).values(rules).run();
+  await reloadEnforcer();
+  return getCasbinRules();
+}
+
+export async function addCasbinRule(rule: CasbinRule): Promise<CasbinRule[]> {
+  orm
+    .insert(casbinRules)
+    .values({
+      ...rule,
+      v0: rule.v0 ?? null,
+      v1: rule.v1 ?? null,
+      v2: rule.v2 ?? null,
+      v3: rule.v3 ?? null,
+      v4: rule.v4 ?? null,
+      v5: rule.v5 ?? null,
+    })
+    .run();
+  await reloadEnforcer();
+  return getCasbinRules();
+}
+
+export async function updateCasbinRule(
+  oldRule: CasbinRule,
+  newRule: CasbinRule,
+): Promise<CasbinRule[]> {
+  orm
+    .update(casbinRules)
+    .set({
+      ...newRule,
+      v0: newRule.v0 ?? null,
+      v1: newRule.v1 ?? null,
+      v2: newRule.v2 ?? null,
+      v3: newRule.v3 ?? null,
+      v4: newRule.v4 ?? null,
+      v5: newRule.v5 ?? null,
+    })
+    .where(
+      and(
+        eq(casbinRules.ptype, oldRule.ptype),
+        eq(casbinRules.v0, oldRule.v0 ?? null),
+        eq(casbinRules.v1, oldRule.v1 ?? null),
+        eq(casbinRules.v2, oldRule.v2 ?? null),
+        eq(casbinRules.v3, oldRule.v3 ?? null),
+        eq(casbinRules.v4, oldRule.v4 ?? null),
+        eq(casbinRules.v5, oldRule.v5 ?? null),
+      ),
+    )
+    .run();
+  await reloadEnforcer();
+  return getCasbinRules();
+}
+
+export async function deleteCasbinRule(
+  rule: CasbinRule,
+): Promise<CasbinRule[]> {
+  orm
+    .delete(casbinRules)
+    .where(
+      and(
+        eq(casbinRules.ptype, rule.ptype),
+        eq(casbinRules.v0, rule.v0 ?? null),
+        eq(casbinRules.v1, rule.v1 ?? null),
+        eq(casbinRules.v2, rule.v2 ?? null),
+        eq(casbinRules.v3, rule.v3 ?? null),
+        eq(casbinRules.v4, rule.v4 ?? null),
+        eq(casbinRules.v5, rule.v5 ?? null),
+      ),
+    )
+    .run();
   await reloadEnforcer();
   return getCasbinRules();
 }

--- a/test/casbinRulesRoute.test.ts
+++ b/test/casbinRulesRoute.test.ts
@@ -84,4 +84,41 @@ describe("casbin rules API", () => {
     expect(res.status).toBe(200);
     expect(await authorize("admin", "admin", "update")).toBe(true);
   });
+
+  it("supports adding and removing rules", async () => {
+    const mod = await import("@/app/api/casbin-rules/route");
+    let res = await mod.POST(
+      new Request("http://test", {
+        method: "POST",
+        body: JSON.stringify({
+          ptype: "p",
+          v0: "user",
+          v1: "cases",
+          v2: "create",
+        }),
+      }),
+      {
+        params: Promise.resolve({}),
+        session: { user: { role: "superadmin" } },
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(res.status).toBe(200);
+    res = await mod.DELETE(
+      new Request("http://test", {
+        method: "DELETE",
+        body: JSON.stringify({
+          ptype: "p",
+          v0: "user",
+          v1: "cases",
+          v2: "create",
+        }),
+      }),
+      {
+        params: Promise.resolve({}),
+        session: { user: { role: "superadmin" } },
+      },
+    );
+    expect(res.status).toBe(200);
+  });
 });


### PR DESCRIPTION
## Summary
- make casbin rules API support CRUD operations
- overhaul admin UI with table-based editor for rules
- adjust admin page tests for new interface
- add API tests for POST/DELETE
- improve casbin rule data handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858a22db214832bb9376f9e5490ecc5