### PR TITLE
Add system status page

### DIFF
--- a/src/app/api/system/jobs/route.ts
+++ b/src/app/api/system/jobs/route.ts
@@ -1,0 +1,13 @@
+import { withAuthorization } from "@/lib/authz";
+import { listJobs } from "@/lib/jobScheduler";
+import { NextResponse } from "next/server";
+
+export const GET = withAuthorization(
+  { obj: "superadmin" },
+  async (req: Request) => {
+    const url = new URL(req.url);
+    const type = url.searchParams.get("type") ?? undefined;
+    const data = listJobs(type);
+    return NextResponse.json(data);
+  },
+);

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -77,6 +77,14 @@ export default function NavBar() {
             Admin
           </Link>
         ) : null}
+        {session?.user?.role === "superadmin" ? (
+          <Link
+            href="/system-status"
+            className="hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            System Status
+          </Link>
+        ) : null}
         <Link
           href="/settings"
           className="hover:text-gray-600 dark:hover:text-gray-300"

--- a/src/app/system-status/SystemStatusClient.tsx
+++ b/src/app/system-status/SystemStatusClient.tsx
@@ -1,0 +1,79 @@
+"use client";
+import { apiFetch } from "@/apiClient";
+import { useCallback, useEffect, useState } from "react";
+
+interface JobInfo {
+  id: number;
+  type: string;
+  startedAt: number;
+}
+
+interface JobResponse {
+  jobs: JobInfo[];
+  auditedAt: number;
+  updatedAt: number;
+}
+
+export default function SystemStatusClient() {
+  const [jobs, setJobs] = useState<JobInfo[]>([]);
+  const [auditedAt, setAuditedAt] = useState<number>(0);
+  const [updatedAt, setUpdatedAt] = useState<number>(0);
+  const [filter, setFilter] = useState<string>("");
+
+  const refresh = useCallback(async (t: string) => {
+    const url = t
+      ? `/api/system/jobs?type=${encodeURIComponent(t)}`
+      : "/api/system/jobs";
+    const res = await apiFetch(url);
+    if (res.ok) {
+      const data: JobResponse = await res.json();
+      setJobs(data.jobs);
+      setAuditedAt(data.auditedAt);
+      setUpdatedAt(data.updatedAt);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh(filter);
+  }, [filter, refresh]);
+
+  const types = Array.from(new Set(jobs.map((j) => j.type)));
+
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">System Status</h1>
+      <p className="mb-2 text-sm text-gray-600 dark:text-gray-400">
+        Last audit: {auditedAt ? new Date(auditedAt).toLocaleString() : "n/a"}
+        {" | "}
+        Last update: {updatedAt ? new Date(updatedAt).toLocaleString() : "n/a"}
+      </p>
+      <label className="block mb-4">
+        <span className="mr-2">Job Type:</span>
+        <select
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          className="border p-1"
+        >
+          <option value="">All</option>
+          {types.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </label>
+      {jobs.length === 0 ? (
+        <p>No active jobs.</p>
+      ) : (
+        <ul className="grid gap-2">
+          {jobs.map((j) => (
+            <li key={j.id} className="border p-2">
+              <span className="font-mono mr-2">{j.type}</span>
+              {new Date(j.startedAt).toLocaleString()}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/system-status/__tests__/SystemStatusPage.test.tsx
+++ b/src/app/system-status/__tests__/SystemStatusPage.test.tsx
@@ -1,0 +1,47 @@
+import SystemStatusPage from "@/app/system-status/page";
+import { getServerSession } from "next-auth/next";
+import { expect, it, vi } from "vitest";
+
+vi.mock("next-auth/next", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/authOptions", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/authz", () => ({
+  withAuthorization:
+    (
+      _opts: unknown,
+      handler: (
+        req: Request,
+        ctx: { session?: { user?: { role?: string } } },
+      ) => unknown,
+    ) =>
+    async (req: Request, ctx: { session?: { user?: { role?: string } } }) => {
+      return ctx.session?.user?.role === "superadmin"
+        ? handler(req, ctx)
+        : new Response(null, { status: 403 });
+    },
+}));
+
+it("returns 403 for non-superadmin", async () => {
+  (
+    getServerSession as unknown as { mockResolvedValue: (v: unknown) => void }
+  ).mockResolvedValue({
+    user: { role: "admin" },
+  });
+  const res = (await SystemStatusPage()) as Response;
+  expect(res.status).toBe(403);
+});
+
+it("renders for superadmin", async () => {
+  (
+    getServerSession as unknown as { mockResolvedValue: (v: unknown) => void }
+  ).mockResolvedValue({
+    user: { role: "superadmin" },
+  });
+  const res = await SystemStatusPage();
+  expect(res).not.toBeInstanceOf(Response);
+});

--- a/src/app/system-status/page.tsx
+++ b/src/app/system-status/page.tsx
@@ -1,0 +1,21 @@
+import { authOptions } from "@/lib/authOptions";
+import { withAuthorization } from "@/lib/authz";
+import { getServerSession } from "next-auth/next";
+import SystemStatusClient from "./SystemStatusClient";
+
+export const dynamic = "force-dynamic";
+
+const handler = withAuthorization(
+  { obj: "superadmin" },
+  async (_req: Request, _ctx: { session?: { user?: { role?: string } } }) => {
+    return <SystemStatusClient />;
+  },
+);
+
+export default async function SystemStatusPage() {
+  const session = await getServerSession(authOptions);
+  return handler(new Request("http://localhost"), {
+    params: Promise.resolve({}),
+    session: session ?? undefined,
+  });
+}

--- a/src/lib/jobScheduler.ts
+++ b/src/lib/jobScheduler.ts
@@ -2,12 +2,78 @@ import path from "node:path";
 import { Worker } from "node:worker_threads";
 import { caseEvents } from "./caseEvents";
 
+interface TrackedJob {
+  type: string;
+  worker: Worker;
+  startedAt: number;
+}
+
+const globalStore = globalThis as unknown as {
+  activeJobs?: Map<number, TrackedJob>;
+  auditTimer?: NodeJS.Timer;
+  lastAudit?: number;
+  lastUpdate?: number;
+};
+
+export const activeJobs: Map<number, TrackedJob> =
+  globalStore.activeJobs ?? new Map();
+
+if (!globalStore.activeJobs) {
+  globalStore.activeJobs = activeJobs;
+}
+
+let lastAudit = globalStore.lastAudit ?? 0;
+let lastUpdate = globalStore.lastUpdate ?? Date.now();
+
+function auditJobs() {
+  lastAudit = Date.now();
+  let changed = false;
+  for (const [id, job] of activeJobs) {
+    if (job.worker.threadId === -1) {
+      activeJobs.delete(id);
+      changed = true;
+    }
+  }
+  if (changed) {
+    lastUpdate = lastAudit;
+  }
+  globalStore.lastAudit = lastAudit;
+  globalStore.lastUpdate = lastUpdate;
+}
+
+if (!globalStore.auditTimer) {
+  globalStore.auditTimer = setInterval(auditJobs, 30_000);
+  globalStore.auditTimer.unref();
+}
+
+export function listJobs(type?: string) {
+  auditJobs();
+  const jobs = Array.from(activeJobs.values()).map((j) => ({
+    id: j.worker.threadId,
+    type: j.type,
+    startedAt: j.startedAt,
+  }));
+  const filtered = type ? jobs.filter((j) => j.type === type) : jobs;
+  return {
+    jobs: filtered,
+    auditedAt: lastAudit,
+    updatedAt: lastUpdate,
+  };
+}
+
 export function runJob(name: string, jobData: unknown): Worker {
   const jobPath = path.join(process.cwd(), "src", "jobs", `${name}.ts`);
   const wrapper = path.join(process.cwd(), "src", "jobs", "workerWrapper.js");
   const worker = new Worker(wrapper, {
     workerData: { path: jobPath, jobData },
   });
+  activeJobs.set(worker.threadId, {
+    type: name,
+    worker,
+    startedAt: Date.now(),
+  });
+  lastUpdate = Date.now();
+  globalStore.lastUpdate = lastUpdate;
   worker.on("message", (msg) => {
     if (msg && msg.event === "update") {
       caseEvents.emit("update", msg.data);
@@ -16,5 +82,14 @@ export function runJob(name: string, jobData: unknown): Worker {
   worker.on("error", (err) => {
     console.error(`${name} worker failed`, err);
   });
+  const cleanup = () => {
+    activeJobs.delete(worker.threadId);
+    lastUpdate = Date.now();
+    globalStore.lastUpdate = lastUpdate;
+  };
+  worker.once("exit", cleanup);
+  worker.once("error", cleanup);
   return worker;
 }
+
+export { auditJobs, lastAudit, lastUpdate };

--- a/test/systemJobsRoute.test.ts
+++ b/test/systemJobsRoute.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Worker } from "node:worker_threads";
+
+let dataDir: string;
+let mod: typeof import("@/app/api/system/jobs/route");
+let jobScheduler: typeof import("@/lib/jobScheduler");
+let orm: typeof import("@/lib/orm").orm;
+let schema: typeof import("@/lib/schema");
+
+beforeEach(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
+  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
+  vi.resetModules();
+  const db = await import("@/lib/db");
+  await db.migrationsReady;
+  ({ orm } = await import("@/lib/orm"));
+  schema = await import("@/lib/schema");
+  orm
+    .insert(schema.casbinRules)
+    .values({ ptype: "p", v0: "superadmin", v1: "superadmin", v2: "read" })
+    .run();
+  mod = await import("@/app/api/system/jobs/route");
+  jobScheduler = await import("@/lib/jobScheduler");
+  jobScheduler.activeJobs.clear();
+});
+
+afterEach(() => {
+  jobScheduler.activeJobs.clear();
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  vi.resetModules();
+  process.env.CASE_STORE_FILE = undefined;
+});
+
+describe("system jobs API", () => {
+  it("rejects non-superadmin", async () => {
+    const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({}),
+      session: { user: { role: "admin" } },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("lists, audits and filters jobs", async () => {
+    jobScheduler.activeJobs.set(1, {
+      type: "a",
+      worker: { threadId: 1 } as Worker,
+      startedAt: 1,
+    });
+    jobScheduler.activeJobs.set(2, {
+      type: "b",
+      worker: { threadId: -1 } as Worker,
+      startedAt: 2,
+    });
+    const res = await mod.GET(new Request("http://test?type=a"), {
+      params: Promise.resolve({}),
+      session: { user: { role: "superadmin" } },
+    });
+    expect(res.status).toBe(200);
+    const { jobs, auditedAt, updatedAt } = await res.json();
+    expect(jobs).toEqual([{ id: 1, type: "a", startedAt: 1 }]);
+    expect(auditedAt).toBeGreaterThan(0);
+    expect(updatedAt).toBeGreaterThanOrEqual(auditedAt);
+  });
+});


### PR DESCRIPTION
## Summary
- track active background jobs in jobScheduler
- expose active job list via `/api/system/jobs`
- add system status page for super admins
- link system status in the navbar
- test job tracking API and page access
- audit active jobs periodically and display audit timestamps
- remove redundant superadmin check

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859767c92c8832ba4e771b6340fa126