### PR TITLE
Focus chat input on open

### DIFF
--- a/src/app/cases/[id]/CaseChat.stories.tsx
+++ b/src/app/cases/[id]/CaseChat.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import CaseChat from "./CaseChat";
-import { useState } from "react";
 import OpenAI from "openai";
+import { useState } from "react";
+import CaseChat from "./CaseChat";
 
 const meta: Meta<typeof CaseChat> = {
   component: CaseChat,
@@ -16,7 +16,9 @@ export const WithLiveLlm: Story = {
     const [apiKey, setApiKey] = useState("");
     const [baseUrl, setBaseUrl] = useState("");
 
-    async function onChat(messages: Array<{ role: "user" | "assistant"; content: string }>) {
+    async function onChat(
+      messages: Array<{ role: "user" | "assistant"; content: string }>,
+    ) {
       if (!apiKey) return "";
       const client = new OpenAI({
         apiKey,

--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -20,6 +20,7 @@ export default function CaseChat({
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   async function send() {
     const text = input.trim();
@@ -64,6 +65,10 @@ export default function CaseChat({
     }
   }, [messages]);
 
+  useEffect(() => {
+    if (open && inputRef.current) inputRef.current.focus();
+  }, [open]);
+
   return (
     <div className="fixed bottom-4 right-4 z-40 text-sm">
       {open ? (
@@ -93,6 +98,7 @@ export default function CaseChat({
           </div>
           <div className="border-t p-2 flex gap-2">
             <input
+              ref={inputRef}
               type="text"
               value={input}
               onChange={(e) => setInput(e.target.value)}

--- a/src/app/cases/__tests__/caseChatFocus.test.tsx
+++ b/src/app/cases/__tests__/caseChatFocus.test.tsx
@@ -1,0 +1,13 @@
+import CaseChat from "@/app/cases/[id]/CaseChat";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+describe("CaseChat input focus", () => {
+  it("focuses the input when opened", () => {
+    const { getByText, getByPlaceholderText } = render(<CaseChat caseId="1" />);
+    const button = getByText("Chat");
+    fireEvent.click(button);
+    const input = getByPlaceholderText("Ask a question...") as HTMLInputElement;
+    expect(document.activeElement).toBe(input);
+  });
+});


### PR DESCRIPTION
## Summary
- refocus input when opening CaseChat
- clean up import order in CaseChat storybook
- add test verifying focus

## Testing
- `npm run format`
- `npm run lint`
- `NEXTAUTH_SECRET=secret npm test` *(fails: anonymousUpload.test.ts timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6859e6a56e40832ba0635eb6542459fd