### PR TITLE
Simplify chat bubble styling

### DIFF
--- a/src/app/cases/[id]/CaseChat.module.css
+++ b/src/app/cases/[id]/CaseChat.module.css
@@ -1,0 +1,53 @@
+.bubble {
+  position: relative;
+  display: inline-block;
+  max-width: 100%;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+}
+
+.user {
+  background-color: rgb(37, 99, 235); /* blue-600 */
+  color: white;
+}
+.user::after {
+  content: "";
+  position: absolute;
+  bottom: 0.25rem;
+  right: -0.25rem;
+  border-width: 0.4rem 0 0.4rem 0.4rem;
+  border-style: solid;
+  border-color: transparent transparent transparent rgb(37, 99, 235);
+}
+
+@media (prefers-color-scheme: dark) {
+  .user {
+    background-color: rgb(29, 78, 216); /* blue-700 */
+  }
+  .user::after {
+    border-left-color: rgb(29, 78, 216);
+  }
+}
+
+.assistant {
+  background-color: rgb(229, 231, 235); /* gray-200 */
+}
+.assistant::after {
+  content: "";
+  position: absolute;
+  bottom: 0.25rem;
+  left: -0.25rem;
+  border-width: 0.4rem 0.4rem 0.4rem 0;
+  border-style: solid;
+  border-color: transparent rgb(229, 231, 235) transparent transparent;
+}
+
+@media (prefers-color-scheme: dark) {
+  .assistant {
+    background-color: rgb(55, 65, 81); /* gray-700 */
+    color: white;
+  }
+  .assistant::after {
+    border-right-color: rgb(55, 65, 81);
+  }
+}

--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { apiFetch } from "@/apiClient";
 import { useEffect, useRef, useState } from "react";
+import styles from "./CaseChat.module.css";
 
 interface Message {
   id: string;
@@ -91,11 +92,9 @@ export default function CaseChat({
                 className={m.role === "user" ? "text-right" : "text-left"}
               >
                 <span
-                  className={
-                    m.role === "user"
-                      ? "relative inline-block max-w-full px-2 py-1 rounded bg-blue-600 text-white after:content-[''] after:absolute after:-right-1 after:bottom-1 after:border-[0.4rem] after:border-y-transparent after:border-l-blue-600 dark:bg-blue-700 dark:after:border-l-blue-700"
-                      : "relative inline-block max-w-full px-2 py-1 rounded bg-gray-200 after:content-[''] after:absolute after:-left-1 after:bottom-1 after:border-[0.4rem] after:border-y-transparent after:border-r-gray-200 dark:bg-gray-700 dark:text-white dark:after:border-r-gray-700"
-                  }
+                  className={`${styles.bubble} ${
+                    m.role === "user" ? styles.user : styles.assistant
+                  }`}
                 >
                   {m.content}
                 </span>


### PR DESCRIPTION
## Summary
- add `CaseChat.module.css` with small classes for case chat bubble styling
- apply those classes in `CaseChat.tsx` for clarity

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Test timed out in anonymous upload)*

------
https://chatgpt.com/codex/tasks/task_e_6859ebb561c4832b96916e24952392cb