### PR TITLE
fix system status page in superadmin

### DIFF
--- a/src/app/system-status/__tests__/SystemStatusPage.test.tsx
+++ b/src/app/system-status/__tests__/SystemStatusPage.test.tsx
@@ -11,29 +11,17 @@ vi.mock("@/lib/authOptions", () => ({
 }));
 
 vi.mock("@/lib/authz", () => ({
-  withAuthorization:
-    (
-      _opts: unknown,
-      handler: (
-        req: Request,
-        ctx: { session?: { user?: { role?: string } } },
-      ) => unknown,
-    ) =>
-    async (req: Request, ctx: { session?: { user?: { role?: string } } }) => {
-      return ctx.session?.user?.role === "superadmin"
-        ? handler(req, ctx)
-        : new Response(null, { status: 403 });
-    },
+  authorize: vi.fn((role: string) => role === "superadmin"),
 }));
 
-it("returns 403 for non-superadmin", async () => {
+it("shows message for non-superadmin", async () => {
   (
     getServerSession as unknown as { mockResolvedValue: (v: unknown) => void }
   ).mockResolvedValue({
     user: { role: "admin" },
   });
-  const res = (await SystemStatusPage()) as Response;
-  expect(res.status).toBe(403);
+  const res = await SystemStatusPage();
+  expect(res).not.toBeInstanceOf(Response);
 });
 
 it("renders for superadmin", async () => {

--- a/src/app/system-status/page.tsx
+++ b/src/app/system-status/page.tsx
@@ -1,21 +1,16 @@
 import { authOptions } from "@/lib/authOptions";
-import { withAuthorization } from "@/lib/authz";
+import { authorize } from "@/lib/authz";
 import { getServerSession } from "next-auth/next";
 import SystemStatusClient from "./SystemStatusClient";
 
 export const dynamic = "force-dynamic";
 
-const handler = withAuthorization(
-  { obj: "superadmin" },
-  async (_req: Request, _ctx: { session?: { user?: { role?: string } } }) => {
-    return <SystemStatusClient />;
-  },
-);
-
 export default async function SystemStatusPage() {
   const session = await getServerSession(authOptions);
-  return handler(new Request("http://localhost"), {
-    params: Promise.resolve({}),
-    session: session ?? undefined,
-  });
+  const role = session?.user?.role ?? "anonymous";
+  const allowed = await authorize(role, "superadmin", "read");
+  if (!allowed) {
+    return <p className="p-8">You are not authorized to view this page.</p>;
+  }
+  return <SystemStatusClient />;
 }


### PR DESCRIPTION
## Summary
- check authorization directly in the System Status page
- adjust tests for the new authorization approach

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859886a0aa4832bbd081c5524d714c5