### PR TITLE
Enable camera capture for case photos

### DIFF
--- a/src/app/__tests__/point.test.tsx
+++ b/src/app/__tests__/point.test.tsx
@@ -4,9 +4,14 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
 }));
 
 vi.mock("@/app/useNewCaseFromFiles", () => ({
+  default: () => async () => {},
+}));
+
+vi.mock("@/app/useAddFilesToCase", () => ({
   default: () => async () => {},
 }));
 

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -100,14 +100,26 @@ export default function ClientCasePage({
     initialIsAdmin;
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const addMenuRef = useRef<HTMLDetailsElement>(null);
+  const [hasCamera, setHasCamera] = useState(false);
   const [dragging, setDragging] = useState(false);
   const photoMenuRef = useRef<HTMLDetailsElement>(null);
   useCloseOnOutsideClick(photoMenuRef);
+  useCloseOnOutsideClick(addMenuRef);
   const notify = useNotify();
 
   useDragReset(() => {
     setDragging(false);
   });
+
+  useEffect(() => {
+    if (
+      navigator.mediaDevices?.getUserMedia &&
+      (location.protocol === "https:" || location.hostname === "localhost")
+    ) {
+      setHasCamera(true);
+    }
+  }, []);
 
   useEffect(() => {
     const stored = sessionStorage.getItem(`preview-${caseId}`);
@@ -894,8 +906,33 @@ export default function ClientCasePage({
                 );
               })}
               {readOnly ? null : (
-                <label className="flex items-center justify-center border rounded w-20 aspect-[4/3] text-sm text-gray-500 dark:text-gray-400 cursor-pointer">
-                  + add image
+                <details ref={addMenuRef} className="relative">
+                  <summary className="flex items-center justify-center border rounded w-20 aspect-[4/3] text-sm text-gray-500 dark:text-gray-400 cursor-pointer select-none">
+                    + add image
+                  </summary>
+                  <div
+                    className="absolute right-0 mt-1 bg-white dark:bg-gray-900 border rounded shadow text-black dark:text-white"
+                    role="menu"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => {
+                        addMenuRef.current?.removeAttribute("open");
+                        fileInputRef.current?.click();
+                      }}
+                      className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+                    >
+                      Upload Image
+                    </button>
+                    {hasCamera ? (
+                      <Link
+                        href={`/point?case=${caseId}`}
+                        className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+                      >
+                        Take Photo
+                      </Link>
+                    ) : null}
+                  </div>
                   <input
                     ref={fileInputRef}
                     type="file"
@@ -904,7 +941,7 @@ export default function ClientCasePage({
                     onChange={handleUpload}
                     className="hidden"
                   />
-                </label>
+                </details>
               )}
             </div>
           </>

--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
 // Worker for lightweight browser analysis
@@ -10,6 +11,7 @@ const AnalyzerWorker = () =>
     : new Worker(new URL("./localAnalyzer.worker.ts", import.meta.url), {
         type: "module",
       });
+import useAddFilesToCase from "@/app/useAddFilesToCase";
 import useNewCaseFromFiles from "@/app/useNewCaseFromFiles";
 
 export default function PointAndShootPage() {
@@ -19,7 +21,9 @@ export default function PointAndShootPage() {
   const workerRef = useRef<Worker | null>(null);
   const [analysisHint, setAnalysisHint] = useState<string | null>(null);
   const [cameraError, setCameraError] = useState<string | null>(null);
-  const uploadCase = useNewCaseFromFiles();
+  const params = useSearchParams();
+  const caseId = params.get("case") || null;
+  const uploadCase = caseId ? useAddFilesToCase(caseId) : useNewCaseFromFiles();
 
   useEffect(() => {
     async function startCamera() {
@@ -181,10 +185,10 @@ export default function PointAndShootPage() {
           </div>
         )}
         <Link
-          href="/cases"
+          href={caseId ? `/cases/${caseId}` : "/cases"}
           className="pointer-events-auto text-xs text-white underline mt-2"
         >
-          Cases
+          {caseId ? "Back to Case" : "Cases"}
         </Link>
       </div>
     </div>

--- a/src/app/useAddFilesToCase.ts
+++ b/src/app/useAddFilesToCase.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { apiFetch } from "@/apiClient";
+import { useRouter } from "next/navigation";
+import { useNotify } from "./components/NotificationProvider";
+
+export default function useAddFilesToCase(caseId: string) {
+  const router = useRouter();
+  const notify = useNotify();
+  return async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const results = await Promise.all(
+      Array.from(files).map((file) => {
+        const formData = new FormData();
+        formData.append("photo", file);
+        formData.append("caseId", caseId);
+        return apiFetch("/api/upload", {
+          method: "POST",
+          body: formData,
+        });
+      }),
+    );
+    if (results.some((r) => !r.ok)) {
+      notify("Failed to upload one or more files.");
+      return;
+    }
+    router.push(`/cases/${caseId}`);
+  };
+}


### PR DESCRIPTION
## Summary
- allow Point and Shoot page to add photos to an existing case
- show a menu to add an image via upload or camera when editing a case
- expose a helper for uploading files to an existing case
- adjust tests for updated hooks

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68599a81dc6c832b86b4ded784eae7c3