### PR TITLE
Fix permissions e2e test setup

### DIFF
--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -54,7 +54,12 @@ async function createCase(): Promise<string> {
 }
 
 beforeAll(async () => {
-  stub = await startOpenAIStub({ subject: "", body: "" });
+  stub = await startOpenAIStub({
+    violationType: "parking",
+    details: "",
+    vehicle: {},
+    images: {},
+  });
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   server = await startServer(3011, {
     NEXTAUTH_SECRET: "secret",


### PR DESCRIPTION
## Summary
- fix OpenAI stub in permissions e2e test to return a valid analysis response

## Testing
- `npm test` *(fails: Could not locate the bindings file...)*

------
https://chatgpt.com/codex/tasks/task_e_6859a1f1fe2c832bbd295d2236e53353