### PR TITLE
fix thumbnails with tall aspect ratios

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -965,7 +965,7 @@ export default function ClientCasePage({
                             alt="case photo"
                             width={80}
                             height={60}
-                            className="object-cover"
+                            imageClassName="object-contain"
                           />
                           {isPhotoReanalysis && reanalyzingPhoto === p ? (
                             <div className="absolute top-0 left-0 right-0">
@@ -1099,7 +1099,7 @@ export default function ClientCasePage({
                               alt="paperwork"
                               width={80}
                               height={60}
-                              className="object-cover"
+                              imageClassName="object-contain"
                             />
                           </div>
                           {time ? (

--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -150,7 +150,7 @@ export default function DraftEditor({
             alt="email attachment"
             width={120}
             height={90}
-            className="object-contain"
+            imageClassName="object-contain"
           />
         ))}
       </div>

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
@@ -342,7 +342,7 @@ export default function NotifyOwnerEditor({
             alt="email attachment"
             width={120}
             height={90}
-            className="object-contain"
+            imageClassName="object-contain"
           />
         ))}
       </div>

--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -146,7 +146,8 @@ export default function ClientThreadPage({
               alt="scan"
               width={150}
               height={100}
-              className="object-contain cursor-pointer"
+              className="cursor-pointer"
+              imageClassName="object-contain"
               onClick={() => setViewImage(img.url)}
             />
             <div className="flex flex-col gap-2 flex-1">

--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -95,7 +95,7 @@ export default function MapPageClient({ cases }: { cases: MapCase[] }) {
                 alt={`Case ${c.id}`}
                 width={160}
                 height={120}
-                className="object-cover"
+                imageClassName="object-cover"
               />
               <div>Case {c.id}</div>
             </a>

--- a/src/components/thumbnail-image.tsx
+++ b/src/components/thumbnail-image.tsx
@@ -2,9 +2,14 @@ import Image from "next/image";
 import { useEffect, useState } from "react";
 
 export interface ThumbnailImageProps
-  extends React.ComponentPropsWithoutRef<typeof Image> {
+  extends Omit<
+    React.ComponentPropsWithoutRef<typeof Image>,
+    "width" | "height" | "className"
+  > {
   width: number;
   height: number;
+  className?: string;
+  imageClassName?: string;
 }
 
 export default function ThumbnailImage({
@@ -13,6 +18,7 @@ export default function ThumbnailImage({
   width,
   height,
   className,
+  imageClassName,
   ...props
 }: ThumbnailImageProps) {
   const [ready, setReady] = useState(false);
@@ -38,7 +44,7 @@ export default function ThumbnailImage({
         height={height}
         onLoad={() => setReady(true)}
         onError={() => setReady(false)}
-        className={`object-cover ${ready ? "" : "invisible"}`}
+        className={`object-cover ${imageClassName ?? ""} ${ready ? "" : "invisible"}`}
         {...props}
       />
     </div>


### PR DESCRIPTION
## Summary
- revert upload route changes
- ensure thumbnails use object-contain via new `imageClassName` prop

## Testing
- `npm run lint`
- `npm test` *(fails: anonymous upload route out of request scope)*

------
https://chatgpt.com/codex/tasks/task_e_6859ca914f94832baebba2177b106836