### PR TITLE
feat: stream job list updates

### DIFF
--- a/src/app/api/cases/[id]/jobs/stream/route.ts
+++ b/src/app/api/cases/[id]/jobs/stream/route.ts
@@ -1,0 +1,84 @@
+import { getSessionDetails, withAuthorization } from "@/lib/authz";
+import { isCaseMember } from "@/lib/caseMembers";
+import { getCase } from "@/lib/caseStore";
+import { jobEvents } from "@/lib/jobEvents";
+import { listJobs } from "@/lib/jobScheduler";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withAuthorization(
+  { obj: "cases" },
+  async (
+    req: Request,
+    {
+      params,
+      session,
+    }: {
+      params: Promise<{ id: string }>;
+      session?: { user?: { id?: string; role?: string } };
+    },
+  ) => {
+    const { id } = await params;
+    const c = getCase(id);
+    if (!c) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const { userId, role } = getSessionDetails({ session }, "user");
+    if (!c.public && role !== "admin" && role !== "superadmin") {
+      if (!userId || !isCaseMember(id, userId)) {
+        return new Response(null, { status: 403 });
+      }
+    }
+    const url = new URL(req.url);
+    const type = url.searchParams.get("type") ?? undefined;
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        function send(chunk: string) {
+          try {
+            controller.enqueue(encoder.encode(chunk));
+          } catch {
+            cleanup();
+          }
+        }
+
+        function onUpdate() {
+          const payload = `data: ${JSON.stringify(listJobs(type, id))}\n\n`;
+          send(payload);
+        }
+
+        function cleanup() {
+          clearInterval(keepAlive);
+          jobEvents.off("update", onUpdate);
+        }
+
+        jobEvents.on("update", onUpdate);
+        onUpdate();
+
+        const keepAlive = setInterval(() => {
+          send(":\n\n");
+        }, 15000);
+
+        req.signal.addEventListener("abort", () => {
+          cleanup();
+          controller.close();
+        });
+
+        const ctrl =
+          controller as ReadableStreamDefaultController<Uint8Array> & {
+            oncancel?: () => void;
+          };
+        ctrl.oncancel = cleanup;
+      },
+    });
+
+    return new NextResponse(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  },
+);

--- a/src/app/api/public/cases/[id]/jobs/stream/route.ts
+++ b/src/app/api/public/cases/[id]/jobs/stream/route.ts
@@ -1,0 +1,70 @@
+import { authorize } from "@/lib/authz";
+import { getCase } from "@/lib/caseStore";
+import { jobEvents } from "@/lib/jobEvents";
+import { listJobs } from "@/lib/jobScheduler";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!(await authorize("anonymous", "public_cases", "read"))) {
+    return new Response(null, { status: 403 });
+  }
+  const { id } = await params;
+  const c = getCase(id);
+  if (!c || !c.public) {
+    return new Response(null, { status: 403 });
+  }
+  const url = new URL(req.url);
+  const type = url.searchParams.get("type") ?? undefined;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      function send(chunk: string) {
+        try {
+          controller.enqueue(encoder.encode(chunk));
+        } catch {
+          cleanup();
+        }
+      }
+
+      function onUpdate() {
+        const payload = `data: ${JSON.stringify(listJobs(type, id))}\n\n`;
+        send(payload);
+      }
+
+      function cleanup() {
+        clearInterval(keepAlive);
+        jobEvents.off("update", onUpdate);
+      }
+
+      jobEvents.on("update", onUpdate);
+      onUpdate();
+
+      const keepAlive = setInterval(() => {
+        send(":\n\n");
+      }, 15000);
+
+      req.signal.addEventListener("abort", () => {
+        cleanup();
+        controller.close();
+      });
+
+      const ctrl = controller as ReadableStreamDefaultController<Uint8Array> & {
+        oncancel?: () => void;
+      };
+      ctrl.oncancel = cleanup;
+    },
+  });
+
+  return new NextResponse(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/src/app/api/system/jobs/stream/route.ts
+++ b/src/app/api/system/jobs/stream/route.ts
@@ -1,0 +1,65 @@
+import { withAuthorization } from "@/lib/authz";
+import { jobEvents } from "@/lib/jobEvents";
+import { listJobs } from "@/lib/jobScheduler";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withAuthorization(
+  { obj: "superadmin" },
+  async (req: Request) => {
+    const url = new URL(req.url);
+    const type = url.searchParams.get("type") ?? undefined;
+    const caseId = url.searchParams.get("caseId") ?? undefined;
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        function send(chunk: string) {
+          try {
+            controller.enqueue(encoder.encode(chunk));
+          } catch {
+            cleanup();
+          }
+        }
+
+        function onUpdate() {
+          const payload = `data: ${JSON.stringify(listJobs(type, caseId))}\n\n`;
+          send(payload);
+        }
+
+        function cleanup() {
+          clearInterval(keepAlive);
+          jobEvents.off("update", onUpdate);
+        }
+
+        jobEvents.on("update", onUpdate);
+
+        // send initial state
+        onUpdate();
+
+        const keepAlive = setInterval(() => {
+          send(":\n\n");
+        }, 15000);
+
+        req.signal.addEventListener("abort", () => {
+          cleanup();
+          controller.close();
+        });
+
+        const ctrl =
+          controller as ReadableStreamDefaultController<Uint8Array> & {
+            oncancel?: () => void;
+          };
+        ctrl.oncancel = cleanup;
+      },
+    });
+
+    return new NextResponse(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  },
+);

