### PR TITLE
Add confirmation to Casbin rule removal

### DIFF
--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -109,6 +109,19 @@ export default function AdminPageClient({
       v4: r.v4 || null,
       v5: r.v5 || null,
     }));
+    const hasEdit = cleaned.some(
+      (r) =>
+        r.ptype === "p" &&
+        r.v0 === "superadmin" &&
+        r.v1 === "superadmin" &&
+        r.v2 === "update",
+    );
+    if (!hasEdit) {
+      const confirmed = window.confirm(
+        "These changes will remove your ability to edit Casbin rules. Continue?",
+      );
+      if (!confirmed) return;
+    }
     const res = await apiFetch("/api/casbin-rules", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },

--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -69,6 +69,7 @@ describe("AdminPageClient", () => {
     vi.mocked(useSession).mockReturnValueOnce({
       data: { user: { role: "superadmin" }, expires: "0" },
     } as unknown as ReturnType<typeof useSessionFn>);
+    vi.spyOn(window, "confirm").mockReturnValueOnce(true);
     const newRules = [
       { id: "rule2", ptype: "p", v0: "user", v1: "cases", v2: "read" },
     ];
@@ -84,5 +85,17 @@ describe("AdminPageClient", () => {
     await waitFor(() =>
       expect(screen.getByDisplayValue("user")).toBeInTheDocument(),
     );
+  });
+
+  it("asks for confirmation if edit access would be removed", () => {
+    vi.mocked(useSession).mockReturnValueOnce({
+      data: { user: { role: "superadmin" }, expires: "0" },
+    } as unknown as ReturnType<typeof useSessionFn>);
+    vi.mocked(apiFetch).mockReset();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValueOnce(false);
+    render(<AdminPageClient initialUsers={users} initialRules={rules} />);
+    fireEvent.click(screen.getByRole("button", { name: /save rules/i }));
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(apiFetch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- warn if saving Casbin rules would remove ability to edit them
- update tests for confirmation step

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596654b5b4832b826ef6889ef5d979