### PR TITLE
Add credit tracking system

### DIFF
--- a/migrations/0014_user_credits.sql
+++ b/migrations/0014_user_credits.sql
@@ -1,0 +1,8 @@
+ALTER TABLE user ADD COLUMN credits INTEGER NOT NULL DEFAULT 0;
+CREATE TABLE IF NOT EXISTS credit_transactions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  amount INTEGER NOT NULL,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY(user_id) REFERENCES user(id) ON DELETE CASCADE
+);

--- a/migrations/0015_credit_policies.sql
+++ b/migrations/0015_credit_policies.sql
@@ -1,0 +1,3 @@
+INSERT INTO casbin_rules (ptype, v0, v1, v2) VALUES
+  ('p', 'user', 'credits', 'read'),
+  ('p', 'user', 'credits', 'update');

--- a/src/app/api/credits/add/route.ts
+++ b/src/app/api/credits/add/route.ts
@@ -1,0 +1,21 @@
+import { withAuthorization } from "@/lib/authz";
+import { getCreditSettings } from "@/lib/creditSettings";
+import { addCredits } from "@/lib/credits";
+import { NextResponse } from "next/server";
+
+export const POST = withAuthorization(
+  { obj: "credits", act: "update" },
+  async (
+    req: Request,
+    { session }: { session?: { user?: { id?: string } } },
+  ) => {
+    if (!session?.user?.id) {
+      return new Response(null, { status: 401 });
+    }
+    const { usd } = (await req.json()) as { usd: number };
+    const { usdPerCredit } = getCreditSettings();
+    const credits = Math.floor(usd / usdPerCredit);
+    const balance = addCredits(session.user.id, credits);
+    return NextResponse.json({ balance });
+  },
+);

--- a/src/app/api/credits/balance/route.ts
+++ b/src/app/api/credits/balance/route.ts
@@ -1,0 +1,17 @@
+import { withAuthorization } from "@/lib/authz";
+import { getCreditBalance } from "@/lib/credits";
+import { NextResponse } from "next/server";
+
+export const GET = withAuthorization(
+  { obj: "credits" },
+  async (
+    _req: Request,
+    { session }: { session?: { user?: { id?: string } } },
+  ) => {
+    if (!session?.user?.id) {
+      return new Response(null, { status: 401 });
+    }
+    const balance = getCreditBalance(session.user.id);
+    return NextResponse.json({ balance });
+  },
+);

--- a/src/app/api/credits/exchange-rate/route.ts
+++ b/src/app/api/credits/exchange-rate/route.ts
@@ -1,0 +1,17 @@
+import { withAuthorization } from "@/lib/authz";
+import { getCreditSettings, setExchangeRate } from "@/lib/creditSettings";
+import { NextResponse } from "next/server";
+
+export const GET = withAuthorization({ obj: "credits" }, async () => {
+  const { usdPerCredit } = getCreditSettings();
+  return NextResponse.json({ usdPerCredit });
+});
+
+export const PUT = withAuthorization(
+  { obj: "superadmin", act: "update" },
+  async (req: Request) => {
+    const { usdPerCredit } = (await req.json()) as { usdPerCredit: number };
+    const settings = setExchangeRate(usdPerCredit);
+    return NextResponse.json(settings);
+  },
+);

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,8 +1,34 @@
 "use client";
 import { useSession } from "@/app/useSession";
