### PR TITLE
Improve Casbin rules editor

### DIFF
--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { apiFetch } from "@/apiClient";
 import { useSession } from "@/app/useSession";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import AppConfigurationTab from "./AppConfigurationTab";
 
 export interface UserRecord {
@@ -12,6 +12,7 @@ export interface UserRecord {
 }
 
 export interface CasbinRule {
+  id: string;
   ptype: string;
   v0?: string | null;
   v1?: string | null;
@@ -21,26 +22,23 @@ export interface CasbinRule {
   v5?: string | null;
 }
 
+export type RuleInput = Omit<CasbinRule, "id">;
+
 export default function AdminPageClient({
   initialUsers,
   initialRules,
 }: {
   initialUsers: UserRecord[];
-  initialRules: CasbinRule[];
+  initialRules: RuleInput[];
 }) {
   const [users, setUsers] = useState(initialUsers);
-  const [rules, setRules] = useState(initialRules);
+  const [rules, setRules] = useState(() =>
+    initialRules.map((r) => ({ ...r, id: crypto.randomUUID() })),
+  );
   const [tab, setTab] = useState<"users" | "config">("users");
   const [inviteEmail, setInviteEmail] = useState("");
-  const [rulesText, setRulesText] = useState(
-    JSON.stringify(initialRules, null, 2),
-  );
   const { data: session } = useSession();
   const isSuperadmin = session?.user?.role === "superadmin";
-
-  useEffect(() => {
-    setRulesText(JSON.stringify(rules, null, 2));
-  }, [rules]);
 
   async function refreshUsers() {
     const res = await apiFetch("/api/users");
@@ -76,19 +74,50 @@ export default function AdminPageClient({
     refreshUsers();
   }
 
+  function updateRule(
+    id: string,
+    field: keyof Omit<CasbinRule, "id">,
+    value: string,
+  ) {
+    setRules((curr) =>
+      curr.map((r) => (r.id === id ? { ...r, [field]: value } : r)),
+    );
+  }
+
+  function addRule() {
+    setRules((curr) => [
+      ...curr,
+      { id: crypto.randomUUID(), ptype: "p", v0: "", v1: "", v2: "" },
+    ]);
+  }
+
+  function removeRule(id: string) {
+    setRules((curr) => curr.filter((r) => r.id !== id));
+  }
+
   async function saveRules() {
     if (!isSuperadmin) return;
-    try {
-      const parsed = JSON.parse(rulesText) as CasbinRule[];
-      const res = await apiFetch("/api/casbin-rules", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(parsed),
-      });
-      if (res.ok) setRules(await res.json());
-    } catch {
-      alert("Invalid rules JSON");
-    }
+    const cleaned = rules.map((r) => ({
+      ptype: r.ptype,
+      v0: r.v0 || null,
+      v1: r.v1 || null,
+      v2: r.v2 || null,
+      v3: r.v3 || null,
+      v4: r.v4 || null,
+      v5: r.v5 || null,
+    }));
+    const res = await apiFetch("/api/casbin-rules", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(cleaned),
+    });
+    if (res.ok)
+      setRules(
+        (await res.json()).map((r: RuleInput) => ({
+          ...r,
+          id: crypto.randomUUID(),
+        })),
+      );
   }
 
   return (
@@ -161,19 +190,95 @@ export default function AdminPageClient({
             ))}
           </ul>
           <h1 className="text-xl font-bold my-4">Casbin Rules</h1>
-          <ul className="grid gap-1">
-            {rules.map((r) => (
-              <li key={`${r.ptype}-${r.v0}-${r.v1}-${r.v2}`}>
-                {r.ptype}, {r.v0 ?? ""}, {r.v1 ?? ""}, {r.v2 ?? ""}
-              </li>
-            ))}
-          </ul>
-          <textarea
-            value={rulesText}
-            onChange={(e) => setRulesText(e.target.value)}
-            rows={10}
-            className="border p-1 w-full my-2 bg-white dark:bg-gray-900"
-          />
+          <table className="mb-2 border-collapse w-full">
+            <thead>
+              <tr>
+                <th className="border px-1">ptype</th>
+                <th className="border px-1">v0</th>
+                <th className="border px-1">v1</th>
+                <th className="border px-1">v2</th>
+                <th className="border px-1">v3</th>
+                <th className="border px-1">v4</th>
+                <th className="border px-1">v5</th>
+                <th className="border px-1" />
+              </tr>
+            </thead>
+            <tbody>
+              {rules.map((r) => (
+                <tr key={r.id}>
+                  <td className="border">
+                    <input
+                      value={r.ptype}
+                      onChange={(e) =>
+                        updateRule(r.id, "ptype", e.target.value)
+                      }
+                      className="w-full p-1 bg-white dark:bg-gray-900"
+                    />
+                  </td>
+                  <td className="border">
+                    <input
+                      value={r.v0 ?? ""}
+                      onChange={(e) => updateRule(r.id, "v0", e.target.value)}
+                      className="w-full p-1 bg-white dark:bg-gray-900"
+                    />
+                  </td>
+                  <td className="border">
+                    <input
+                      value={r.v1 ?? ""}
+                      onChange={(e) => updateRule(r.id, "v1", e.target.value)}
+                      className="w-full p-1 bg-white dark:bg-gray-900"
+                    />
+                  </td>
+                  <td className="border">
+                    <input
+                      value={r.v2 ?? ""}
+                      onChange={(e) => updateRule(r.id, "v2", e.target.value)}
+                      className="w-full p-1 bg-white dark:bg-gray-900"
+                    />
+                  </td>
+                  <td className="border">
+                    <input
+                      value={r.v3 ?? ""}
+                      onChange={(e) => updateRule(r.id, "v3", e.target.value)}
+                      className="w-full p-1 bg-white dark:bg-gray-900"
+                    />
+                  </td>
+                  <td className="border">
+                    <input
+                      value={r.v4 ?? ""}
+                      onChange={(e) => updateRule(r.id, "v4", e.target.value)}
+                      className="w-full p-1 bg-white dark:bg-gray-900"
+                    />
+                  </td>
+                  <td className="border">
+                    <input
+                      value={r.v5 ?? ""}
+                      onChange={(e) => updateRule(r.id, "v5", e.target.value)}
+                      className="w-full p-1 bg-white dark:bg-gray-900"
+                    />
+                  </td>
+                  <td className="border">
+                    <button
+                      type="button"
+                      onClick={() => removeRule(r.id)}
+                      className="bg-red-500 text-white px-2 py-1 rounded"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="flex gap-2 mb-2">
+            <button
+              type="button"
+              onClick={addRule}
+              className="bg-green-600 text-white px-2 py-1 rounded"
+            >
+              Add Rule
+            </button>
+          </div>
           <button
             type="button"
             onClick={saveRules}

--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -21,14 +21,16 @@ import { apiFetch } from "@/apiClient";
 import AdminPageClient from "@/app/admin/AdminPageClient";
 
 const users = [{ id: "1", email: "a@example.com", name: null, role: "admin" }];
-const rules = [{ ptype: "p", v0: "admin", v1: "users", v2: "read" }];
+const rules = [
+  { id: "rule1", ptype: "p", v0: "admin", v1: "users", v2: "read" },
+];
 
 describe("AdminPageClient", () => {
   it("renders users and rules", () => {
     render(<AdminPageClient initialUsers={users} initialRules={rules} />);
     expect(screen.getByText("a@example.com")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("admin")).toBeInTheDocument();
-    expect(screen.getByText(/p, admin, users/)).toBeInTheDocument();
+    expect(screen.getAllByDisplayValue("admin")[0]).toBeInTheDocument();
+    expect(screen.getByDisplayValue("users")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /save rules/i })).toBeDisabled();
   });
 
@@ -54,7 +56,7 @@ describe("AdminPageClient", () => {
       ],
     } as Response);
     render(<AdminPageClient initialUsers={users} initialRules={rules} />);
-    fireEvent.change(screen.getByDisplayValue("admin"), {
+    fireEvent.change(screen.getAllByDisplayValue("admin")[0], {
       target: { value: "user" },
     });
     await waitFor(() =>
@@ -67,20 +69,20 @@ describe("AdminPageClient", () => {
     vi.mocked(useSession).mockReturnValueOnce({
       data: { user: { role: "superadmin" }, expires: "0" },
     } as unknown as ReturnType<typeof useSessionFn>);
-    const newRules = [{ ptype: "p", v0: "user", v1: "cases", v2: "read" }];
+    const newRules = [
+      { id: "rule2", ptype: "p", v0: "user", v1: "cases", v2: "read" },
+    ];
     vi.mocked(apiFetch).mockResolvedValueOnce({
       ok: true,
       json: async () => newRules,
     } as Response);
     render(<AdminPageClient initialUsers={users} initialRules={rules} />);
-    fireEvent.change(screen.getAllByRole("textbox")[1], {
-      target: { value: JSON.stringify(newRules, null, 2) },
+    fireEvent.change(screen.getAllByDisplayValue("admin")[1], {
+      target: { value: "user" },
     });
     fireEvent.click(screen.getByRole("button", { name: /save rules/i }));
     await waitFor(() =>
-      expect(
-        screen.getByText((t) => t.includes("user") && t.includes("cases")),
-      ).toBeInTheDocument(),
+      expect(screen.getByDisplayValue("user")).toBeInTheDocument(),
     );
   });
 });

--- a/src/app/api/casbin-rules/route.ts
+++ b/src/app/api/casbin-rules/route.ts
@@ -1,7 +1,10 @@
 import {
   type CasbinRule,
+  addCasbinRule,
+  deleteCasbinRule,
   getCasbinRules,
   replaceCasbinRules,
+  updateCasbinRule,
 } from "@/lib/adminStore";
 import { withAuthorization } from "@/lib/authz";
 import { NextResponse } from "next/server";
@@ -28,6 +31,54 @@ export const PUT = withAuthorization(
   ) => {
     const rules = (await req.json()) as CasbinRule[];
     const updated = await replaceCasbinRules(rules);
+    return NextResponse.json(updated);
+  },
+);
+
+export const POST = withAuthorization(
+  { obj: "superadmin", act: "update" },
+  async (
+    req: Request,
+    _ctx: {
+      params: Promise<Record<string, string>>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
+    const rule = (await req.json()) as CasbinRule;
+    const updated = await addCasbinRule(rule);
+    return NextResponse.json(updated);
+  },
+);
+
+export const PATCH = withAuthorization(
+  { obj: "superadmin", act: "update" },
+  async (
+    req: Request,
+    _ctx: {
+      params: Promise<Record<string, string>>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
+    const { oldRule, newRule } = (await req.json()) as {
+      oldRule: CasbinRule;
+      newRule: CasbinRule;
+    };
+    const updated = await updateCasbinRule(oldRule, newRule);
+    return NextResponse.json(updated);
+  },
+);
+
+export const DELETE = withAuthorization(
+  { obj: "superadmin", act: "update" },
+  async (
+    req: Request,
+    _ctx: {
+      params: Promise<Record<string, string>>;
+      session?: { user?: { role?: string } };
+    },
+  ) => {
+    const rule = (await req.json()) as CasbinRule;
+    const updated = await deleteCasbinRule(rule);
     return NextResponse.json(updated);
   },
 );

--- a/src/lib/adminStore.ts
+++ b/src/lib/adminStore.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { reloadEnforcer } from "./authz";
 import { orm } from "./orm";
 import { casbinRules, users } from "./schema";
@@ -60,6 +60,75 @@ export async function replaceCasbinRules(
 ): Promise<CasbinRule[]> {
   orm.delete(casbinRules).run();
   if (rules.length) orm.insert(casbinRules).values(rules).run();
+  await reloadEnforcer();
+  return getCasbinRules();
+}
+
+export async function addCasbinRule(rule: CasbinRule): Promise<CasbinRule[]> {
+  orm
+    .insert(casbinRules)
+    .values({
+      ...rule,
+      v0: rule.v0 ?? null,
+      v1: rule.v1 ?? null,
+      v2: rule.v2 ?? null,
+      v3: rule.v3 ?? null,
+      v4: rule.v4 ?? null,
+      v5: rule.v5 ?? null,
+    })
+    .run();
+  await reloadEnforcer();
+  return getCasbinRules();
+}
+
+export async function updateCasbinRule(
+  oldRule: CasbinRule,
+  newRule: CasbinRule,
+): Promise<CasbinRule[]> {
+  orm
+    .update(casbinRules)
+    .set({
+      ...newRule,
+      v0: newRule.v0 ?? null,
+      v1: newRule.v1 ?? null,
+      v2: newRule.v2 ?? null,
+      v3: newRule.v3 ?? null,
+      v4: newRule.v4 ?? null,
+      v5: newRule.v5 ?? null,
+    })
+    .where(
+      and(
+        eq(casbinRules.ptype, oldRule.ptype),
+        eq(casbinRules.v0, oldRule.v0 ?? null),
+        eq(casbinRules.v1, oldRule.v1 ?? null),
+        eq(casbinRules.v2, oldRule.v2 ?? null),
+        eq(casbinRules.v3, oldRule.v3 ?? null),
+        eq(casbinRules.v4, oldRule.v4 ?? null),
+        eq(casbinRules.v5, oldRule.v5 ?? null),
+      ),
+    )
+    .run();
+  await reloadEnforcer();
+  return getCasbinRules();
+}
+
+export async function deleteCasbinRule(
+  rule: CasbinRule,
+): Promise<CasbinRule[]> {
+  orm
+    .delete(casbinRules)
+    .where(
+      and(
+        eq(casbinRules.ptype, rule.ptype),
+        eq(casbinRules.v0, rule.v0 ?? null),
+        eq(casbinRules.v1, rule.v1 ?? null),
+        eq(casbinRules.v2, rule.v2 ?? null),
+        eq(casbinRules.v3, rule.v3 ?? null),
+        eq(casbinRules.v4, rule.v4 ?? null),
+        eq(casbinRules.v5, rule.v5 ?? null),
+      ),
+    )
+    .run();
   await reloadEnforcer();
   return getCasbinRules();
 }

--- a/test/casbinRulesRoute.test.ts
+++ b/test/casbinRulesRoute.test.ts
@@ -84,4 +84,41 @@ describe("casbin rules API", () => {
     expect(res.status).toBe(200);
     expect(await authorize("admin", "admin", "update")).toBe(true);
   });
+
+  it("supports adding and removing rules", async () => {
+    const mod = await import("@/app/api/casbin-rules/route");
+    let res = await mod.POST(
+      new Request("http://test", {
+        method: "POST",
+        body: JSON.stringify({
+          ptype: "p",
+          v0: "user",
+          v1: "cases",
+          v2: "create",
+        }),
+      }),
+      {
+        params: Promise.resolve({}),
+        session: { user: { role: "superadmin" } },
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(res.status).toBe(200);
+    res = await mod.DELETE(
+      new Request("http://test", {
+        method: "DELETE",
+        body: JSON.stringify({
+          ptype: "p",
+          v0: "user",
+          v1: "cases",
+          v2: "create",
+        }),
+      }),
+      {
+        params: Promise.resolve({}),
+        session: { user: { role: "superadmin" } },
+      },
+    );
+    expect(res.status).toBe(200);
+  });
 });


### PR DESCRIPTION
## Summary
- make casbin rules API support CRUD operations
- overhaul admin UI with table-based editor for rules
- adjust admin page tests for new interface
- add API tests for POST/DELETE
- improve casbin rule data handling
- keep focus while typing in Casbin rule inputs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858a22db214832bb9376f9e5490ecc5