### PR TITLE
Add mobile redirect

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,10 +9,13 @@ import LoggedOutLanding from "./LoggedOutLanding";
 export default async function Home() {
   const session = await getServerSession(authOptions);
   console.log("home session", !!session);
-  if (!session) {
-    return <LoggedOutLanding />;
-  }
   const ua = (await headers()).get("user-agent") ?? "";
   const isMobile = /Mobile|Android|iPhone|iPad/i.test(ua);
+  if (!session) {
+    if (isMobile) {
+      redirect(withBasePath("/point"));
+    }
+    return <LoggedOutLanding />;
+  }
   redirect(withBasePath(isMobile ? "/point" : "/cases"));
 }


### PR DESCRIPTION
## Summary
- redirect mobile visitors without a session from the homepage to the point-and-shoot page

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: `cookies` was called outside a request scope)*

------
https://chatgpt.com/codex/tasks/task_e_6859b6fa2fe8832bbf0353018ce826d7