### PR TITLE
Add CaseChat story with live LLM option

### DIFF
--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -5,7 +5,7 @@ import { NextResponse } from "next/server";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 
 export const POST = withCaseAuthorization(
-  { obj: "cases" },
+  { obj: "cases", act: "read" },
   async (req: Request, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
     const body = (await req.json()) as {

--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -1,0 +1,39 @@
+import { withCaseAuthorization } from "@/lib/authz";
+import { getCase } from "@/lib/caseStore";
+import { getLlm } from "@/lib/llm";
+import { NextResponse } from "next/server";
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+
+export const POST = withCaseAuthorization(
+  { obj: "cases" },
+  async (req: Request, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const body = (await req.json()) as {
+      messages: Array<{ role: "user" | "assistant"; content: string }>;
+    };
+    const c = getCase(id);
+    if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    const analysis = c.analysis;
+    const vehicle = analysis?.vehicle ?? {};
+    const location =
+      c.streetAddress ||
+      c.intersection ||
+      (c.gps ? `${c.gps.lat}, ${c.gps.lon}` : "unknown location");
+    const system = `You are a helpful legal assistant for the Photo To Citation app. The user is asking about a case with these details:\nViolation: ${analysis?.violationType || ""}\nDescription: ${analysis?.details || ""}\nLocation: ${location}\nLicense Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}\nNumber of photos: ${c.photos.length}.`;
+
+    const messages: ChatCompletionMessageParam[] = [
+      { role: "system", content: system },
+      ...body.messages,
+    ];
+
+    const { client, model } = getLlm("draft_email");
+    const res = await client.chat.completions.create({
+      model,
+      messages,
+      max_tokens: 800,
+    });
+    const reply = res.choices[0]?.message?.content ?? "";
+    return NextResponse.json({ reply });
+  },
+);

--- a/src/app/cases/[id]/CaseChat.stories.tsx
+++ b/src/app/cases/[id]/CaseChat.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import CaseChat from "./CaseChat";
+import { useState } from "react";
+import OpenAI from "openai";
+
+const meta: Meta<typeof CaseChat> = {
+  component: CaseChat,
+  title: "Components/CaseChat",
+};
+export default meta;
+
+type Story = StoryObj<typeof CaseChat>;
+
+export const WithLiveLlm: Story = {
+  render: () => {
+    const [apiKey, setApiKey] = useState("");
+    const [baseUrl, setBaseUrl] = useState("");
+
+    async function onChat(messages: Array<{ role: "user" | "assistant"; content: string }>) {
+      if (!apiKey) return "";
+      const client = new OpenAI({
+        apiKey,
+        baseURL: baseUrl || undefined,
+        dangerouslyAllowBrowser: true,
+      });
+      const res = await client.chat.completions.create({
+        model: "gpt-4o",
+        messages,
+        max_tokens: 800,
+      });
+      return res.choices[0]?.message?.content ?? "";
+    }
+
+    return (
+      <div className="space-y-2 p-4">
+        <label className="block">
+          API Key:
+          <input
+            type="text"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            className="border rounded w-full p-1"
+          />
+        </label>
+        <label className="block">
+          Base URL:
+          <input
+            type="text"
+            value={baseUrl}
+            onChange={(e) => setBaseUrl(e.target.value)}
+            placeholder="https://api.openai.com/v1"
+            className="border rounded w-full p-1"
+          />
+        </label>
+        <CaseChat caseId="story" onChat={onChat} />
+      </div>
+    );
+  },
+};

--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -1,0 +1,149 @@
+"use client";
+import { apiFetch } from "@/apiClient";
+import { useEffect, useRef, useState } from "react";
+
+interface Message {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+}
+
+export default function CaseChat({
+  caseId,
+  onChat,
+}: {
+  caseId: string;
+  onChat?: (messages: Message[]) => Promise<string>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  async function send() {
+    const text = input.trim();
+    if (!text) return;
+    const list = [
+      ...messages,
+      { id: crypto.randomUUID(), role: "user", content: text },
+    ];
+    setMessages(list);
+    setInput("");
+    setLoading(true);
+    try {
+      let reply = "";
+      if (onChat) {
+        reply = await onChat(list);
+      } else {
+        const res = await apiFetch(`/api/cases/${caseId}/chat`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ messages: list }),
+        });
+        if (res.ok) {
+          const data = (await res.json()) as { reply: string };
+          reply = data.reply;
+        }
+      }
+      if (reply) {
+        setMessages([
+          ...list,
+          { id: crypto.randomUUID(), role: "assistant", content: reply },
+        ]);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll when messages change
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  return (
+    <div className="fixed bottom-4 right-4 z-40 text-sm">
+      {open ? (
+        <div className="bg-white dark:bg-gray-900 shadow-lg rounded w-80 h-96 flex flex-col">
+          <div className="flex justify-between items-center border-b p-2">
+            <span className="font-semibold">Case Chat</span>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close chat"
+              className="text-xl leading-none"
+            >
+              ×
+            </button>
+          </div>
+          <div ref={scrollRef} className="flex-1 overflow-y-auto p-2 space-y-2">
+            {messages.map((m) => (
+              <div
+                key={m.id}
+                className={m.role === "user" ? "text-right" : "text-left"}
+              >
+                <span className="inline-block px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
+                  {m.content}
+                </span>
+              </div>
+            ))}
+          </div>
+          <div className="border-t p-2 flex gap-2">
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  void send();
+                }
+              }}
+              className="flex-1 border rounded px-1 dark:bg-gray-800"
+              placeholder="Ask a question..."
+            />
+            <button
+              type="button"
+              onClick={send}
+              disabled={loading}
+              className="bg-blue-600 text-white px-2 rounded disabled:opacity-50"
+            >
+              Send
+            </button>
+          </div>
+          <div className="border-t p-2 flex gap-2 justify-end">
+            <a
+              href={`/cases/${caseId}/compose`}
+              className="underline text-blue-500"
+            >
+              Draft Report
+            </a>
+            <a
+              href={`/cases/${caseId}/followup`}
+              className="underline text-blue-500"
+            >
+              Follow Up
+            </a>
+            <a
+              href={`/cases/${caseId}/notify-owner`}
+              className="underline text-blue-500"
+            >
+              Notify Owner
+            </a>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="bg-blue-600 text-white px-3 py-1 rounded shadow"
+        >
+          Chat
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { apiEventSource, apiFetch } from "@/apiClient";
+import CaseChat from "@/app/cases/[id]/CaseChat";
 import useDragReset from "@/app/cases/useDragReset";
 import AnalysisInfo from "@/app/components/AnalysisInfo";
 import CaseJobList from "@/app/components/CaseJobList";
@@ -1122,6 +1123,7 @@ export default function ClientCasePage({
           Drop to add photos
         </div>
       )}
+      <CaseChat caseId={caseId} />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
 export { dynamic } from "./cases/page";
 import { withBasePath } from "@/basePath";
 import { authOptions } from "@/lib/authOptions";
+import isMobile from "is-mobile";
 import { getServerSession } from "next-auth/next";
 import { headers } from "next/headers";
-import isMobile from "is-mobile";
 import { redirect } from "next/navigation";
 import LoggedOutLanding from "./LoggedOutLanding";
 

--- a/test/e2e/chat.test.ts
+++ b/test/e2e/chat.test.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createApi } from "./api";
+import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
+import { createPhoto } from "./photo";
+import { type TestServer, startServer } from "./startServer";
+
+let server: TestServer;
+let api: (path: string, opts?: RequestInit) => Promise<Response>;
+let stub: OpenAIStub;
+let tmpDir: string;
+
+beforeAll(async () => {
+  stub = await startOpenAIStub("hello");
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-chat-"));
+  server = await startServer(3012, {
+    NEXTAUTH_SECRET: "secret",
+    OPENAI_BASE_URL: stub.url,
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
+  });
+  api = createApi(server);
+});
+
+afterAll(async () => {
+  await server.close();
+  await stub.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("chat api", () => {
+  async function createCase(): Promise<string> {
+    const file = createPhoto("a");
+    const form = new FormData();
+    form.append("photo", file);
+    const res = await api("/api/upload", { method: "POST", body: form });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { caseId: string };
+    return data.caseId;
+  }
+
+  it("returns an LLM reply", async () => {
+    const id = await createCase();
+    const res = await api(`/api/cases/${id}/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "Hi" }] }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { reply: string };
+    expect(data.reply).toBe("hello");
+    expect(stub.requests.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- let `CaseChat` accept an optional custom chat handler
- provide a Storybook example to talk to a live LLM

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c0341b64832bb7f46a4a4296f415