### PR TITLE
Overlay progress on photo reanalysis

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -13,6 +13,7 @@ import MapPreview from "@/app/components/MapPreview";
 import useCloseOnOutsideClick from "@/app/useCloseOnOutsideClick";
 import { useSession } from "@/app/useSession";
 import { withBasePath } from "@/basePath";
+import { Progress } from "@/components/ui/progress";
 import type { Case, SentEmail } from "@/lib/caseStore";
 import {
   getCaseOwnerContact,
@@ -93,6 +94,7 @@ export default function ClientCasePage({
   >([]);
   const [inviteUserId, setInviteUserId] = useState("");
   const [copied, setCopied] = useState(false);
+  const [reanalyzingPhoto, setReanalyzingPhoto] = useState<string | null>(null);
   const { data: session } = useSession();
   const isAdmin =
     session?.user?.role === "admin" ||
@@ -168,6 +170,12 @@ export default function ClientCasePage({
       setPhotoNote(caseData.photoNotes?.[selectedPhoto] || "");
     }
   }, [caseData, selectedPhoto]);
+
+  useEffect(() => {
+    if (caseData?.analysisStatus !== "pending") {
+      setReanalyzingPhoto(null);
+    }
+  }, [caseData?.analysisStatus]);
 
   async function uploadFiles(files: FileList) {
     if (!files || files.length === 0) return;
@@ -361,6 +369,7 @@ export default function ClientCasePage({
       photo,
     )}`;
     if (caseData) setCaseData({ ...caseData, analysisStatus: "pending" });
+    setReanalyzingPhoto(photo);
     const res = await apiFetch(url, { method: "POST" });
     if (res.ok) {
       if (detailsEl) {
@@ -467,6 +476,19 @@ export default function ClientCasePage({
     caseData.analysisStatus === "pending" && caseData.analysisProgress
       ? caseData.analysisProgress
       : null;
+  const isPhotoReanalysis = Boolean(
+    reanalyzingPhoto ||
+      (caseData.analysisStatus === "pending" &&
+        caseData.analysisProgress?.total === 1 &&
+        caseData.analysis),
+  );
+  const requestValue = progress
+    ? progress.stage === "upload"
+      ? progress.index > 0
+        ? (progress.index / progress.total) * 100
+        : undefined
+      : Math.min((progress.received / progress.total) * 100, 100)
+    : undefined;
   const progressDescription = progress
     ? `${progress.steps ? `Step ${progress.step} of ${progress.steps}: ` : ""}${
         progress.stage === "upload"
@@ -623,7 +645,7 @@ export default function ClientCasePage({
               caseId={caseId}
               disabled={!violationIdentified}
               hasOwner={Boolean(ownerContact)}
-              progress={progress}
+              progress={isPhotoReanalysis ? null : progress}
               canDelete={isAdmin}
               closed={caseData.closed}
               archived={caseData.archived}
@@ -772,6 +794,14 @@ export default function ClientCasePage({
                     fill
                     className="object-contain"
                   />
+                  {isPhotoReanalysis && reanalyzingPhoto === selectedPhoto ? (
+                    <div className="absolute top-0 left-0 right-0">
+                      <Progress
+                        value={requestValue}
+                        indeterminate={requestValue === undefined}
+                      />
+                    </div>
+                  ) : null}
                   {readOnly ? null : (
                     <details
                       ref={photoMenuRef}
@@ -882,6 +912,14 @@ export default function ClientCasePage({
                             fill
                             className="object-cover"
                           />
+                          {isPhotoReanalysis && reanalyzingPhoto === p ? (
+                            <div className="absolute top-0 left-0 right-0">
+                              <Progress
+                                value={requestValue}
+                                indeterminate={requestValue === undefined}
+                              />
+                            </div>
+                          ) : null}
                         </div>
                         {(() => {
                           const t = caseData.photoTimes[p];

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -163,7 +163,10 @@ function saveCase(c: Case) {
   const tx = db.transaction(() => {
     stmt.run(c.id, JSON.stringify(rest), c.public ? 1 : 0);
     orm.delete(casePhotos).where(eq(casePhotos.caseId, c.id)).run();
-    orm.delete(casePhotoAnalysis).where(eq(casePhotoAnalysis.caseId, c.id)).run();
+    orm
+      .delete(casePhotoAnalysis)
+      .where(eq(casePhotoAnalysis.caseId, c.id))
+      .run();
     for (const url of photos) {
       orm
         .insert(casePhotos)


### PR DESCRIPTION
## Summary
- hide toolbar progress when reanalyzing a single photo
- show progress bar over the photo being reanalyzed for the entire request
- format case store to satisfy lint
- keep case toolbar hidden during photo analysis

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859a1aa98ec832bb7f5301c5cffdba4