### PR TITLE
Include sender info in email drafts

### DIFF
--- a/src/app/api/cases/[id]/followup/route.ts
+++ b/src/app/api/cases/[id]/followup/route.ts
@@ -28,10 +28,12 @@ export const GET = withCaseAuthorization(
     req: Request,
     {
       params,
-      session: _session,
+      session,
     }: {
       params: Promise<{ id: string }>;
-      session?: { user?: { id?: string; role?: string } };
+      session?: {
+        user?: { id?: string; role?: string; name?: string; email?: string };
+      };
     },
   ) => {
     const { id } = await params;
@@ -51,7 +53,10 @@ export const GET = withCaseAuthorization(
     console.log(
       `drafting followup for ${recipient} with ${thread.length} emails`,
     );
-    const email = await draftFollowUp(c, recipient, thread);
+    const sender = session?.user
+      ? { name: session.user.name ?? null, email: session.user.email ?? null }
+      : undefined;
+    const email = await draftFollowUp(c, recipient, thread, sender);
     console.log(`drafted email subject: ${email.subject}`);
     return NextResponse.json({
       email,

--- a/src/app/api/cases/[id]/report/route.ts
+++ b/src/app/api/cases/[id]/report/route.ts
@@ -12,17 +12,22 @@ export const GET = withCaseAuthorization(
     _req: Request,
     {
       params,
-      session: _session,
+      session,
     }: {
       params: Promise<{ id: string }>;
-      session?: { user?: { id?: string; role?: string } };
+      session?: {
+        user?: { id?: string; role?: string; email?: string; name?: string };
+      };
     },
   ) => {
     const { id } = await params;
     const c = getCase(id);
     if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
     const reportModule = reportModules["oak-park"];
-    const email = await draftEmail(c, reportModule);
+    const sender = session?.user
+      ? { name: session.user.name ?? null, email: session.user.email ?? null }
+      : undefined;
+    const email = await draftEmail(c, reportModule, sender);
     return NextResponse.json({
       email,
       attachments: c.photos,

--- a/src/app/cases/[id]/draft/page.tsx
+++ b/src/app/cases/[id]/draft/page.tsx
@@ -1,6 +1,8 @@
+import { authOptions } from "@/lib/authOptions";
 import { draftEmail } from "@/lib/caseReport";
 import { getCase } from "@/lib/caseStore";
 import { reportModules } from "@/lib/reportModules";
+import { getServerSession } from "next-auth/next";
 import DraftEditor from "./DraftEditor";
 
 export const dynamic = "force-dynamic";
@@ -12,7 +14,11 @@ export default async function DraftPage({
   const c = getCase(id);
   if (!c) return <div className="p-8">Case not found</div>;
   const reportModule = reportModules["oak-park"];
-  const email = await draftEmail(c, reportModule);
+  const session = await getServerSession(authOptions);
+  const sender = session?.user
+    ? { name: session.user.name ?? null, email: session.user.email ?? null }
+    : undefined;
+  const email = await draftEmail(c, reportModule, sender);
   return (
     <DraftEditor
       caseId={id}

--- a/src/lib/__tests__/caseReport.test.ts
+++ b/src/lib/__tests__/caseReport.test.ts
@@ -27,6 +27,8 @@ const baseCase: Case = {
   public: false,
 };
 
+const sender = { name: "Test User", email: "user@example.com" };
+
 beforeEach(() => {
   vi.restoreAllMocks();
   vi.spyOn(violationCodes, "getViolationCode").mockResolvedValue("1-1-1");
@@ -41,7 +43,11 @@ describe("draftEmail", () => {
       ],
     } as unknown as ChatCompletion);
 
-    const result = await draftEmail(baseCase, reportModules["oak-park"]);
+    const result = await draftEmail(
+      baseCase,
+      reportModules["oak-park"],
+      sender,
+    );
     expect(result).toEqual({ subject: "s", body: "b" });
   });
 
@@ -59,7 +65,11 @@ describe("draftEmail", () => {
         ],
       } as unknown as ChatCompletion);
 
-    const result = await draftEmail(baseCase, reportModules["oak-park"]);
+    const result = await draftEmail(
+      baseCase,
+      reportModules["oak-park"],
+      sender,
+    );
     expect(result).toEqual({ subject: "s2", body: "b2" });
   });
 
@@ -69,7 +79,11 @@ describe("draftEmail", () => {
       choices: [{ message: { content: "{}" } }],
     } as unknown as ChatCompletion);
 
-    const result = await draftEmail(baseCase, reportModules["oak-park"]);
+    const result = await draftEmail(
+      baseCase,
+      reportModules["oak-park"],
+      sender,
+    );
     expect(result).toEqual({ subject: "", body: "" });
   });
 });


### PR DESCRIPTION
## Summary
- include optional sender info when drafting email reports
- pass user profile name and email to report routes and pages
- update follow-up email logic and tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859a8f30ed4832bbab3af63ccc266cc