### PR TITLE
Add session tracking to cases

### DIFF
--- a/migrations/0017_cases_session_id.sql
+++ b/migrations/0017_cases_session_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cases ADD COLUMN session_id TEXT;

--- a/src/generated/zod/caseStore.ts
+++ b/src/generated/zod/caseStore.ts
@@ -44,6 +44,7 @@ export const caseSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
   public: z.boolean(),
+  sessionId: z.string().optional().nullable(),
   gps: z
     .object({
       lat: z.number(),
@@ -77,6 +78,8 @@ export const caseSchema = z.object({
   sentEmails: z.array(sentEmailSchema).optional(),
   ownershipRequests: z.array(ownershipRequestSchema).optional(),
   threadImages: z.array(threadImageSchema).optional(),
+  closed: z.boolean().optional(),
   note: z.string().optional().nullable(),
   photoNotes: z.record(z.string().nullable()).optional(),
+  archived: z.boolean().optional(),
 });

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -10,6 +10,7 @@ export const cases = sqliteTable("cases", {
   id: text("id").primaryKey(),
   data: text("data").notNull(),
   public: integer("public", { mode: "boolean" }).notNull().default(false),
+  sessionId: text("session_id"),
 });
 
 export const casePhotos = sqliteTable(

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -184,4 +184,17 @@ describe("caseStore", () => {
     const stored = getCase(c.id);
     expect(stored?.photoNotes?.["/p.jpg"]).toBe("foo");
   });
+
+  it("handles session-based cases", () => {
+    const { createCase, getCasesBySession, claimCasesForSession, getCase } =
+      caseStore;
+    const c1 = createCase("/s1.jpg", null, undefined, null, null, false, "s1");
+    const c2 = createCase("/s2.jpg", null, undefined, null, null, false, "s1");
+    const list = getCasesBySession("s1");
+    expect(list.map((c) => c.id).sort()).toEqual([c1.id, c2.id].sort());
+    claimCasesForSession("u1", "s1");
+    const claimed1 = getCase(c1.id);
+    expect(claimed1?.sessionId).toBeNull();
+    expect(members.isCaseMember(c1.id, "u1", "owner")).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- add session_id column to cases
- expose sessionId on Case objects
- store and load sessionId in case store
- claim and query cases by session
- cover new behavior in tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859b305b7ac832ba0486756b05d64e8