--- a/src/app/components/CaseJobList.tsx
+++ b/src/app/components/CaseJobList.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { apiFetch } from "@/apiClient";
-import { useCallback, useEffect, useState } from "react";
+import { apiEventSource } from "@/apiClient";
+import { useEffect, useState } from "react";
 
 interface JobInfo {
   id: number;
@@ -25,20 +25,19 @@ export default function CaseJobList({
   const [auditedAt, setAuditedAt] = useState<number>(0);
   const [updatedAt, setUpdatedAt] = useState<number>(0);
 
-  const refresh = useCallback(async () => {
+  useEffect(() => {
     const base = isPublic ? "/api/public/cases" : "/api/cases";
-    const res = await apiFetch(`${base}/${encodeURIComponent(caseId)}/jobs`);
-    if (res.ok) {
-      const data: JobResponse = await res.json();
+    const es = apiEventSource(
+      `${base}/${encodeURIComponent(caseId)}/jobs/stream`,
+    );
+    es.onmessage = (e) => {
+      const data: JobResponse = JSON.parse(e.data);
       setJobs(data.jobs);
       setAuditedAt(data.auditedAt);
       setUpdatedAt(data.updatedAt);
-    }
+    };
+    return () => es.close();
   }, [caseId, isPublic]);
-
-  useEffect(() => {
-    refresh();
-  }, [refresh]);
 
   if (jobs.length === 0) {
     return null;

--- a/src/lib/jobEvents.ts
+++ b/src/lib/jobEvents.ts
@@ -1,0 +1,20 @@
+import { EventEmitter } from "node:events";
+import { parentPort } from "node:worker_threads";
+
+const globalStore = globalThis as unknown as {
+  jobEvents?: EventEmitter;
+};
+
+const emitter: EventEmitter = globalStore.jobEvents ?? new EventEmitter();
+
+if (parentPort) {
+  emitter.on("update", (data) => {
+    parentPort?.postMessage({ event: "jobUpdate", data });
+  });
+}
+
+if (!globalStore.jobEvents) {
+  globalStore.jobEvents = emitter;
+}
+
+export const jobEvents = emitter;

--- a/src/lib/jobScheduler.ts
+++ b/src/lib/jobScheduler.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { Worker } from "node:worker_threads";
 import { caseEvents } from "./caseEvents";
+import { jobEvents } from "./jobEvents";
 
 interface TrackedJob {
   type: string;
@@ -37,6 +38,7 @@ function auditJobs() {
   }
   if (changed) {
     lastUpdate = lastAudit;
+    jobEvents.emit("update", listJobs());
   }
   globalStore.lastAudit = lastAudit;
   globalStore.lastUpdate = lastUpdate;
@@ -82,6 +84,7 @@ export function runJob(
   });
   lastUpdate = Date.now();
   globalStore.lastUpdate = lastUpdate;
+  jobEvents.emit("update", listJobs());
   worker.on("message", (msg) => {
     if (msg && msg.event === "update") {
       caseEvents.emit("update", msg.data);
@@ -94,6 +97,7 @@ export function runJob(
     activeJobs.delete(worker.threadId);
     lastUpdate = Date.now();
     globalStore.lastUpdate = lastUpdate;
+    jobEvents.emit("update", listJobs());
   };
   worker.once("exit", cleanup);
   worker.once("error", cleanup);


### PR DESCRIPTION
## Summary
- add `jobEvents` emitter for job change notifications
- emit updates from `jobScheduler`
- create streaming routes for job lists
- stream case job list and system status updates on the client

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859871cfd54832b9a7d94cacd4cc41f