### PR TITLE
Prompt reanalysis after deleting photo

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -402,6 +402,9 @@ export default function ClientCasePage({
       notify("Failed to refresh case after removing photo.");
     }
     router.refresh();
+    if (window.confirm("Re-run analysis now that a photo was removed?")) {
+      await retryAnalysis();
+    }
   }
 
   async function refreshMembers() {


### PR DESCRIPTION
## Summary
- ask if the user wants to re-run analysis when removing a photo from a case

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859a6889da8832b9c3787006d6a0c96