### PR TITLE
Fix chat history dropdown overflow

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -165,8 +165,8 @@ export default function CaseChat({
     <div className="fixed bottom-4 right-4 z-40 text-sm">
       {open ? (
         <div className="bg-white dark:bg-gray-900 shadow-lg rounded w-80 h-96 flex flex-col">
-          <div className="flex justify-between items-center border-b p-2 gap-2">
-            <span className="font-semibold flex-1">Case Chat</span>
+          <div className="flex items-center border-b p-2 gap-2">
+            <span className="font-semibold flex-none">Case Chat</span>
             <select
               aria-label="Chat history"
               value={sessionId ?? ""}
@@ -184,7 +184,7 @@ export default function CaseChat({
                   }
                 }
               }}
-              className="text-black dark:text-black text-xs"
+              className="text-black dark:text-black text-xs flex-auto min-w-0 truncate"
             >
               <option value="new">New Chat</option>
               {!history.some((h) => h.id === sessionId) && sessionId && (
@@ -203,7 +203,7 @@ export default function CaseChat({
               type="button"
               onClick={handleClose}
               aria-label="Close chat"
-              className="text-xl leading-none"
+              className="text-xl leading-none flex-none"
             >
               ×
             </button>

--- a/src/app/cases/__tests__/caseChatCurrent.test.tsx
+++ b/src/app/cases/__tests__/caseChatCurrent.test.tsx
@@ -1,6 +1,10 @@
 import CaseChat from "@/app/cases/[id]/CaseChat";
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
 
 describe("CaseChat current session", () => {
   it("shows current chat option and updates summary", async () => {

--- a/src/app/cases/__tests__/caseChatFocus.test.tsx
+++ b/src/app/cases/__tests__/caseChatFocus.test.tsx
@@ -1,6 +1,10 @@
 import CaseChat from "@/app/cases/[id]/CaseChat";
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
 
 describe("CaseChat input focus", () => {
   it("focuses the input when opened", () => {

--- a/src/app/cases/__tests__/caseChatHistory.test.tsx
+++ b/src/app/cases/__tests__/caseChatHistory.test.tsx
@@ -1,6 +1,10 @@
 import CaseChat from "@/app/cases/[id]/CaseChat";
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
 
 describe("CaseChat history", () => {
   it("saves chat to localStorage", async () => {


### PR DESCRIPTION
## Summary
- constrain CaseChat history select width
- mock router in case chat tests so tests pass

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a03957244832ba71a0e803cc44b62