### PR TITLE
Fix system status page authorization

### DIFF
--- a/src/app/system-status/__tests__/SystemStatusPage.test.tsx
+++ b/src/app/system-status/__tests__/SystemStatusPage.test.tsx
@@ -1,5 +1,6 @@
 import SystemStatusPage from "@/app/system-status/page";
 import { getServerSession } from "next-auth/next";
+import type { ReactElement } from "react";
 import { expect, it, vi } from "vitest";
 
 vi.mock("next-auth/next", () => ({
@@ -11,29 +12,24 @@ vi.mock("@/lib/authOptions", () => ({
 }));
 
 vi.mock("@/lib/authz", () => ({
-  withAuthorization:
-    (
-      _opts: unknown,
-      handler: (
-        req: Request,
-        ctx: { session?: { user?: { role?: string } } },
-      ) => unknown,
-    ) =>
-    async (req: Request, ctx: { session?: { user?: { role?: string } } }) => {
-      return ctx.session?.user?.role === "superadmin"
-        ? handler(req, ctx)
-        : new Response(null, { status: 403 });
-    },
+  authorize: vi.fn(async (role: string) => role === "superadmin"),
+  getSessionDetails: ({
+    session,
+  }: { session?: { user?: { role?: string } } }) => ({
+    role: session?.user?.role ?? "anonymous",
+    userId: session?.user?.id,
+  }),
 }));
 
-it("returns 403 for non-superadmin", async () => {
+it("renders access denied for non-superadmin", async () => {
   (
     getServerSession as unknown as { mockResolvedValue: (v: unknown) => void }
   ).mockResolvedValue({
     user: { role: "admin" },
   });
-  const res = (await SystemStatusPage()) as Response;
-  expect(res.status).toBe(403);
+  const res = (await SystemStatusPage()) as ReactElement;
+  expect(res).not.toBeInstanceOf(Response);
+  expect(res.props.children).toBe("Access denied");
 });
 
 it("renders for superadmin", async () => {
@@ -42,6 +38,7 @@ it("renders for superadmin", async () => {
   ).mockResolvedValue({
     user: { role: "superadmin" },
   });
-  const res = await SystemStatusPage();
+  const res = (await SystemStatusPage()) as ReactElement;
   expect(res).not.toBeInstanceOf(Response);
+  expect(res.type).not.toBe("p");
 });

--- a/src/app/system-status/page.tsx
+++ b/src/app/system-status/page.tsx
@@ -1,15 +1,16 @@
 import { authOptions } from "@/lib/authOptions";
 import { authorize, getSessionDetails } from "@/lib/authz";
 import { getServerSession } from "next-auth/next";
+import type { ReactElement } from "react";
 import SystemStatusClient from "./SystemStatusClient";
 
 export const dynamic = "force-dynamic";
 
-export default async function SystemStatusPage() {
+export default async function SystemStatusPage(): Promise<ReactElement> {
   const session = await getServerSession(authOptions);
   const { role, userId } = getSessionDetails({ session });
   if (!(await authorize(role, "superadmin", "read", { userId }))) {
-    return new Response(null, { status: 403 });
+    return <p>Access denied</p>;
   }
   return <SystemStatusClient />;
 }


### PR DESCRIPTION
## Summary
- rewrite system status page to authorize directly instead of using helper

## Testing
- `npx biome check src/app/system-status/page.tsx`
- `npx vitest run src/app/system-status/__tests__/SystemStatusPage.test.tsx` *(fails: Need to install the following packages: vitest)*

------
https://chatgpt.com/codex/tasks/task_e_685984895310832bb04265752248bd82