### PR TITLE
Fix system status page auth

### DIFF
--- a/migrations/0016_superadmin_read_policy.sql
+++ b/migrations/0016_superadmin_read_policy.sql
@@ -1,0 +1,2 @@
+INSERT INTO casbin_rules (ptype, v0, v1, v2)
+VALUES ('p', 'superadmin', 'superadmin', 'read');


### PR DESCRIPTION
## Summary
- seed casbin to allow `superadmin` to read `superadmin` resource

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859886a0aa4832bbd081c5524d714c5