### PR TITLE
Remove chat action buttons

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -248,18 +248,6 @@ export default function CaseChat({
               Send
             </button>
           </div>
-          <div className="border-t p-2 flex gap-2 justify-end">
-            {caseActions.map((a) => (
-              <button
-                key={a.id}
-                type="button"
-                onClick={() => router.push(a.href(caseId))}
-                className="bg-blue-600 text-white px-2 py-1 rounded"
-              >
-                {a.label}
-              </button>
-            ))}
-          </div>
         </div>
       ) : (
         <button

--- a/src/app/cases/__tests__/caseChatCurrent.test.tsx
+++ b/src/app/cases/__tests__/caseChatCurrent.test.tsx
@@ -1,6 +1,10 @@
 import CaseChat from "@/app/cases/[id]/CaseChat";
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
 
 describe("CaseChat current session", () => {
   it("shows current chat option and updates summary", async () => {

--- a/src/app/cases/__tests__/caseChatFocus.test.tsx
+++ b/src/app/cases/__tests__/caseChatFocus.test.tsx
@@ -1,6 +1,10 @@
 import CaseChat from "@/app/cases/[id]/CaseChat";
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
 
 describe("CaseChat input focus", () => {
   it("focuses the input when opened", () => {

--- a/src/app/cases/__tests__/caseChatHistory.test.tsx
+++ b/src/app/cases/__tests__/caseChatHistory.test.tsx
@@ -1,6 +1,10 @@
 import CaseChat from "@/app/cases/[id]/CaseChat";
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
 
 describe("CaseChat history", () => {
   it("saves chat to localStorage", async () => {


### PR DESCRIPTION
## Summary
- remove action buttons from CaseChat popup
- mock next/navigation router in CaseChat tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a0306a71c832ba571f0a17daffeff