### PR TITLE
Fix system status page error

### DIFF
--- a/src/app/system-status/page.tsx
+++ b/src/app/system-status/page.tsx
@@ -1,21 +1,17 @@
 import { authOptions } from "@/lib/authOptions";
-import { withAuthorization } from "@/lib/authz";
+import { authorize } from "@/lib/authz";
 import { getServerSession } from "next-auth/next";
+import { notFound } from "next/navigation";
 import SystemStatusClient from "./SystemStatusClient";
 
 export const dynamic = "force-dynamic";
 
-const handler = withAuthorization(
-  { obj: "superadmin" },
-  async (_req: Request, _ctx: { session?: { user?: { role?: string } } }) => {
-    return <SystemStatusClient />;
-  },
-);
-
 export default async function SystemStatusPage() {
   const session = await getServerSession(authOptions);
-  return handler(new Request("http://localhost"), {
-    params: Promise.resolve({}),
-    session: session ?? undefined,
-  });
+  const role = session?.user?.role ?? "anonymous";
+  const allowed = await authorize(role, "superadmin", "read");
+  if (!allowed) {
+    notFound();
+  }
+  return <SystemStatusClient />;
 }


### PR DESCRIPTION
## Summary
- avoid returning `Response` from the system status page
- update tests for new authorization logic

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685984895310832bb04265752248bd82