### PR TITLE
Fix anonymous upload test

### DIFF
--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -1,4 +1,4 @@
-import { getAnonymousSessionId } from "@/lib/anonymousSession";
+import { getAnonSession, getAnonymousSessionId } from "@/lib/anonymousSession";
 import {
   authorize,
   getSessionDetails,
@@ -25,7 +25,10 @@ export async function GET(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
   const { role, userId } = await loadAuthContext({ session }, "anonymous");
-  const anonId = getAnonymousSessionId(req);
+  let anonId = getAnonymousSessionId(req);
+  if (!anonId) {
+    anonId = getAnonSession(req);
+  }
   const sessionMatch = anonId && c.sessionId && c.sessionId === anonId;
   const authRole = sessionMatch ? "user" : role;
   if (!(await authorize(authRole, "cases", "read"))) {

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -101,8 +101,8 @@ export const POST = withAuthorization(
       userId ?? null,
     );
     if (!userId) {
-      const anonId = getAnonymousSessionId(req);
-      if (anonId) setCaseSessionId(newCase.id, anonId);
+      const cookieAnon = getAnonymousSessionId(req);
+      setCaseSessionId(newCase.id, cookieAnon ?? anonId);
     }
     const p = updateCase(newCase.id, {
       analysisStatus: "pending",

--- a/test/anonymousUpload.test.ts
+++ b/test/anonymousUpload.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
@@ -54,13 +55,13 @@ afterEach(() => {
 });
 
 describe("anonymous upload", () => {
-  // TODO: investigate intermittent timeouts when running this test
-  it.skip("sets session cookie and returns case", async () => {
+  it("sets session cookie and returns case", async () => {
     const file = new File([Buffer.from("a")], "a.jpg", { type: "image/jpeg" });
     const form = new FormData();
     form.append("photo", file);
     const req = new Request("http://test", { method: "POST", body: form });
     const res = await upload.POST(req, { params: Promise.resolve({}) });
+    await new Promise((r) => setImmediate(r));
     worker.emit("exit");
     expect(res.status).toBe(200);
     const setCookie = res.headers.get("set-cookie") ?? "";


### PR DESCRIPTION
## Summary
- unskip anonymous upload test and run it under the node environment
- ensure GET route recognizes legacy `anonSession` cookie
- store anonymous session ID when creating a new case

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859ee6184c8832b9408a19e14146ed1