### PR TITLE
Show member name or email on case page

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -81,7 +81,12 @@ export default function ClientCasePage({
   const [note, setNote] = useState<string>(initialCase?.note || "");
   const [photoNote, setPhotoNote] = useState<string>("");
   const [members, setMembers] = useState<
-    Array<{ userId: string; role: string }>
+    Array<{
+      userId: string;
+      role: string;
+      name: string | null;
+      email: string | null;
+    }>
   >([]);
   const [inviteUserId, setInviteUserId] = useState("");
   const [copied, setCopied] = useState(false);
@@ -666,7 +671,7 @@ export default function ClientCasePage({
                     {members.map((m) => (
                       <li key={m.userId} className="flex items-center gap-2">
                         <span className="flex-1">
-                          {m.userId} ({m.role})
+                          {m.name ?? m.email ?? m.userId} ({m.role})
                         </span>
                         {canManageMembers && m.role !== "owner" ? (
                           <button

--- a/src/lib/caseMembers.ts
+++ b/src/lib/caseMembers.ts
@@ -1,6 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import { orm } from "./orm";
-import { caseMembers } from "./schema";
+import { caseMembers, users } from "./schema";
 
 export type CaseMemberRole = "owner" | "collaborator";
 
@@ -21,8 +21,14 @@ export function removeCaseMember(caseId: string, userId: string): void {
 
 export function listCaseMembers(caseId: string) {
   return orm
-    .select()
+    .select({
+      userId: caseMembers.userId,
+      role: caseMembers.role,
+      name: users.name,
+      email: users.email,
+    })
     .from(caseMembers)
+    .leftJoin(users, eq(caseMembers.userId, users.id))
     .where(eq(caseMembers.caseId, caseId))
     .all();
 }


### PR DESCRIPTION
## Summary
- join `users` table when listing case members so their name and email are available
- show member `name` or `email` instead of user id on the case page

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68596eeb2d70832bb40ca61ce6d2d2b0