### PR TITLE
Add profile page

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,35 @@
+import { loadAuthContext } from "@/lib/authz";
+import { getUser, updateUser } from "@/lib/userStore";
+import { NextResponse } from "next/server";
+
+export async function GET(
+  _req: Request,
+  ctx: {
+    params: Promise<Record<string, string>>;
+    session?: { user?: { id?: string } };
+  },
+) {
+  const { userId } = await loadAuthContext(ctx, "user");
+  if (!userId) return new Response(null, { status: 401 });
+  const user = getUser(userId);
+  if (!user) return new Response(null, { status: 404 });
+  return NextResponse.json(user);
+}
+
+export async function PUT(
+  req: Request,
+  ctx: {
+    params: Promise<Record<string, string>>;
+    session?: { user?: { id?: string } };
+  },
+) {
+  const { userId } = await loadAuthContext(ctx, "user");
+  if (!userId) return new Response(null, { status: 401 });
+  const { name, image } = (await req.json()) as {
+    name?: string | null;
+    image?: string | null;
+  };
+  const user = updateUser(userId, { name, image });
+  if (!user) return new Response(null, { status: 404 });
+  return NextResponse.json(user);
+}

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -26,8 +26,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useNotify } from "../../components/NotificationProvider";
 import { FaShare } from "react-icons/fa";
+import { useNotify } from "../../components/NotificationProvider";
 
 function buildThreads(c: Case): SentEmail[] {
   const mails = c.sentEmails ?? [];

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -77,6 +77,12 @@ export default function NavBar() {
         >
           User Settings
         </Link>
+        <Link
+          href="/profile"
+          className="hover:text-gray-600 dark:hover:text-gray-300"
+        >
+          Profile
+        </Link>
         {session ? (
           <button
             type="button"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default async function RootLayout({
             <NavBar />
             {children}
           </AuthProvider>
-        <NotificationProvider>
+        </NotificationProvider>
       </body>
     </html>
   );

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useSession } from "../useSession";
+
+export default function ProfilePage() {
+  const { data: session } = useSession();
+  const [name, setName] = useState("");
+  const [image, setImage] = useState("");
+
+  useEffect(() => {
+    if (session) {
+      fetch("/api/profile")
+        .then((r) => r.json())
+        .then((data) => {
+          setName(data.name ?? "");
+          setImage(data.image ?? "");
+        });
+    }
+  }, [session]);
+
+  if (!session) {
+    return <div className="p-8">You are not logged in.</div>;
+  }
+
+  return (
+    <form
+      className="p-8 flex flex-col gap-2"
+      onSubmit={async (e) => {
+        e.preventDefault();
+        await fetch("/api/profile", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, image }),
+        });
+      }}
+    >
+      <h1 className="text-xl font-bold mb-4">User Profile</h1>
+      <label htmlFor="name">Name</label>
+      <input
+        id="name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="border p-2"
+      />
+      <label htmlFor="image">Image URL</label>
+      <input
+        id="image"
+        value={image}
+        onChange={(e) => setImage(e.target.value)}
+        className="border p-2"
+      />
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+        Save
+      </button>
+    </form>
+  );
+}

--- a/src/lib/userStore.ts
+++ b/src/lib/userStore.ts
@@ -1,0 +1,28 @@
+import { eq } from "drizzle-orm";
+import { orm } from "./orm";
+import { users } from "./schema";
+
+export interface UserRecord {
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  role: string;
+}
+
+export function getUser(id: string): UserRecord | null {
+  const row = orm.select().from(users).where(eq(users.id, id)).get();
+  return row ? { ...row } : null;
+}
+
+export function updateUser(
+  id: string,
+  updates: Partial<Pick<UserRecord, "name" | "image">>,
+): UserRecord | null {
+  const data: Record<string, string | null> = {};
+  if (updates.name !== undefined) data.name = updates.name;
+  if (updates.image !== undefined) data.image = updates.image;
+  if (Object.keys(data).length)
+    orm.update(users).set(data).where(eq(users.id, id)).run();
+  return getUser(id);
+}

--- a/test/profileRoute.test.ts
+++ b/test/profileRoute.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let dataDir: string;
+
+beforeEach(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
+  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
+  vi.resetModules();
+  const db = await import("@/lib/db");
+  await db.migrationsReady;
+  const { orm } = await import("@/lib/orm");
+  const { users } = await import("@/lib/schema");
+  orm
+    .insert(users)
+    .values({ id: "u1", name: "Alice", email: "a@example.com" })
+    .run();
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  vi.resetModules();
+  process.env.CASE_STORE_FILE = undefined;
+});
+
+describe("profile API", () => {
+  it("reads and updates profile", async () => {
+    const mod = await import("@/app/api/profile/route");
+    const getRes = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({}),
+      session: { user: { id: "u1" } },
+    });
+    const user = await getRes.json();
+    expect(user.name).toBe("Alice");
+
+    const req = new Request("http://test", {
+      method: "PUT",
+      body: JSON.stringify({ name: "Bob" }),
+    });
+    await mod.PUT(req, {
+      params: Promise.resolve({}),
+      session: { user: { id: "u1" } },
+    });
+
+    const { getUser } = await import("@/lib/userStore");
+    const updated = getUser("u1");
+    expect(updated?.name).toBe("Bob");
+  });
+});


### PR DESCRIPTION
## Summary
- add user profile data store
- create API for viewing/updating current user's profile
- expose profile page with editable form
- link to profile in navigation bar
- test profile API behavior

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858bb31aed8832b93274b00218b455d