### PR TITLE
Handle active analysis when uploading

### DIFF
--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -2,7 +2,10 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { getSessionDetails, withAuthorization } from "@/lib/authz";
-import { analyzeCaseInBackground } from "@/lib/caseAnalysis";
+import {
+  analyzeCaseInBackground,
+  cancelCaseAnalysis,
+} from "@/lib/caseAnalysis";
 import { fetchCaseLocationInBackground } from "@/lib/caseLocation";
 import { addCasePhoto, createCase, getCase, updateCase } from "@/lib/caseStore";
 import { extractGps, extractTimestamp } from "@/lib/exif";
@@ -40,6 +43,7 @@ export const POST = withAuthorization(
     generateThumbnailsInBackground(buffer, filename);
     const existing = clientId ? getCase(clientId) : null;
     if (existing) {
+      cancelCaseAnalysis(existing.id);
       const updated = addCasePhoto(
         existing.id,
         `/uploads/${filename}`,

--- a/test/uploadRoute.test.ts
+++ b/test/uploadRoute.test.ts
@@ -1,0 +1,96 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Worker } from "node:worker_threads";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let dataDir: string;
+let tmpDir: string;
+let mod: typeof import("@/app/api/upload/route");
+let caseStore: typeof import("@/lib/caseStore");
+let caseAnalysis: typeof import("@/lib/caseAnalysis");
+let cancelSpy: ReturnType<typeof vi.spyOn>;
+
+const terminateMock = vi.fn();
+const worker = Object.assign(new EventEmitter(), {
+  terminate: terminateMock,
+}) as unknown as Worker;
+
+const runJobMock = vi.fn(() => worker);
+vi.mock("@/lib/jobScheduler", () => ({ runJob: runJobMock }));
+vi.mock("@/lib/thumbnails", () => ({
+  generateThumbnailsInBackground: vi.fn(),
+}));
+vi.mock("@/lib/exif", () => ({
+  extractGps: () => null,
+  extractTimestamp: () => null,
+}));
+vi.mock("@/lib/caseLocation", () => ({
+  fetchCaseLocationInBackground: vi.fn(),
+}));
+
+beforeEach(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "uploads-"));
+  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
+  vi.resetModules();
+  const db = await import("@/lib/db");
+  await db.migrationsReady;
+  caseStore = await import("@/lib/caseStore");
+  caseAnalysis = await import("@/lib/caseAnalysis");
+  cancelSpy = vi.spyOn(caseAnalysis, "cancelCaseAnalysis");
+  fs.mkdirSync(path.join(process.cwd(), "public", "uploads"), {
+    recursive: true,
+  });
+  mod = await import("@/app/api/upload/route");
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(path.join(process.cwd(), "public", "uploads"), {
+    recursive: true,
+    force: true,
+  });
+  vi.resetModules();
+  process.env.CASE_STORE_FILE = undefined;
+  cancelSpy?.mockRestore();
+});
+
+describe("upload route", () => {
+  it("cancels active analysis when uploading additional photo", async () => {
+    const c = caseStore.createCase("/a.jpg");
+    caseAnalysis.analyzeCaseInBackground(c);
+    expect(runJobMock).toHaveBeenCalledTimes(1);
+
+    const fakeReq = {
+      method: "POST",
+      formData: async () => ({
+        get(name: string) {
+          if (name === "photo") {
+            return {
+              arrayBuffer: async () => Buffer.from("b"),
+              name: "b.jpg",
+              type: "image/jpeg",
+            } as unknown as File;
+          }
+          if (name === "caseId") return c.id;
+          return null;
+        },
+      }),
+    } as unknown as Request;
+    const res = await mod.POST(fakeReq, {
+      params: Promise.resolve({}),
+      session: { user: { role: "user" } },
+    });
+    worker.emit("exit");
+    worker.emit("exit");
+    expect(res.status).toBe(200);
+    expect(cancelSpy).toHaveBeenCalledWith(c.id);
+    expect(terminateMock).toHaveBeenCalledTimes(1);
+    expect(runJobMock).toHaveBeenCalledTimes(2);
+    const updated = caseStore.getCase(c.id);
+    expect(updated?.photos.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- cancel active case analysis when uploading to an existing case
- test that upload cancels previous analysis and restarts processing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859a6aa3a28832b8cf828d3d67abc38