+import { useEffect, useState } from "react";
 
 export default function UserSettingsPage() {
   const { data: session } = useSession();
+  const [tab, setTab] = useState<"profile" | "credits">("profile");
+  const [balance, setBalance] = useState<number | null>(null);
+  const [usd, setUsd] = useState("0");
+
+  useEffect(() => {
+    if (tab === "credits") {
+      fetch("/api/credits/balance")
+        .then((res) => res.json())
+        .then((data) => setBalance(data.balance));
+    }
+  }, [tab]);
+
+  async function addCredits() {
+    await fetch("/api/credits/add", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ usd: Number(usd) }),
+    });
+    setUsd("0");
+    const res = await fetch("/api/credits/balance");
+    if (res.ok) {
+      const data = await res.json();
+      setBalance(data.balance);
+    }
+  }
 
   if (!session) {
     return <div className="p-8">You are not logged in.</div>;
@@ -11,8 +37,48 @@ export default function UserSettingsPage() {
   return (
     <div className="p-8">
       <h1 className="text-xl font-bold mb-4">User Settings</h1>
-      <p>Email: {session.user?.email ?? session.user?.name ?? "Unknown"}</p>
-      <p>Role: {session.user?.role}</p>
+      <div className="flex gap-4 mb-4">
+        <button
+          type="button"
+          onClick={() => setTab("profile")}
+          className="bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
+        >
+          Profile
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab("credits")}
+          className="bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
+        >
+          Credits
+        </button>
+      </div>
+      {tab === "profile" && (
+        <div>
+          <p>Email: {session.user?.email ?? session.user?.name ?? "Unknown"}</p>
+          <p>Role: {session.user?.role}</p>
+        </div>
+      )}
+      {tab === "credits" && (
+        <div className="grid gap-2 max-w-sm">
+          <p>Balance: {balance ?? 0} credits</p>
+          <div className="flex gap-2">
+            <input
+              type="number"
+              value={usd}
+              onChange={(e) => setUsd(e.target.value)}
+              className="border p-1 flex-1"
+            />
+            <button
+              type="button"
+              onClick={addCredits}
+              className="bg-blue-600 text-white px-2 py-1 rounded"
+            >
+              Add
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/creditSettings.ts
+++ b/src/lib/creditSettings.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+import { readJsonFile, writeJsonFile } from "./fileUtils";
+
+export interface CreditSettings {
+  usdPerCredit: number;
+}
+
+const settingsFile = path.join(process.cwd(), "data", "creditSettings.json");
+const defaultSettings: CreditSettings = { usdPerCredit: 1 };
+
+export function getCreditSettings(): CreditSettings {
+  return readJsonFile<CreditSettings>(settingsFile, defaultSettings);
+}
+
+export function setExchangeRate(usdPerCredit: number): CreditSettings {
+  const settings = { usdPerCredit };
+  writeJsonFile(settingsFile, settings);
+  return settings;
+}

--- a/src/lib/credits.ts
+++ b/src/lib/credits.ts
@@ -1,0 +1,35 @@
+import crypto from "node:crypto";
+import { db } from "./db";
+
+export interface CreditTransaction {
+  id: string;
+  userId: string;
+  amount: number;
+  createdAt: string;
+}
+
+const insertTx = db.prepare(
+  "INSERT INTO credit_transactions (id, user_id, amount, created_at) VALUES (?, ?, ?, ?)",
+);
+const updateBalance = db.prepare(
+  "UPDATE user SET credits = credits + ? WHERE id = ?",
+);
+const selectBalance = db.prepare("SELECT credits FROM user WHERE id = ?");
+
+const txAdd = db.transaction((userId: string, amount: number) => {
+  const id = crypto.randomUUID();
+  const createdAt = new Date().toISOString();
+  insertTx.run(id, userId, amount, createdAt);
+  updateBalance.run(amount, userId);
+  const row = selectBalance.get(userId) as { credits: number } | undefined;
+  return row?.credits ?? 0;
+});
+
+export function addCredits(userId: string, amount: number): number {
+  return txAdd(userId, amount);
+}
+
+export function getCreditBalance(userId: string): number {
+  const row = selectBalance.get(userId) as { credits: number } | undefined;
+  return row?.credits ?? 0;
+}


### PR DESCRIPTION
## Summary
- add migrations to support user credits and permissions
- implement credit balance API
- implement credit purchase API with exchange rate
- allow superadmins to set the exchange rate
- show a credits tab on the user settings page

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68597d741d00832ba0bc44cee24908b1