### PR TITLE
Implement anonymous upload session

### DIFF
--- a/migrations/0017_anonymous_upload_rule.sql
+++ b/migrations/0017_anonymous_upload_rule.sql
@@ -1,0 +1,2 @@
+INSERT INTO casbin_rules (ptype, v0, v1, v2)
+  VALUES ('p', 'anonymous', 'upload', 'create');


### PR DESCRIPTION
## Summary
- allow anonymous uploads in Casbin policies
- keep session cookie for anonymous case creation

## Testing
- `npm install` *(fails: ENETUNREACH)*
- `npx biome format` *(fails: could not download biome)*
- `npm test` *(fails: dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859b3312304832bbdb4bd3a1c47fa1c