### PR TITLE
feat: add animated thumbnail placeholder

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -13,6 +13,7 @@ import MapPreview from "@/app/components/MapPreview";
 import useCloseOnOutsideClick from "@/app/useCloseOnOutsideClick";
 import { useSession } from "@/app/useSession";
 import { withBasePath } from "@/basePath";
+import ThumbnailImage from "@/components/thumbnail-image";
 import type { Case, SentEmail } from "@/lib/caseStore";
 import {
   getCaseOwnerContact,
@@ -876,10 +877,11 @@ export default function ClientCasePage({
                         }
                       >
                         <div className="relative w-20 aspect-[4/3]">
-                          <Image
+                          <ThumbnailImage
                             src={getThumbnailUrl(p, 128)}
                             alt="case photo"
-                            fill
+                            width={80}
+                            height={60}
                             className="object-cover"
                           />
                         </div>
@@ -1001,10 +1003,11 @@ export default function ClientCasePage({
                           }
                         >
                           <div className="relative w-20 aspect-[4/3]">
-                            <Image
+                            <ThumbnailImage
                               src={getThumbnailUrl(url, 128)}
                               alt="paperwork"
-                              fill
+                              width={80}
+                              height={60}
                               className="object-cover"
                             />
                           </div>

--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { apiFetch } from "@/apiClient";
 import { useSession } from "@/app/useSession";
+import ThumbnailImage from "@/components/thumbnail-image";
 import type { EmailDraft } from "@/lib/caseReport";
 import type { Case } from "@/lib/caseStore";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
@@ -143,7 +144,7 @@ export default function DraftEditor({
       </label>
       <div className="flex gap-2 flex-wrap">
         {attachments.map((p) => (
-          <Image
+          <ThumbnailImage
             key={p}
             src={getThumbnailUrl(p, 128)}
             alt="email attachment"

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import ThumbnailImage from "@/components/thumbnail-image";
 import type { EmailDraft } from "@/lib/caseReport";
 import type { Case } from "@/lib/caseStore";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
@@ -335,7 +336,7 @@ export default function NotifyOwnerEditor({
       </label>
       <div className="flex gap-2 flex-wrap">
         {attachments.map((p) => (
-          <Image
+          <ThumbnailImage
             key={p}
             src={getThumbnailUrl(p, 128)}
             alt="email attachment"

--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { apiEventSource, apiFetch } from "@/apiClient";
+import ThumbnailImage from "@/components/thumbnail-image";
 import type { Case, SentEmail, ThreadImage } from "@/lib/caseStore";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import Image from "next/image";
@@ -140,7 +141,7 @@ export default function ClientThreadPage({
         ))}
         {images.map((img) => (
           <li key={img.id} className="border p-2 rounded flex gap-2">
-            <Image
+            <ThumbnailImage
               src={getThumbnailUrl(img.url, 256)}
               alt="scan"
               width={150}

--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 import * as L from "leaflet";
 import "leaflet/dist/leaflet.css";
+import ThumbnailImage from "@/components/thumbnail-image";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
@@ -89,7 +90,7 @@ export default function MapPageClient({ cases }: { cases: MapCase[] }) {
                 router.push(`/cases/${c.id}`);
               }}
             >
-              <Image
+              <ThumbnailImage
                 src={getThumbnailUrl(c.photo, 256)}
                 alt={`Case ${c.id}`}
                 width={160}

--- a/src/components/thumbnail-image.tsx
+++ b/src/components/thumbnail-image.tsx
@@ -1,0 +1,46 @@
+import Image from "next/image";
+import { useEffect, useState } from "react";
+
+export interface ThumbnailImageProps
+  extends React.ComponentPropsWithoutRef<typeof Image> {
+  width: number;
+  height: number;
+}
+
+export default function ThumbnailImage({
+  src,
+  alt,
+  width,
+  height,
+  className,
+  ...props
+}: ThumbnailImageProps) {
+  const [ready, setReady] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    if (ready) return;
+    const timer = setInterval(() => setAttempt((a) => a + 1), 2000);
+    return () => clearInterval(timer);
+  }, [ready]);
+
+  return (
+    <div style={{ width, height }} className={`relative ${className ?? ""}`}>
+      {!ready && (
+        <div className="absolute inset-0 flex items-center justify-center bg-gray-200 dark:bg-gray-800">
+          <div className="w-6 h-6 border-2 border-gray-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      )}
+      <Image
+        src={`${src}${attempt ? `?${attempt}` : ""}`}
+        alt={alt}
+        width={width}
+        height={height}
+        onLoad={() => setReady(true)}
+        onError={() => setReady(false)}
+        className={`object-cover ${ready ? "" : "invisible"}`}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -163,7 +163,10 @@ function saveCase(c: Case) {
   const tx = db.transaction(() => {
     stmt.run(c.id, JSON.stringify(rest), c.public ? 1 : 0);
     orm.delete(casePhotos).where(eq(casePhotos.caseId, c.id)).run();
-    orm.delete(casePhotoAnalysis).where(eq(casePhotoAnalysis.caseId, c.id)).run();
+    orm
+      .delete(casePhotoAnalysis)
+      .where(eq(casePhotoAnalysis.caseId, c.id))
+      .run();
     for (const url of photos) {
       orm
         .insert(casePhotos)


### PR DESCRIPTION
## Summary
- show placeholder spinner while waiting for generated thumbnails
- replace usages of `Image` with `ThumbnailImage`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859a14e0a30832ba6cf39e52bdddb10