### PR TITLE
Prompt reanalysis after photo deletion

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -402,6 +402,11 @@ export default function ClientCasePage({
       notify("Failed to refresh case after removing photo.");
     }
     router.refresh();
+    const confirmed = window.confirm("Photo removed. Reanalyze this case now?");
+    if (confirmed) {
+      await apiFetch(`/api/cases/${caseId}/reanalyze`, { method: "POST" });
+      router.refresh();
+    }
   }
 
   async function refreshMembers() {


### PR DESCRIPTION
## Summary
- ask the user whether they want to reanalyze the case after deleting a photo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859a6889da8832b9c3787006d6a0c96