### PR TITLE
Add case job list

### DIFF
--- a/src/app/api/cases/[id]/jobs/route.ts
+++ b/src/app/api/cases/[id]/jobs/route.ts
@@ -1,0 +1,35 @@
+import { getSessionDetails, withAuthorization } from "@/lib/authz";
+import { isCaseMember } from "@/lib/caseMembers";
+import { getCase } from "@/lib/caseStore";
+import { listJobs } from "@/lib/jobScheduler";
+import { NextResponse } from "next/server";
+
+export const GET = withAuthorization(
+  { obj: "cases" },
+  async (
+    req: Request,
+    {
+      params,
+      session,
+    }: {
+      params: Promise<{ id: string }>;
+      session?: { user?: { id?: string; role?: string } };
+    },
+  ) => {
+    const { id } = await params;
+    const c = getCase(id);
+    if (!c) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const { userId, role } = getSessionDetails({ session }, "user");
+    if (!c.public && role !== "admin" && role !== "superadmin") {
+      if (!userId || !isCaseMember(id, userId)) {
+        return new Response(null, { status: 403 });
+      }
+    }
+    const url = new URL(req.url);
+    const type = url.searchParams.get("type") ?? undefined;
+    const data = listJobs(type, id);
+    return NextResponse.json(data);
+  },
+);

--- a/src/app/api/public/cases/[id]/jobs/route.ts
+++ b/src/app/api/public/cases/[id]/jobs/route.ts
@@ -1,0 +1,22 @@
+import { authorize } from "@/lib/authz";
+import { getCase } from "@/lib/caseStore";
+import { listJobs } from "@/lib/jobScheduler";
+import { NextResponse } from "next/server";
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!(await authorize("anonymous", "public_cases", "read"))) {
+    return new Response(null, { status: 403 });
+  }
+  const { id } = await params;
+  const c = getCase(id);
+  if (!c || !c.public) {
+    return new Response(null, { status: 403 });
+  }
+  const url = new URL(req.url);
+  const type = url.searchParams.get("type") ?? undefined;
+  const data = listJobs(type, id);
+  return NextResponse.json(data);
+}

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -2,6 +2,7 @@
 import { apiEventSource, apiFetch } from "@/apiClient";
 import useDragReset from "@/app/cases/useDragReset";
 import AnalysisInfo from "@/app/components/AnalysisInfo";
+import CaseJobList from "@/app/components/CaseJobList";
 import CaseLayout from "@/app/components/CaseLayout";
 import CaseProgressGraph from "@/app/components/CaseProgressGraph";
 import CaseToolbar from "@/app/components/CaseToolbar";
