### PR TITLE
Add case chat history dropdown

### DIFF
--- a/src/app/cases/__tests__/caseChatHistory.test.tsx
+++ b/src/app/cases/__tests__/caseChatHistory.test.tsx
@@ -1,0 +1,20 @@
+import CaseChat from "@/app/cases/[id]/CaseChat";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+describe("CaseChat history", () => {
+  it("saves chat to localStorage", async () => {
+    localStorage.clear();
+    const { getByText, getByPlaceholderText, getByLabelText, findByText } =
+      render(<CaseChat caseId="1" onChat={async () => "ok"} />);
+    fireEvent.click(getByText("Chat"));
+    const input = getByPlaceholderText("Ask a question...");
+    fireEvent.change(input, { target: { value: "Hello" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+    await findByText("ok");
+    fireEvent.click(getByLabelText("Close chat"));
+    fireEvent.click(getByText("Chat"));
+    const select = getByLabelText("Chat history") as HTMLSelectElement;
+    expect(select.options.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- store chat messages in localStorage per case
- add dropdown in CaseChat to load past sessions
- test that chat history is saved

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Failed Suites 5, Failed Tests 34)*

------
https://chatgpt.com/codex/tasks/task_e_6859ee06b390832b9fd933db2d97977a