### PR TITLE
Improve CaseChat session selection

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -27,6 +27,8 @@ export default function CaseChat({
   const [messages, setMessages] = useState<Message[]>([]);
   const [history, setHistory] = useState<ChatSession[]>([]);
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [sessionCreatedAt, setSessionCreatedAt] = useState<string>("");
+  const [sessionSummary, setSessionSummary] = useState<string>("");
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -56,6 +58,8 @@ export default function CaseChat({
   function startNew() {
     setMessages([]);
     setSessionId(crypto.randomUUID());
+    setSessionCreatedAt(new Date().toISOString());
+    setSessionSummary("");
   }
 
   function handleOpen() {
@@ -67,10 +71,11 @@ export default function CaseChat({
     setOpen(false);
     if (messages.length > 0 && sessionId) {
       const firstUser = messages.find((m) => m.role === "user");
-      const summary = firstUser ? firstUser.content.slice(0, 30) : "";
+      const summary =
+        sessionSummary || (firstUser ? firstUser.content.slice(0, 30) : "");
       const session: ChatSession = {
         id: sessionId,
-        createdAt: new Date().toISOString(),
+        createdAt: sessionCreatedAt,
         summary,
         messages,
       };
@@ -87,6 +92,9 @@ export default function CaseChat({
       ...messages,
       { id: crypto.randomUUID(), role: "user", content: text },
     ];
+    if (messages.length === 0) {
+      setSessionSummary(text.slice(0, 30));
+    }
     setMessages(list);
     setInput("");
     setLoading(true);
@@ -135,7 +143,7 @@ export default function CaseChat({
             <span className="font-semibold flex-1">Case Chat</span>
             <select
               aria-label="Chat history"
-              value={sessionId ?? "new"}
+              value={sessionId ?? ""}
               onChange={(e) => {
                 const val = e.target.value;
                 if (val === "new") {
@@ -145,12 +153,20 @@ export default function CaseChat({
                   if (found) {
                     setMessages(found.messages);
                     setSessionId(found.id);
+                    setSessionCreatedAt(found.createdAt);
+                    setSessionSummary(found.summary);
                   }
                 }
               }}
               className="text-black dark:text-black text-xs"
             >
               <option value="new">New Chat</option>
+              {!history.some((h) => h.id === sessionId) && sessionId && (
+                <option value={sessionId}>
+                  {new Date(sessionCreatedAt).toLocaleString()}
+                  {sessionSummary ? ` - ${sessionSummary}` : ""}
+                </option>
+              )}
               {history.map((h) => (
                 <option key={h.id} value={h.id}>
                   {new Date(h.createdAt).toLocaleString()} - {h.summary}

--- a/src/app/cases/__tests__/caseChatCurrent.test.tsx
+++ b/src/app/cases/__tests__/caseChatCurrent.test.tsx
@@ -1,0 +1,23 @@
+import CaseChat from "@/app/cases/[id]/CaseChat";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+describe("CaseChat current session", () => {
+  it("shows current chat option and updates summary", async () => {
+    const { getByText, getByLabelText, getByPlaceholderText, findByText } =
+      render(<CaseChat caseId="1" onChat={async () => "ok"} />);
+    fireEvent.click(getByText("Chat"));
+    const select = getByLabelText("Chat history") as HTMLSelectElement;
+    expect(select.options.length).toBe(2);
+    const currentValue = select.value;
+    expect(currentValue).not.toBe("new");
+    const input = getByPlaceholderText("Ask a question...");
+    fireEvent.change(input, { target: { value: "Hello world" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+    await findByText("ok");
+    const currentOption = Array.from(select.options).find(
+      (o) => o.value === currentValue,
+    );
+    expect(currentOption?.textContent).toContain("Hello world");
+  });
+});

--- a/src/app/cases/__tests__/caseChatHistory.test.tsx
+++ b/src/app/cases/__tests__/caseChatHistory.test.tsx
@@ -15,6 +15,6 @@ describe("CaseChat history", () => {
     fireEvent.click(getByLabelText("Close chat"));
     fireEvent.click(getByText("Chat"));
     const select = getByLabelText("Chat history") as HTMLSelectElement;
-    expect(select.options.length).toBe(2);
+    expect(select.options.length).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary
- track current chat session metadata
- show current session in the CaseChat history menu
- update chat summary when messages are sent
- adjust tests for new behavior and add coverage

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859fd501e60832b86d659075df1ac20