### PR TITLE
Allow session cookie access to cases

### DIFF
--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -1,38 +1,43 @@
+import { getAnonymousSessionId } from "@/lib/anonymousSession";
 import {
+  authorize,
   getSessionDetails,
-  withAuthorization,
+  loadAuthContext,
   withCaseAuthorization,
 } from "@/lib/authz";
 import { isCaseMember } from "@/lib/caseMembers";
 import { deleteCase, getCase } from "@/lib/caseStore";
 import { NextResponse } from "next/server";
 
-export const GET = withAuthorization(
-  { obj: "cases" },
-  async (
-    req: Request,
-    {
-      params,
-      session,
-    }: {
-      params: Promise<{ id: string }>;
-      session?: { user?: { id?: string; role?: string } };
-    },
-  ) => {
-    const { id } = await params;
-    const c = getCase(id);
-    if (!c) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
-    }
-    const { userId, role } = getSessionDetails({ session }, "user");
-    if (!c.public && role !== "admin" && role !== "superadmin") {
-      if (!userId || !isCaseMember(id, userId)) {
-        return new Response(null, { status: 403 });
-      }
-    }
-    return NextResponse.json(c);
+export async function GET(
+  req: Request,
+  {
+    params,
+    session,
+  }: {
+    params: Promise<{ id: string }>;
+    session?: { user?: { id?: string; role?: string } };
   },
-);
+) {
+  const { id } = await params;
+  const c = getCase(id);
+  if (!c) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const { role, userId } = await loadAuthContext({ session }, "anonymous");
+  const anonId = getAnonymousSessionId(req);
+  const sessionMatch = anonId && c.sessionId && c.sessionId === anonId;
+  const authRole = sessionMatch ? "user" : role;
+  if (!(await authorize(authRole, "cases", "read"))) {
+    return new Response(null, { status: 403 });
+  }
+  if (!c.public && role !== "admin" && role !== "superadmin") {
+    if (!(sessionMatch || (userId && isCaseMember(id, userId)))) {
+      return new Response(null, { status: 403 });
+    }
+  }
+  return NextResponse.json(c);
+}
 
 export const DELETE = withCaseAuthorization(
   { obj: "cases" },

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,13 +1,20 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { getAnonymousSessionId } from "@/lib/anonymousSession";
 import { getSessionDetails, withAuthorization } from "@/lib/authz";
 import {
   analyzeCaseInBackground,
   cancelCaseAnalysis,
 } from "@/lib/caseAnalysis";
 import { fetchCaseLocationInBackground } from "@/lib/caseLocation";
-import { addCasePhoto, createCase, getCase, updateCase } from "@/lib/caseStore";
+import {
+  addCasePhoto,
+  createCase,
+  getCase,
+  setCaseSessionId,
+  updateCase,
+} from "@/lib/caseStore";
 import { extractGps, extractTimestamp } from "@/lib/exif";
 import { generateThumbnailsInBackground } from "@/lib/thumbnails";
 import { NextResponse } from "next/server";
@@ -76,6 +83,10 @@ export const POST = withAuthorization(
       takenAt,
       userId ?? null,
     );
+    if (!userId) {
+      const anonId = getAnonymousSessionId(req);
+      if (anonId) setCaseSessionId(newCase.id, anonId);
+    }
     const p = updateCase(newCase.id, {
       analysisStatus: "pending",
       analysisProgress: {

--- a/src/lib/anonymousSession.ts
+++ b/src/lib/anonymousSession.ts
@@ -1,0 +1,11 @@
+export function getAnonymousSessionId(req: Request): string | undefined {
+  const cookie = req.headers.get("cookie");
+  if (!cookie) return undefined;
+  for (const part of cookie.split(/;\s*/)) {
+    const [name, ...rest] = part.split("=");
+    if (name === "anon_session_id") {
+      return decodeURIComponent(rest.join("="));
+    }
+  }
+  return undefined;
+}

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -41,6 +41,7 @@ export interface Case {
   closed?: boolean;
   note?: string | null;
   photoNotes?: Record<string, string | null>;
+  sessionId?: string | null;
   archived?: boolean;
 }
 
@@ -464,6 +465,13 @@ export function setCaseArchived(
   archived: boolean,
 ): Case | undefined {
   return updateCase(id, { archived });
+}
+
+export function setCaseSessionId(
+  id: string,
+  sessionId: string | null,
+): Case | undefined {
+  return updateCase(id, { sessionId });
 }
 
 export function deleteCase(id: string): boolean {

--- a/test/caseAuthorization.test.ts
+++ b/test/caseAuthorization.test.ts
@@ -77,6 +77,16 @@ describe("case authorization", () => {
     expect(res.status).toBe(403);
   });
 
+  it("allows access when session cookie matches", async () => {
+    const c = caseStore.createCase("/e.jpg");
+    caseStore.setCaseSessionId(c.id, "abc");
+    const { GET } = await import("@/app/api/cases/[id]/route");
+    const req = new Request("http://test");
+    req.headers.set("cookie", "anon_session_id=abc");
+    const res = await GET(req, { params: Promise.resolve({ id: c.id }) });
+    expect(res.status).toBe(200);
+  });
+
   it("allows superadmin to toggle visibility", async () => {
     const c = caseStore.createCase("/d.jpg", null, undefined, null, "u1");
     const { PUT } = await import("@/app/api/cases/[id]/public/route");


### PR DESCRIPTION
## Summary
- add `getAnonymousSessionId` helper
- include `sessionId` on `Case` objects
- authorize case routes when cookie session matches
- store anonymous session ID on case upload
- test case access via session cookie

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859b335f0f8832b8463719a79795dfa