### PR TITLE
Restrict features for anonymous users

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -11,6 +11,7 @@ import Image from "next/image";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useNotify } from "../components/NotificationProvider";
+import { useSession } from "../useSession";
 import useDragReset from "./useDragReset";
 
 type Order = "createdAt" | "updatedAt" | "distance";
@@ -54,6 +55,7 @@ export default function ClientCasesPage({
   const [dragging, setDragging] = useState(false);
   const [dropCase, setDropCase] = useState<string | null>(null);
   const notify = useNotify();
+  const { data: session } = useSession();
   const params = useParams<{ id?: string }>();
   const searchParams = useSearchParams();
   const selectedIds =
@@ -61,6 +63,7 @@ export default function ClientCasesPage({
     (params.id ? [params.id] : []);
 
   useEffect(() => {
+    if (!session) return;
     const es = apiEventSource("/api/cases/stream");
     es.onmessage = (e) => {
       const data = JSON.parse(e.data) as Case & { deleted?: boolean };
@@ -80,7 +83,7 @@ export default function ClientCasesPage({
       });
     };
     return () => es.close();
-  }, [orderBy, userLocation]);
+  }, [orderBy, userLocation, session]);
 
   useEffect(() => {
     setCases((prev) => sortList(prev, orderBy, userLocation));

--- a/src/app/cases/layout.tsx
+++ b/src/app/cases/layout.tsx
@@ -1,4 +1,6 @@
+import { authOptions } from "@/lib/authOptions";
 import { getCases } from "@/lib/caseStore";
+import { getServerSession } from "next-auth/next";
 import type { ReactNode } from "react";
 import CasesLayoutClient from "./CasesLayoutClient";
 
@@ -12,6 +14,8 @@ export default async function CasesLayout({
   params: Promise<{ id?: string }>;
 }) {
   await params;
-  const cases = getCases();
+  const session = await getServerSession(authOptions);
+  const list = getCases();
+  const cases = session ? list : list.filter((c) => c.public);
   return <CasesLayoutClient initialCases={cases}>{children}</CasesLayoutClient>;
 }

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -62,12 +62,14 @@ export default function NavBar() {
         >
           Map View
         </Link>
-        <Link
-          href="/triage"
-          className="hover:text-gray-600 dark:hover:text-gray-300"
-        >
-          Triage
-        </Link>
+        {session ? (
+          <Link
+            href="/triage"
+            className="hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            Triage
+          </Link>
+        ) : null}
         {session?.user?.role === "admin" ||
         session?.user?.role === "superadmin" ? (
           <Link
@@ -85,18 +87,22 @@ export default function NavBar() {
             System Status
           </Link>
         ) : null}
-        <Link
-          href="/settings"
-          className="hover:text-gray-600 dark:hover:text-gray-300"
-        >
-          User Settings
-        </Link>
-        <Link
-          href="/profile"
-          className="hover:text-gray-600 dark:hover:text-gray-300"
-        >
-          Profile
-        </Link>
+        {session ? (
+          <>
+            <Link
+              href="/settings"
+              className="hover:text-gray-600 dark:hover:text-gray-300"
+            >
+              User Settings
+            </Link>
+            <Link
+              href="/profile"
+              className="hover:text-gray-600 dark:hover:text-gray-300"
+            >
+              Profile
+            </Link>
+          </>
+        ) : null}
         {session ? (
           <button
             type="button"

--- a/src/app/triage/page.tsx
+++ b/src/app/triage/page.tsx
@@ -1,3 +1,4 @@
+import { authOptions } from "@/lib/authOptions";
 import type { Case } from "@/lib/caseStore";
 import { getCases } from "@/lib/caseStore";
 import {
@@ -8,6 +9,7 @@ import {
   hasViolation,
 } from "@/lib/caseUtils";
 import { reportModules } from "@/lib/reportModules";
+import { getServerSession } from "next-auth/next";
 import Link from "next/link";
 
 export const dynamic = "force-dynamic";
@@ -46,7 +48,19 @@ function nextAction(c: Case): string {
 }
 
 export default async function TriagePage() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return <div className="p-8">You are not logged in.</div>;
+  }
   const cases = getCases();
+  if (cases.length === 0) {
+    return (
+      <div className="p-8">
+        <h1 className="text-xl font-bold mb-4">Case Triage</h1>
+        <p>No cases available.</p>
+      </div>
+    );
+  }
   const triage = cases
     .map((c) => ({ case: c, severity: computeSeverity(c) }))
     .filter((t) => t.severity > 0)

--- a/test/e2e/triage.test.ts
+++ b/test/e2e/triage.test.ts
@@ -3,17 +3,27 @@ import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { createAuthHelpers } from "./authHelpers";
+import { createPhoto } from "./photo";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 let signIn: (email: string) => Promise<Response>;
+async function createCase(): Promise<string> {
+  const file = createPhoto("a");
+  const form = new FormData();
+  form.append("photo", file);
+  const res = await api("/api/upload", { method: "POST", body: form });
+  const data = (await res.json()) as { caseId: string };
+  return data.caseId;
+}
 
 beforeAll(async () => {
   server = await startServer(3040, { NEXTAUTH_SECRET: "secret" });
   api = createApi(server);
   ({ signIn } = createAuthHelpers(api, server));
   await signIn("user@example.com");
+  await createCase();
 });
 
 afterAll(async () => {


### PR DESCRIPTION
## Summary
- hide triage, settings and profile links when not logged in
- filter case list for anonymous users to only public cases
- require authentication and existing cases for triage page
- subscribe to case stream only when authenticated
- update e2e triage test to create a case first

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859a9acf020832baeb764442ad5a811