### PR TITLE
Implement case archiving

### DIFF
--- a/src/app/api/cases/[id]/archived/route.ts
+++ b/src/app/api/cases/[id]/archived/route.ts
@@ -1,0 +1,26 @@
+import { withCaseAuthorization } from "@/lib/authz";
+import { getCase, setCaseArchived } from "@/lib/caseStore";
+import { NextResponse } from "next/server";
+
+export const PUT = withCaseAuthorization(
+  { obj: "cases" },
+  async (
+    req: Request,
+    {
+      params,
+      session: _session,
+    }: {
+      params: Promise<{ id: string }>;
+      session?: { user?: { id?: string; role?: string } };
+    },
+  ) => {
+    const { id } = await params;
+    const { archived } = (await req.json()) as { archived: boolean };
+    const updated = setCaseArchived(id, archived);
+    if (!updated) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const layered = getCase(id);
+    return NextResponse.json(layered);
+  },
+);

--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -44,7 +44,7 @@ export default function ClientCasesPage({
 }) {
   const [orderBy, setOrderBy] = useState<Order>("createdAt");
   const [cases, setCases] = useState(() => sortList(initialCases, "createdAt"));
-  const [showClosed, setShowClosed] = useState(false);
+  const [states, setStates] = useState<string[]>(["open"]);
   const [userLocation, setUserLocation] = useState<{
     lat: number;
     lon: number;
@@ -161,20 +161,35 @@ export default function ClientCasesPage({
           <option value="updatedAt">Last Updated</option>
           <option value="distance">Distance from My Location</option>
         </select>
-        <label className="flex items-center gap-1" htmlFor="show-closed">
-          <input
-            id="show-closed"
-            type="checkbox"
-            checked={showClosed}
-            onChange={(e) => setShowClosed(e.target.checked)}
-            className="mr-1"
-          />
-          Show closed cases
+        <label className="flex items-center gap-1" htmlFor="case-states">
+          <span>Show:</span>
+          <select
+            id="case-states"
+            multiple
+            value={states}
+            onChange={(e) =>
+              setStates(
+                Array.from(e.target.selectedOptions).map((o) => o.value),
+              )
+            }
+            className="border rounded p-1 bg-white dark:bg-gray-900"
+          >
+            <option value="open">Open</option>
+            <option value="archived">Archived</option>
+            <option value="closed">Closed</option>
+          </select>
         </label>
       </div>
       <ul className="grid gap-4">
         {cases
-          .filter((c) => showClosed || !c.closed)
+          .filter((c) => {
+            const state = c.archived
+              ? "archived"
+              : c.closed
+                ? "closed"
+                : "open";
+            return states.includes(state);
+          })
           .map((c) => (
             <li
               key={c.id}

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -273,6 +273,19 @@ export default function ClientCasePage({
     await refreshCase();
   }
 
+  async function toggleArchived() {
+    const res = await apiFetch(`/api/cases/${caseId}/archived`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ archived: !(caseData?.archived ?? false) }),
+    });
+    if (!res.ok) {
+      notify("Failed to update status.");
+      return;
+    }
+    await refreshCase();
+  }
+
   async function copyPublicUrl() {
     const url = `${window.location.origin}${withBasePath(
       `/public/cases/${caseId}`,
@@ -525,6 +538,7 @@ export default function ClientCasePage({
               progress={progress}
               canDelete={isAdmin}
               closed={caseData.closed}
+              archived={caseData.archived}
             />
           </div>
         }
@@ -559,7 +573,11 @@ export default function ClientCasePage({
                 </p>
                 <p>
                   <span className="font-semibold">Status:</span>{" "}
-                  {caseData.closed ? "Closed" : "Open"}
+                  {caseData.archived
+                    ? "Archived"
+                    : caseData.closed
+                      ? "Closed"
+                      : "Open"}
                 </p>
                 {caseData.streetAddress ? (
                   <p>

--- a/src/app/cases/__tests__/filterCaseStates.test.tsx
+++ b/src/app/cases/__tests__/filterCaseStates.test.tsx
@@ -36,14 +36,18 @@ const baseCase: Case = {
 
 const closedCase: Case = { ...baseCase, id: "2", closed: true };
 
-describe("show closed cases", () => {
+describe("case state filter", () => {
   it("toggles closed case visibility", () => {
     const { getByLabelText, queryByText } = render(
       <ClientCasesPage initialCases={[baseCase, closedCase]} />,
     );
     expect(queryByText(/Case 2/)).toBeNull();
-    const checkbox = getByLabelText(/show closed cases/i);
-    fireEvent.click(checkbox);
+    const select = getByLabelText(/show/i) as HTMLSelectElement;
+    const closedOption = Array.from(select.options).find(
+      (o) => o.value === "closed",
+    ) as HTMLOptionElement;
+    closedOption.selected = true;
+    fireEvent.change(select);
     expect(queryByText(/Case 2/)).toBeInTheDocument();
   });
 });

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -14,6 +14,7 @@ export default function CaseToolbar({
   progress,
   canDelete = false,
   closed = false,
+  archived = false,
 }: {
   caseId: string;
   disabled?: boolean;
@@ -21,6 +22,7 @@ export default function CaseToolbar({
   progress?: LlmProgress | null;
   canDelete?: boolean;
   closed?: boolean;
+  archived?: boolean;
 }) {
   const reqText = progress
     ? progress.stage === "upload"
@@ -100,6 +102,21 @@ export default function CaseToolbar({
               className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
             >
               Re-run Analysis
+            </button>
+            <button
+              type="button"
+              onClick={async () => {
+                await apiFetch(`/api/cases/${caseId}/archived`, {
+                  method: "PUT",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ archived: !archived }),
+                });
+                window.location.reload();
+              }}
+              data-testid="archive-case-button"
+              className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+            >
+              {archived ? "Unarchive Case" : "Archive Case"}
             </button>
             {disabled ? null : (
               <>

--- a/src/app/components/MultiCaseToolbar.tsx
+++ b/src/app/components/MultiCaseToolbar.tsx
@@ -55,6 +55,24 @@ export default function MultiCaseToolbar({
           >
             Re-run Analysis
           </button>
+          <button
+            type="button"
+            onClick={async () => {
+              await Promise.all(
+                caseIds.map((id) =>
+                  apiFetch(`/api/cases/${id}/archived`, {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ archived: true }),
+                  }),
+                ),
+              );
+              window.location.reload();
+            }}
+            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+          >
+            Archive Cases
+          </button>
           {disabled ? null : (
             <>
               <Link

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -39,6 +39,7 @@ export interface Case {
   ownershipRequests?: OwnershipRequest[];
   threadImages?: ThreadImage[];
   closed?: boolean;
+  archived?: boolean;
 }
 
 export interface SentEmail {
@@ -80,6 +81,9 @@ function rowToCase(row: { id: string; data: string; public: number }): Case {
   }
   if (!("closed" in base)) {
     (base as Partial<Case>).closed = false;
+  }
+  if (!("archived" in base)) {
+    (base as Partial<Case>).archived = false;
   }
   const photos = orm
     .select()
@@ -273,6 +277,7 @@ export function createCase(
     ownershipRequests: [],
     threadImages: [],
     closed: false,
+    archived: false,
   };
   saveCase(newCase);
   if (ownerId) {
@@ -413,6 +418,13 @@ export function setCasePublic(id: string, isPublic: boolean): Case | undefined {
 
 export function setCaseClosed(id: string, closed: boolean): Case | undefined {
   return updateCase(id, { closed });
+}
+
+export function setCaseArchived(
+  id: string,
+  archived: boolean,
+): Case | undefined {
+  return updateCase(id, { archived });
 }
 
 export function deleteCase(id: string): boolean {


### PR DESCRIPTION
## Summary
- add archived flag to Case data model
- expose API to archive a case
- display case status with Archived/Closed/Open
- offer Archive Case actions and archive multiple cases
- filter cases by multiple states
- update tests for multi-state filter

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68595e09741c832bba14d1db4bdeab2c