### PR TITLE
Improve Casbin rules editor

### DIFF
--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -27,8 +27,10 @@ describe("AdminPageClient", () => {
   it("renders users and rules", () => {
     render(<AdminPageClient initialUsers={users} initialRules={rules} />);
     expect(screen.getByText("a@example.com")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("admin")).toBeInTheDocument();
-    expect(screen.getByText(/p, admin, users/)).toBeInTheDocument();
+    expect(screen.getAllByDisplayValue("admin").length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("button", { name: /add rule/i }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /save rules/i })).toBeDisabled();
   });
 
@@ -54,7 +56,7 @@ describe("AdminPageClient", () => {
       ],
     } as Response);
     render(<AdminPageClient initialUsers={users} initialRules={rules} />);
-    fireEvent.change(screen.getByDisplayValue("admin"), {
+    fireEvent.change(screen.getByRole("combobox"), {
       target: { value: "user" },
     });
     await waitFor(() =>
@@ -73,14 +75,12 @@ describe("AdminPageClient", () => {
       json: async () => newRules,
     } as Response);
     render(<AdminPageClient initialUsers={users} initialRules={rules} />);
-    fireEvent.change(screen.getAllByRole("textbox")[1], {
-      target: { value: JSON.stringify(newRules, null, 2) },
-    });
+    const inputs = screen.getAllByRole("textbox");
+    fireEvent.change(inputs[1], { target: { value: "user" } });
+    fireEvent.change(inputs[2], { target: { value: "cases" } });
     fireEvent.click(screen.getByRole("button", { name: /save rules/i }));
     await waitFor(() =>
-      expect(
-        screen.getByText((t) => t.includes("user") && t.includes("cases")),
-      ).toBeInTheDocument(),
+      expect(screen.getByDisplayValue("user")).toBeInTheDocument(),
     );
   });
 });


### PR DESCRIPTION
## Summary
- add editable table UI for Casbin rules
- adjust AdminPageClient tests for new interface

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858a22db214832bb9376f9e5490ecc5