### PR TITLE
Allow superadmin read policy option

### DIFF
--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -20,7 +20,7 @@ const policyOptions = {
     snail_mail_providers: ["update"],
     vin_sources: ["update"],
   },
-  superadmin: { superadmin: ["update"] },
+  superadmin: { superadmin: ["read", "update"] },
 } as const;
 
 const groupOptions = {


### PR DESCRIPTION
## Summary
- add `read` to superadmin policy options so the policy editor can select it

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685997c441f4832b85a99bd0eaefe345