### PR TITLE
Unify anonymous session cookie handling

### DIFF
--- a/docs/feature-outline.md
+++ b/docs/feature-outline.md
@@ -91,9 +91,10 @@ Desktop users can access this page from the "Point & Shoot" link in the header.
 Visitors can create cases without signing in. When an unauthenticated user hits
 the landing page on a phone they are redirected straight to `/point`. Each
 upload on this page stores a temporary session identifier in the `anonSession`
-cookie. The identifier is saved on the newly created case so that when the user
-signs in later the case is automatically claimed by their account. A weekly
-cleanup job removes any cases that were never claimed.
+cookie (older `anon_session_id` cookies are still recognized). The identifier is
+saved on the newly created case so that when the user signs in later the case is
+automatically claimed by their account. A weekly cleanup job removes any cases
+that were never claimed.
 
 ## 4. Automatic Analysis
 

--- a/src/app/api/cases/[id]/route.ts
+++ b/src/app/api/cases/[id]/route.ts
@@ -1,4 +1,4 @@
-import { getAnonSession, getAnonymousSessionId } from "@/lib/anonymousSession";
+import { getAnonymousSessionId } from "@/lib/anonymousSession";
 import {
   authorize,
   getSessionDetails,
@@ -25,10 +25,7 @@ export async function GET(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
   const { role, userId } = await loadAuthContext({ session }, "anonymous");
-  let anonId = getAnonymousSessionId(req);
-  if (!anonId) {
-    anonId = getAnonSession(req);
-  }
+  const anonId = getAnonymousSessionId(req);
   const sessionMatch = anonId && c.sessionId && c.sessionId === anonId;
   const authRole = sessionMatch ? "user" : role;
   if (!(await authorize(authRole, "cases", "read"))) {

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { getAnonSession, getAnonymousSessionId } from "@/lib/anonymousSession";
+import { getAnonymousSessionId } from "@/lib/anonymousSession";
 import { getSessionDetails, withAuthorization } from "@/lib/authz";
 import {
   analyzeCaseInBackground,
@@ -37,7 +37,7 @@ export const POST = withAuthorization(
       const store = await cookies();
       anonId = store.get("anonSession")?.value;
     } catch {
-      anonId = getAnonSession(req);
+      anonId = getAnonymousSessionId(req);
     }
     let setSessionCookie = false;
     if (!anonId) {

--- a/src/app/cases/__tests__/caseChatCurrent.test.tsx
+++ b/src/app/cases/__tests__/caseChatCurrent.test.tsx
@@ -1,6 +1,8 @@
 import CaseChat from "@/app/cases/[id]/CaseChat";
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 describe("CaseChat current session", () => {
   it("shows current chat option and updates summary", async () => {

--- a/src/app/cases/__tests__/caseChatFocus.test.tsx
+++ b/src/app/cases/__tests__/caseChatFocus.test.tsx
@@ -1,6 +1,8 @@
 import CaseChat from "@/app/cases/[id]/CaseChat";
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 describe("CaseChat input focus", () => {
   it("focuses the input when opened", () => {

--- a/src/app/cases/__tests__/caseChatHistory.test.tsx
+++ b/src/app/cases/__tests__/caseChatHistory.test.tsx
@@ -1,6 +1,8 @@
 import CaseChat from "@/app/cases/[id]/CaseChat";
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 describe("CaseChat history", () => {
   it("saves chat to localStorage", async () => {

--- a/src/lib/anonymousSession.ts
+++ b/src/lib/anonymousSession.ts
@@ -1,23 +1,10 @@
 export function getAnonymousSessionId(req: Request): string | undefined {
-  const cookie = req.headers.get("cookie");
-  if (!cookie) return undefined;
-  for (const part of cookie.split(/;\s*/)) {
-    const [name, ...rest] = part.split("=");
-    if (name === "anon_session_id") {
-      return decodeURIComponent(rest.join("="));
-    }
-  }
-  return undefined;
-}
-
-export function getAnonSession(req: Request): string | undefined {
-  // handle tests where `req` may be a simple object without headers
-  const headers = (req as { headers?: Headers }).headers;
+  const headers = (req as { headers?: Headers }).headers ?? req.headers;
   const cookie = headers?.get("cookie");
   if (!cookie) return undefined;
   for (const part of cookie.split(/;\s*/)) {
     const [name, ...rest] = part.split("=");
-    if (name === "anonSession") {
+    if (name === "anon_session_id" || name === "anonSession") {
       return decodeURIComponent(rest.join("="));
     }
   }

--- a/test/anonymousUpload.test.ts
+++ b/test/anonymousUpload.test.ts
@@ -67,8 +67,9 @@ describe("anonymous upload", () => {
     const setCookie = res.headers.get("set-cookie") ?? "";
     expect(setCookie).toMatch(/anon/);
     const { caseId } = await res.json();
+    const cookieValue = setCookie.split(";")[0];
     const getReq = new Request("http://test", {
-      headers: { cookie: setCookie.split(";")[0] },
+      headers: { cookie: cookieValue },
     });
     const caseRes = await caseRoute.GET(getReq, {
       params: Promise.resolve({ id: caseId }),
@@ -76,5 +77,13 @@ describe("anonymous upload", () => {
     expect(caseRes.status).toBe(200);
     const data = await caseRes.json();
     expect(data.id).toBe(caseId);
+
+    const fallbackReq = new Request("http://test", {
+      headers: { cookie: `anon_session_id=${cookieValue.split("=")[1]}` },
+    });
+    const fallbackRes = await caseRoute.GET(fallbackReq, {
+      params: Promise.resolve({ id: caseId }),
+    });
+    expect(fallbackRes.status).toBe(200);
   }, 15000);
 });

--- a/test/caseAuthorization.test.ts
+++ b/test/caseAuthorization.test.ts
@@ -87,6 +87,16 @@ describe("case authorization", () => {
     expect(res.status).toBe(200);
   });
 
+  it("allows access with legacy cookie name", async () => {
+    const c = caseStore.createCase("/f.jpg");
+    caseStore.setCaseSessionId(c.id, "def");
+    const { GET } = await import("@/app/api/cases/[id]/route");
+    const req = new Request("http://test");
+    req.headers.set("cookie", "anonSession=def");
+    const res = await GET(req, { params: Promise.resolve({ id: c.id }) });
+    expect(res.status).toBe(200);
+  });
+
   it("allows superadmin to toggle visibility", async () => {
     const c = caseStore.createCase("/d.jpg", null, undefined, null, "u1");
     const { PUT } = await import("@/app/api/cases/[id]/public/route");


### PR DESCRIPTION
## Summary
- check for both `anon_session_id` and `anonSession` cookies in `getAnonymousSessionId`
- remove `getAnonSession` and update routes to use the new helper
- recognize legacy cookie in upload and case routes
- document anonymous session cookie name
- test both cookie names and mock router in case chat tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a012a5244832b9d2a0ad241bbe586