@@ -706,6 +707,7 @@ export default function ClientCasePage({
                 </div>
               </div>
             </DebugWrapper>
+            <CaseJobList caseId={caseId} isPublic={caseData.public} />
             {selectedPhoto ? (
               <>
                 <div className="relative w-full aspect-[3/2] md:max-w-2xl shrink-0">

--- a/src/app/components/CaseJobList.tsx
+++ b/src/app/components/CaseJobList.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { apiFetch } from "@/apiClient";
+import { useCallback, useEffect, useState } from "react";
+
+interface JobInfo {
+  id: number;
+  type: string;
+  startedAt: number;
+}
+
+interface JobResponse {
+  jobs: JobInfo[];
+  auditedAt: number;
+  updatedAt: number;
+}
+
+export default function CaseJobList({
+  caseId,
+  isPublic,
+}: {
+  caseId: string;
+  isPublic: boolean;
+}) {
+  const [jobs, setJobs] = useState<JobInfo[]>([]);
+  const [auditedAt, setAuditedAt] = useState<number>(0);
+  const [updatedAt, setUpdatedAt] = useState<number>(0);
+
+  const refresh = useCallback(async () => {
+    const base = isPublic ? "/api/public/cases" : "/api/cases";
+    const res = await apiFetch(`${base}/${encodeURIComponent(caseId)}/jobs`);
+    if (res.ok) {
+      const data: JobResponse = await res.json();
+      setJobs(data.jobs);
+      setAuditedAt(data.auditedAt);
+      setUpdatedAt(data.updatedAt);
+    }
+  }, [caseId, isPublic]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  if (jobs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded flex flex-col gap-2 text-sm">
+      <h2 className="font-semibold">Active Jobs</h2>
+      <ul className="grid gap-1">
+        {jobs.map((j) => (
+          <li key={j.id} className="flex justify-between">
+            <span className="font-mono mr-2">{j.type}</span>
+            {new Date(j.startedAt).toLocaleString()}
+          </li>
+        ))}
+      </ul>
+      <p className="text-xs text-gray-600 dark:text-gray-400">
+        Last audit: {auditedAt ? new Date(auditedAt).toLocaleString() : "n/a"} |
+        Last update: {updatedAt ? new Date(updatedAt).toLocaleString() : "n/a"}
+      </p>
+    </div>
+  );
+}

--- a/src/app/system-status/SystemStatusClient.tsx
+++ b/src/app/system-status/SystemStatusClient.tsx
@@ -6,6 +6,7 @@ interface JobInfo {
   id: number;
   type: string;
   startedAt: number;
+  caseId?: string;
 }
 
 interface JobResponse {
@@ -69,6 +70,9 @@ export default function SystemStatusClient() {
           {jobs.map((j) => (
             <li key={j.id} className="border p-2">
               <span className="font-mono mr-2">{j.type}</span>
+              {j.caseId ? (
+                <span className="mr-2 text-gray-500">case {j.caseId}</span>
+              ) : null}
               {new Date(j.startedAt).toLocaleString()}
             </li>
           ))}

--- a/src/lib/caseAnalysis.ts
+++ b/src/lib/caseAnalysis.ts
@@ -179,7 +179,7 @@ export function analyzeCaseInBackground(caseData: Case): void {
     run() {
       if (activeWorkers.has(caseData.id)) return Promise.resolve();
       return new Promise<void>((resolve) => {
-        const worker = runJob("analyzeCase", caseData);
+        const worker = runJob("analyzeCase", caseData, { caseId: caseData.id });
         activeWorkers.set(caseData.id, worker);
         const cleanup = () => {
           activeWorkers.delete(caseData.id);
@@ -304,7 +304,11 @@ export function analyzePhotoInBackground(caseData: Case, photo: string): void {
     photo,
     run() {
       return new Promise<void>((resolve) => {
-        const worker = runJob("analyzePhoto", { caseData, photo });
+        const worker = runJob(
+          "analyzePhoto",
+          { caseData, photo },
+          { caseId: caseData.id },
+        );
         activeWorkers.set(caseData.id, worker);
         const cleanup = () => {
           activeWorkers.delete(caseData.id);

--- a/src/lib/caseLocation.ts
+++ b/src/lib/caseLocation.ts
@@ -16,5 +16,5 @@ export async function fetchCaseLocation(caseData: Case): Promise<void> {
 }
 
 export function fetchCaseLocationInBackground(caseData: Case): void {
-  runJob("fetchCaseLocation", caseData);
+  runJob("fetchCaseLocation", caseData, { caseId: caseData.id });
 }

--- a/src/lib/vinLookup.ts
+++ b/src/lib/vinLookup.ts
@@ -86,5 +86,5 @@ export async function fetchCaseVin(caseData: Case): Promise<void> {
 }
 
 export function fetchCaseVinInBackground(caseData: Case): void {
-  runJob("fetchCaseVin", caseData);
+  runJob("fetchCaseVin", caseData, { caseId: caseData.id });
 }

--- a/test/caseJobsRoute.test.ts
+++ b/test/caseJobsRoute.test.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Worker } from "node:worker_threads";
+
+let dataDir: string;
+let mod: typeof import("@/app/api/cases/[id]/jobs/route");
+let pubMod: typeof import("@/app/api/public/cases/[id]/jobs/route");
+let jobScheduler: typeof import("@/lib/jobScheduler");
+let caseStore: typeof import("@/lib/caseStore");
+
+beforeEach(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
+  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
+  vi.resetModules();
+  const db = await import("@/lib/db");
+  await db.migrationsReady;
+  caseStore = await import("@/lib/caseStore");
+  jobScheduler = await import("@/lib/jobScheduler");
+  jobScheduler.activeJobs.clear();
+  mod = await import("@/app/api/cases/[id]/jobs/route");
+  pubMod = await import("@/app/api/public/cases/[id]/jobs/route");
+});
+
+afterEach(() => {
+  jobScheduler.activeJobs.clear();
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  vi.resetModules();
+  process.env.CASE_STORE_FILE = undefined;
+});
+
+describe("case jobs API", () => {
+  it("rejects unauthorized user", async () => {
+    const c = caseStore.createCase("/a.jpg");
+    const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({ id: c.id }),
+      session: { user: { id: "u1", role: "user" } },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns jobs for public case", async () => {
+    const c = caseStore.createCase("/b.jpg", null, undefined, null, null, true);
+    jobScheduler.activeJobs.set(1, {
+      type: "analyzeCase",
+      worker: { threadId: 1 } as Worker,
+      startedAt: 1,
+      caseId: c.id,
+    });
+    const res = await pubMod.GET(new Request("http://test"), {
+      params: Promise.resolve({ id: c.id }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.jobs).toEqual([
+      { id: 1, type: "analyzeCase", startedAt: 1, caseId: c.id },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- track caseId in active jobs and expose via API
- implement API endpoints to list jobs for a case
- show active jobs on case page
- display related case in system status page
- test case job API

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68597ecd6330832bb58b0dcd43b6b1c4