### PR TITLE
Fix TypeScript errors

### DIFF
--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -30,21 +30,22 @@ const groupOptions = {
 
 function normalizeRule(rule: RuleInput): RuleInput {
   if (rule.ptype === "p") {
-    const v0s = Object.keys(policyOptions);
+    const v0s = Object.keys(policyOptions) as Array<keyof typeof policyOptions>;
     if (!rule.v0 || !v0s.includes(rule.v0)) rule.v0 = v0s[0];
     const v1s = Object.keys(
       policyOptions[rule.v0 as keyof typeof policyOptions],
-    );
+    ) as Array<keyof (typeof policyOptions)[keyof typeof policyOptions]>;
     if (!rule.v1 || !v1s.includes(rule.v1)) rule.v1 = v1s[0];
-    const v2s =
-      policyOptions[rule.v0 as keyof typeof policyOptions][
-        rule.v1 as keyof (typeof policyOptions)[keyof typeof policyOptions]
-      ];
+    const v2s = policyOptions[rule.v0 as keyof typeof policyOptions][
+      rule.v1 as keyof (typeof policyOptions)[keyof typeof policyOptions]
+    ] as readonly string[];
     if (!rule.v2 || !v2s.includes(rule.v2)) rule.v2 = v2s[0];
   } else {
-    const v0s = Object.keys(groupOptions);
+    const v0s = Object.keys(groupOptions) as Array<keyof typeof groupOptions>;
     if (!rule.v0 || !v0s.includes(rule.v0)) rule.v0 = v0s[0];
-    const v1s = groupOptions[rule.v0 as keyof typeof groupOptions];
+    const v1s = groupOptions[
+      rule.v0 as keyof typeof groupOptions
+    ] as readonly string[];
     if (!rule.v1 || !v1s.includes(rule.v1)) rule.v1 = v1s[0];
     rule.v2 = null;
   }
@@ -130,7 +131,9 @@ export default function AdminPageClient({
   ) {
     setRules((curr) =>
       curr.map((r) =>
-        r.id === id ? normalizeRule({ ...r, [field]: value }) : r,
+        r.id === id
+          ? { ...normalizeRule({ ...r, [field]: value }), id: r.id }
+          : r,
       ),
     );
   }

--- a/src/lib/adminStore.ts
+++ b/src/lib/adminStore.ts
@@ -1,8 +1,13 @@
 import crypto from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { type AnyColumn, and, eq } from "drizzle-orm";
+import { isNull } from "drizzle-orm/sql";
 import { reloadEnforcer } from "./authz";
 import { orm } from "./orm";
 import { casbinRules, users } from "./schema";
+
+function eqMaybeNull(column: AnyColumn, value: string | null | undefined) {
+  return value == null ? isNull(column) : eq(column, value);
+}
 
 export interface UserRecord {
   id: string;
@@ -99,12 +104,12 @@ export async function updateCasbinRule(
     .where(
       and(
         eq(casbinRules.ptype, oldRule.ptype),
-        eq(casbinRules.v0, oldRule.v0 ?? null),
-        eq(casbinRules.v1, oldRule.v1 ?? null),
-        eq(casbinRules.v2, oldRule.v2 ?? null),
-        eq(casbinRules.v3, oldRule.v3 ?? null),
-        eq(casbinRules.v4, oldRule.v4 ?? null),
-        eq(casbinRules.v5, oldRule.v5 ?? null),
+        eqMaybeNull(casbinRules.v0, oldRule.v0),
+        eqMaybeNull(casbinRules.v1, oldRule.v1),
+        eqMaybeNull(casbinRules.v2, oldRule.v2),
+        eqMaybeNull(casbinRules.v3, oldRule.v3),
+        eqMaybeNull(casbinRules.v4, oldRule.v4),
+        eqMaybeNull(casbinRules.v5, oldRule.v5),
       ),
     )
     .run();
@@ -120,12 +125,12 @@ export async function deleteCasbinRule(
     .where(
       and(
         eq(casbinRules.ptype, rule.ptype),
-        eq(casbinRules.v0, rule.v0 ?? null),
-        eq(casbinRules.v1, rule.v1 ?? null),
-        eq(casbinRules.v2, rule.v2 ?? null),
-        eq(casbinRules.v3, rule.v3 ?? null),
-        eq(casbinRules.v4, rule.v4 ?? null),
-        eq(casbinRules.v5, rule.v5 ?? null),
+        eqMaybeNull(casbinRules.v0, rule.v0),
+        eqMaybeNull(casbinRules.v1, rule.v1),
+        eqMaybeNull(casbinRules.v2, rule.v2),
+        eqMaybeNull(casbinRules.v3, rule.v3),
+        eqMaybeNull(casbinRules.v4, rule.v4),
+        eqMaybeNull(casbinRules.v5, rule.v5),
       ),
     )
     .run();

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -76,7 +76,7 @@ export interface ThreadImage {
 function rowToCase(row: { id: string; data: string; public: number }): Case {
   const base = JSON.parse(row.data) as Omit<
     Case,
-    "photos" | "photoTimes" | "photoGps" | "photoNotes"
+    "photos" | "photoTimes" | "photoGps"
   >;
   if (!("updatedAt" in base)) {
     (base as Partial<Case>).updatedAt = (base as Partial<Case>).createdAt;

--- a/test/e2e/notes.test.ts
+++ b/test/e2e/notes.test.ts
@@ -58,7 +58,7 @@ describe("notes e2e", () => {
       body: JSON.stringify({ note: "hello" }),
     });
     expect(res.status).toBe(200);
-    let data = (await res.json()) as {
+    const data = (await res.json()) as {
       note?: string;
       photos: string[];
       photoNotes?: Record<string, string | null>;
@@ -71,7 +71,11 @@ describe("notes e2e", () => {
       body: JSON.stringify({ photo, note: "img" }),
     });
     expect(res.status).toBe(200);
-    data = (await res.json()) as { photoNotes?: Record<string, string | null> };
-    expect(data.photoNotes?.[photo]).toBe("img");
+    const data2 = (await res.json()) as {
+      photoNotes?: Record<string, string | null>;
+      photos: string[];
+      note?: string;
+    };
+    expect(data2.photoNotes?.[photo]).toBe("img");
   });
 });

--- a/test/e2e/websiteImages.test.ts
+++ b/test/e2e/websiteImages.test.ts
@@ -34,6 +34,7 @@ describe("generateWebsiteImages", () => {
       WEBSITE_DIR: site,
       OPENAI_API_KEY: "x",
       OPENAI_BASE_URL: stub.url,
+      NODE_ENV: "test",
     });
     expect(res.status).toBe(0);
     expect(stub.requests.length).toBe(1);


### PR DESCRIPTION
## Summary
- cast option arrays in admin client for proper inference
- preserve rule id when editing rules
- compare nullable Casbin rule fields with helper
- parse `photoNotes` from stored case data
- update e2e tests to satisfy TypeScript

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68596e6c944c832ba61a87324a11dfac