### PR TITLE
Fix anonymous upload case handling

### DIFF
--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { getAnonymousSessionId } from "@/lib/anonymousSession";
+import { getAnonSession, getAnonymousSessionId } from "@/lib/anonymousSession";
 import { getSessionDetails, withAuthorization } from "@/lib/authz";
 import {
   analyzeCaseInBackground,
@@ -32,8 +32,13 @@ export const POST = withAuthorization(
       session?: { user?: { id?: string; role?: string } };
     },
   ) => {
-    const cookieStore = cookies();
-    let anonId = cookieStore.get("anonSession")?.value;
+    let anonId: string | undefined;
+    try {
+      const store = await cookies();
+      anonId = store.get("anonSession")?.value;
+    } catch {
+      anonId = getAnonSession(req);
+    }
     let setSessionCookie = false;
     if (!anonId) {
       anonId = crypto.randomUUID();

--- a/src/lib/anonymousSession.ts
+++ b/src/lib/anonymousSession.ts
@@ -9,3 +9,17 @@ export function getAnonymousSessionId(req: Request): string | undefined {
   }
   return undefined;
 }
+
+export function getAnonSession(req: Request): string | undefined {
+  // handle tests where `req` may be a simple object without headers
+  const headers = (req as { headers?: Headers }).headers;
+  const cookie = headers?.get("cookie");
+  if (!cookie) return undefined;
+  for (const part of cookie.split(/;\s*/)) {
+    const [name, ...rest] = part.split("=");
+    if (name === "anonSession") {
+      return decodeURIComponent(rest.join("="));
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- parse `anonSession` cookie using next/headers when available
- fall back to request headers in tests
- keep anonymous upload permission
- update protected routes test for new behavior

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859b7a77cd4832b9bae36103c45e547