### PR TITLE
Add image context to LLM analysis

### DIFF
--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -20,7 +20,12 @@ export const POST = withCaseAuthorization(
       c.streetAddress ||
       c.intersection ||
       (c.gps ? `${c.gps.lat}, ${c.gps.lon}` : "unknown location");
-    const system = `You are a helpful legal assistant for the Photo To Citation app. The user is asking about a case with these details:\nViolation: ${analysis?.violationType || ""}\nDescription: ${analysis?.details || ""}\nLocation: ${location}\nLicense Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}\nNumber of photos: ${c.photos.length}.`;
+    const contextLines = analysis?.images
+      ? Object.entries(analysis.images)
+          .map(([name, info]) => `Photo ${name}: ${info.context || ""}`)
+          .join("\n")
+      : "";
+    const system = `You are a helpful legal assistant for the Photo To Citation app. The user is asking about a case with these details:\nViolation: ${analysis?.violationType || ""}\nDescription: ${analysis?.details || ""}\nLocation: ${location}\nLicense Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}\nNumber of photos: ${c.photos.length}.${contextLines ? `\nImage contexts:\n${contextLines}` : ""}`;
 
     const messages: ChatCompletionMessageParam[] = [
       { role: "system", content: system },

--- a/src/app/cases/[id]/CaseChat.stories.tsx
+++ b/src/app/cases/[id]/CaseChat.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import CaseChat from "./CaseChat";
-import { useState } from "react";
 import OpenAI from "openai";
+import { useState } from "react";
+import CaseChat from "./CaseChat";
 
 const meta: Meta<typeof CaseChat> = {
   component: CaseChat,
@@ -16,7 +16,9 @@ export const WithLiveLlm: Story = {
     const [apiKey, setApiKey] = useState("");
     const [baseUrl, setBaseUrl] = useState("");
 
-    async function onChat(messages: Array<{ role: "user" | "assistant"; content: string }>) {
+    async function onChat(
+      messages: Array<{ role: "user" | "assistant"; content: string }>,
+    ) {
       if (!apiKey) return "";
       const client = new OpenAI({
         apiKey,

--- a/src/app/components/ImageHighlights.tsx
+++ b/src/app/components/ImageHighlights.tsx
@@ -18,6 +18,7 @@ export default function ImageHighlights({
         {info.representationScore.toFixed(2)}
       </span>
       {info.highlights ? <span>{info.highlights}</span> : null}
+      {info.context ? <span>{info.context}</span> : null}
     </div>
   );
 }

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -98,6 +98,7 @@ export const violationReportSchema = z.object({
       z.object({
         representationScore: z.number().min(0).max(1),
         highlights: z.string().optional(),
+        context: z.string().optional(),
         violation: z.boolean().optional(),
         paperwork: z.boolean().optional(),
         paperworkText: z.string().optional(),
@@ -141,6 +142,7 @@ export async function analyzeViolation(
           properties: {
             representationScore: { type: "number" },
             highlights: { type: "string" },
+            context: { type: "string" },
             violation: { type: "boolean" },
             paperwork: { type: "boolean" },
             paperworkText: { type: "string" },
@@ -165,7 +167,7 @@ export async function analyzeViolation(
       content: [
         {
           type: "text",
-          text: `Analyze the photo${urls.length > 1 ? "s" : ""} and score each image from 0 to 1 for how well it represents the case. Indicate with a boolean if each photo depicts a violation. If an image is paperwork such as a letter or form, set a paperwork flag and omit the text. Also provide a short description of the evidence each image adds. Use these filenames as keys: ${names.join(", ")}. Respond with JSON matching this schema: ${JSON.stringify(
+          text: `Analyze the photo${urls.length > 1 ? "s" : ""} and score each image from 0 to 1 for how well it represents the case. Indicate with a boolean if each photo depicts a violation. If an image is paperwork such as a letter or form, set a paperwork flag and omit the text. Also provide a short description of the evidence each image adds. Include a detailed context description of everything visible in each image, even if it seems irrelevant, under a context field. Use these filenames as keys: ${names.join(", ")}. Respond with JSON matching this schema: ${JSON.stringify(
             schema,
           )}`,
         },

--- a/test/anonymousUpload.test.ts
+++ b/test/anonymousUpload.test.ts
@@ -34,10 +34,8 @@ afterEach(() => {
 });
 
 describe("anonymous upload", () => {
-  it(
-    "sets session cookie and returns case",
-    async () => {
-      const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
+  it("sets session cookie and returns case", async () => {
+    const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();
     form.append("photo", file);
     const req = new Request("http://test", { method: "POST", body: form });
@@ -49,13 +47,11 @@ describe("anonymous upload", () => {
     const getReq = new Request("http://test", {
       headers: { cookie: setCookie.split(";")[0] },
     });
-      const caseRes = await caseRoute.GET(getReq, {
-        params: Promise.resolve({ id: caseId }),
-      });
-      expect(caseRes.status).toBe(200);
-      const data = await caseRes.json();
-      expect(data.id).toBe(caseId);
-    },
-    15000,
-  );
+    const caseRes = await caseRoute.GET(getReq, {
+      params: Promise.resolve({ id: caseId }),
+    });
+    expect(caseRes.status).toBe(200);
+    const data = await caseRes.json();
+    expect(data.id).toBe(caseId);
+  }, 15000);
 });


### PR DESCRIPTION
## Summary
- generate a `context` field for each image in `analyzeViolation`
- include the context in case chat system prompts
- show context in `ImageHighlights`
- fix import order in storybook example
- format test files

## Testing
- `npm run lint`
- `NEXTAUTH_SECRET=secret npm test` *(fails: Test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6859e7969c8c832ba57a0682c9c8e2c8