### PR TITLE
Add syntax for case chat action buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,5 +449,6 @@ Set `NEXT_PUBLIC_BROWSER_DEBUG` to `true` in your `.env` to enable a JSON overla
 - [**GitHub Repository**](https://github.com/antialias/photo-to-citation) — star the project or submit a pull request.
 - [**Documentation Outline**](docs/feature-outline.md) — discover planned features and architecture.
 - [**Credit System**](docs/credit-system.md) — how users purchase credits and how balances update.
+- [**Case Chat Buttons**](docs/case-chat-actions.md) — LLM syntax for inserting action buttons.
 - [**Releases**](https://github.com/antialias/photo-to-citation/releases) — download the latest packaged version.
 - [**Live Demo**](https://730op.synology.me/photo-citation) — try the hosted web app.

--- a/docs/case-chat-actions.md
+++ b/docs/case-chat-actions.md
@@ -1,0 +1,28 @@
+# Case Chat Action Buttons
+
+Case Chat now supports inline buttons suggested by the LLM. The assistant can include
+special tokens in its reply to render a button for any available case action.
+
+Use the syntax `[action:ACTION_ID]` within the message text. When displayed, this
+placeholder becomes a button using the label from the case action list. The
+button opens a modal or page with the requested action.
+
+Example:
+```
+You may want to notify the vehicle owner. [action:notify-owner]
+```
+This produces a **Notify Owner** button in the chat.
+
+Available actions:
+
+- `[action:compose]` — **Draft Report**: open a form to compose an email report
+  to the appropriate authority.
+- `[action:followup]` — **Follow Up**: send another email in an existing thread
+  to ask about citation status.
+- `[action:notify-owner]` — **Notify Owner**: create an anonymous email warning
+  the vehicle owner about their violation.
+- `[action:ownership]` — **Request Ownership Info**: record the request for
+  official ownership details from the state.
+
+This list is populated from the `caseActions` export, so new actions become
+available to the chat UI automatically.

--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -1,4 +1,5 @@
 import { withCaseAuthorization } from "@/lib/authz";
+import { caseActions } from "@/lib/caseActions";
 import { getCase } from "@/lib/caseStore";
 import { getLlm } from "@/lib/llm";
 import { NextResponse } from "next/server";
@@ -20,7 +21,10 @@ export const POST = withCaseAuthorization(
       c.streetAddress ||
       c.intersection ||
       (c.gps ? `${c.gps.lat}, ${c.gps.lon}` : "unknown location");
-    const system = `You are a helpful legal assistant for the Photo To Citation app. The user is asking about a case with these details:\nViolation: ${analysis?.violationType || ""}\nDescription: ${analysis?.details || ""}\nLocation: ${location}\nLicense Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}\nNumber of photos: ${c.photos.length}.`;
+    const actionList = caseActions
+      .map((a) => `- ${a.label} [${a.id}]: ${a.description}`)
+      .join("\\n");
+    const system = `You are a helpful legal assistant for the Photo To Citation app. The user is asking about a case with these details:\nViolation: ${analysis?.violationType || ""}\nDescription: ${analysis?.details || ""}\nLocation: ${location}\nLicense Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}\nNumber of photos: ${c.photos.length}.\nUse [action:ID] tokens to display helpful action buttons for the user. Available actions:\n${actionList}`;
 
     const messages: ChatCompletionMessageParam[] = [
       { role: "system", content: system },

--- a/src/app/cases/[id]/CaseChat.stories.tsx
+++ b/src/app/cases/[id]/CaseChat.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import CaseChat from "./CaseChat";
-import { useState } from "react";
 import OpenAI from "openai";
+import { useState } from "react";
+import CaseChat from "./CaseChat";
 
 const meta: Meta<typeof CaseChat> = {
   component: CaseChat,
@@ -16,7 +16,9 @@ export const WithLiveLlm: Story = {
     const [apiKey, setApiKey] = useState("");
     const [baseUrl, setBaseUrl] = useState("");
 
-    async function onChat(messages: Array<{ role: "user" | "assistant"; content: string }>) {
+    async function onChat(
+      messages: Array<{ role: "user" | "assistant"; content: string }>,
+    ) {
       if (!apiKey) return "";
       const client = new OpenAI({
         apiKey,

--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -1,5 +1,7 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import { caseActions } from "@/lib/caseActions";
+import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
 interface Message {
@@ -20,6 +22,30 @@ export default function CaseChat({
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
+
+  function renderContent(text: string) {
+    const parts = text.split(/(\[action:[^\]]+\])/g);
+    return parts.map((p, idx) => {
+      const match = p.match(/^\[action:([^\]]+)\]$/);
+      if (match) {
+        const act = caseActions.find((a) => a.id === match[1]);
+        if (act) {
+          return (
+            <button
+              key={`${act.id}-${idx}`}
+              type="button"
+              onClick={() => router.push(act.href(caseId))}
+              className="bg-blue-600 text-white px-2 py-1 rounded mx-1"
+            >
+              {act.label}
+            </button>
+          );
+        }
+      }
+      return <span key={`text-${idx}-${p}`}>{p}</span>;
+    });
+  }
 
   async function send() {
     const text = input.trim();
@@ -86,7 +112,7 @@ export default function CaseChat({
                 className={m.role === "user" ? "text-right" : "text-left"}
               >
                 <span className="inline-block px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
-                  {m.content}
+                  {renderContent(m.content)}
                 </span>
               </div>
             ))}
@@ -115,24 +141,16 @@ export default function CaseChat({
             </button>
           </div>
           <div className="border-t p-2 flex gap-2 justify-end">
-            <a
-              href={`/cases/${caseId}/compose`}
-              className="underline text-blue-500"
-            >
-              Draft Report
-            </a>
-            <a
-              href={`/cases/${caseId}/followup`}
-              className="underline text-blue-500"
-            >
-              Follow Up
-            </a>
-            <a
-              href={`/cases/${caseId}/notify-owner`}
-              className="underline text-blue-500"
-            >
-              Notify Owner
-            </a>
+            {caseActions.map((a) => (
+              <button
+                key={a.id}
+                type="button"
+                onClick={() => router.push(a.href(caseId))}
+                className="bg-blue-600 text-white px-2 py-1 rounded"
+              >
+                {a.label}
+              </button>
+            ))}
           </div>
         </div>
       ) : (

--- a/src/lib/caseActions.ts
+++ b/src/lib/caseActions.ts
@@ -1,0 +1,37 @@
+export interface CaseAction {
+  id: string;
+  label: string;
+  href: (caseId: string) => string;
+  description: string;
+}
+
+export const caseActions: CaseAction[] = [
+  {
+    id: "compose",
+    label: "Draft Report",
+    href: (id) => `/cases/${id}/compose`,
+    description:
+      "Open a modal to draft an email report to the relevant authority. Use when the user wants to formally report the violation.",
+  },
+  {
+    id: "followup",
+    label: "Follow Up",
+    href: (id) => `/cases/${id}/followup`,
+    description:
+      "Send a follow-up email referencing previous correspondence. Suggest this when the user needs to check the status of a prior report.",
+  },
+  {
+    id: "notify-owner",
+    label: "Notify Owner",
+    href: (id) => `/cases/${id}/notify-owner`,
+    description:
+      "Send an anonymous notice to the vehicle owner about the violation. Useful when the owner might not know they were reported.",
+  },
+  {
+    id: "ownership",
+    label: "Request Ownership Info",
+    href: (id) => `/cases/${id}/ownership`,
+    description:
+      "Record the steps for requesting official ownership details from the state. Use if the license plate is known but contact info is missing.",
+  },
+];


### PR DESCRIPTION
## Summary
- expose `caseActions` list for chat UI
- parse `[action:id]` tokens in CaseChat messages
- show case action links dynamically
- document chat button syntax
- fix import ordering in CaseChat story
- use Next.js router to open actions as modals
- style buttons and expand LLM prompt guidance

## Testing
- `npm run lint`
- `npm test` *(fails: NEXTAUTH_SECRET environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_6859df6be480832b929f6a62db970830