### PR TITLE
Block photo reanalysis during active case jobs

### DIFF
--- a/src/app/api/cases/[id]/reanalyze-photo/route.ts
+++ b/src/app/api/cases/[id]/reanalyze-photo/route.ts
@@ -3,6 +3,7 @@ import {
   analyzePhotoInBackground,
   cancelCaseAnalysis,
   cancelPhotoAnalysis,
+  isCaseAnalysisActive,
 } from "@/lib/caseAnalysis";
 import { getCase, updateCase } from "@/lib/caseStore";
 import { NextResponse } from "next/server";
@@ -28,6 +29,15 @@ export const POST = withCaseAuthorization(
     const c = getCase(id);
     if (!c || !c.photos.includes(photo)) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    if (isCaseAnalysisActive(id)) {
+      return NextResponse.json(
+        {
+          error:
+            "Individual photo reanalysis is blocked until the case job finishes or is canceled.",
+        },
+        { status: 409 },
+      );
     }
     cancelCaseAnalysis(id);
     cancelPhotoAnalysis(id, photo);

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -14,6 +14,7 @@ import useCloseOnOutsideClick from "@/app/useCloseOnOutsideClick";
 import { useSession } from "@/app/useSession";
 import { withBasePath } from "@/basePath";
 import ThumbnailImage from "@/components/thumbnail-image";
+import { isCaseAnalysisActive } from "@/lib/caseAnalysis";
 import type { Case, SentEmail } from "@/lib/caseStore";
 import {
   getCaseOwnerContact,
@@ -804,6 +805,10 @@ export default function ClientCasePage({
                             )
                           }
                           className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+                          disabled={
+                            caseData.analysisStatus === "pending" &&
+                            isCaseAnalysisActive(caseId)
+                          }
                         >
                           Reanalyze Photo
                         </button>

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -90,6 +90,17 @@ describe("reanalysis", () => {
           vehicle: { licensePlateNumber: "ABC123", licensePlateState: "IL" },
           images: { [photoName]: { representationScore: 1 } },
         }),
+        { violationType: "parking", details: "d", vehicle: {}, images: {} },
+        () => {
+          const start = Date.now();
+          while (Date.now() - start < 200) {}
+          return {
+            violationType: "parking",
+            details: "d",
+            vehicle: {},
+            images: {},
+          };
+        },
       ]);
     });
 
@@ -141,6 +152,36 @@ describe("reanalysis", () => {
         20,
       );
       expect(stub.requests.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("rejects photo reanalysis while case analysis active", async () => {
+      const file = createPhoto("block");
+      const form = new FormData();
+      form.append("photo", file);
+      const res = await api("/api/upload", { method: "POST", body: form });
+      expect(res.status).toBe(200);
+      const { caseId } = (await res.json()) as { caseId: string };
+
+      type CaseData = { photos: string[] };
+      const first = await poll(
+        () => api(`/api/cases/${caseId}`),
+        (r) => r.status === 200,
+        10,
+      );
+      const json = (await first.json()) as CaseData;
+      const photo = json.photos[0] as string;
+      photoName = path.basename(photo);
+
+      const rean = await api(`/api/cases/${caseId}/reanalyze`, {
+        method: "POST",
+      });
+      expect(rean.status).toBe(200);
+
+      const single = await api(
+        `/api/cases/${caseId}/reanalyze-photo?photo=${encodeURIComponent(photo)}`,
+        { method: "POST" },
+      );
+      expect(single.status).toBe(409);
     });
   });
 


### PR DESCRIPTION
## Summary
- prevent reanalyzing an individual photo while a case analysis job is running
- disable the Reanalyze Photo button in the UI when a case job is active
- cover the new behaviour with an e2e test

## Testing
- `npm run lint`
- `npm test` *(fails: Could not locate better-sqlite3 bindings)*

------
https://chatgpt.com/codex/tasks/task_e_6859a6b70e6c832b96afb7aa794bd566