### PR TITLE
Implement case claiming after sign-in

### DIFF
--- a/src/app/api/cases/claim/route.ts
+++ b/src/app/api/cases/claim/route.ts
@@ -1,0 +1,29 @@
+import { getAnonymousSessionId } from "@/lib/anonymousSession";
+import { getSessionDetails, withAuthorization } from "@/lib/authz";
+import { claimCasesForSession } from "@/lib/caseStore";
+import { NextResponse } from "next/server";
+
+export const POST = withAuthorization(
+  { obj: "cases", act: "update" },
+  async (
+    req: Request,
+    {
+      params: _params,
+      session,
+    }: {
+      params: Promise<Record<string, string>>;
+      session?: { user?: { id?: string; role?: string } };
+    },
+  ) => {
+    const { userId } = getSessionDetails({ session }, "user");
+    if (!userId) {
+      return new Response(null, { status: 403 });
+    }
+    const sessionId = getAnonymousSessionId(req);
+    if (!sessionId) {
+      return NextResponse.json([]);
+    }
+    const claimed = claimCasesForSession(userId, sessionId);
+    return NextResponse.json(claimed);
+  },
+);

--- a/src/app/auth-provider.tsx
+++ b/src/app/auth-provider.tsx
@@ -1,6 +1,18 @@
 "use client";
+import { apiFetch } from "@/apiClient";
 import type { Session } from "next-auth";
-import { SessionProvider } from "next-auth/react";
+import { SessionProvider, useSession } from "next-auth/react";
+import { useEffect } from "react";
+
+function ClaimCases() {
+  const { status } = useSession();
+  useEffect(() => {
+    if (status === "authenticated") {
+      apiFetch("/api/cases/claim", { method: "POST" });
+    }
+  }, [status]);
+  return null;
+}
 
 export default function AuthProvider({
   children,
@@ -9,5 +21,10 @@ export default function AuthProvider({
   children: React.ReactNode;
   session?: Session | null;
 }) {
-  return <SessionProvider session={session}>{children}</SessionProvider>;
+  return (
+    <SessionProvider session={session}>
+      <ClaimCases />
+      {children}
+    </SessionProvider>
+  );
 }


### PR DESCRIPTION
## Summary
- add API route for claiming cases using session cookie
- trigger case claiming on client after sign-in via `apiFetch`

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: cookies used outside request scope)*

------
https://chatgpt.com/codex/tasks/task_e_6859b5ef2adc832bad9d5ad7be6bbae6