### PR TITLE
Remove duplicate sessionId property

### DIFF
--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -31,18 +31,26 @@ const groupOptions = {
 function normalizeRule(rule: RuleInput): RuleInput {
   if (rule.ptype === "p") {
     const v0s = Object.keys(policyOptions) as Array<keyof typeof policyOptions>;
-    if (!rule.v0 || !v0s.includes(rule.v0)) rule.v0 = v0s[0];
+    if (!rule.v0 || !v0s.includes(rule.v0 as keyof typeof policyOptions))
+      rule.v0 = v0s[0];
     const v1s = Object.keys(
       policyOptions[rule.v0 as keyof typeof policyOptions],
     ) as Array<keyof (typeof policyOptions)[keyof typeof policyOptions]>;
-    if (!rule.v1 || !v1s.includes(rule.v1)) rule.v1 = v1s[0];
+    if (
+      !rule.v1 ||
+      !v1s.includes(
+        rule.v1 as keyof (typeof policyOptions)[keyof typeof policyOptions],
+      )
+    )
+      rule.v1 = v1s[0];
     const v2s = policyOptions[rule.v0 as keyof typeof policyOptions][
       rule.v1 as keyof (typeof policyOptions)[keyof typeof policyOptions]
     ] as readonly string[];
     if (!rule.v2 || !v2s.includes(rule.v2)) rule.v2 = v2s[0];
   } else {
     const v0s = Object.keys(groupOptions) as Array<keyof typeof groupOptions>;
-    if (!rule.v0 || !v0s.includes(rule.v0)) rule.v0 = v0s[0];
+    if (!rule.v0 || !v0s.includes(rule.v0 as keyof typeof groupOptions))
+      rule.v0 = v0s[0];
     const v1s = groupOptions[
       rule.v0 as keyof typeof groupOptions
     ] as readonly string[];

--- a/src/app/api/credits/add/route.ts
+++ b/src/app/api/credits/add/route.ts
@@ -7,7 +7,7 @@ export const POST = withAuthorization(
   { obj: "credits", act: "update" },
   async (
     req: Request,
-    { session }: { session?: { user?: { id?: string } } },
+    { session }: { session?: { user?: { id?: string; role?: string } } },
   ) => {
     if (!session?.user?.id) {
       return new Response(null, { status: 401 });

--- a/src/app/api/credits/balance/route.ts
+++ b/src/app/api/credits/balance/route.ts
@@ -6,7 +6,7 @@ export const GET = withAuthorization(
   { obj: "credits" },
   async (
     _req: Request,
-    { session }: { session?: { user?: { id?: string } } },
+    { session }: { session?: { user?: { id?: string; role?: string } } },
   ) => {
     if (!session?.user?.id) {
       return new Response(null, { status: 401 });

--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -116,7 +116,7 @@ export default function CaseChat({
     if (!text) return;
     const list = [
       ...messages,
-      { id: crypto.randomUUID(), role: "user", content: text },
+      { id: crypto.randomUUID(), role: "user" as const, content: text },
     ];
     if (messages.length === 0) {
       setSessionSummary(text.slice(0, 30));
@@ -142,7 +142,11 @@ export default function CaseChat({
       if (reply) {
         setMessages([
           ...list,
-          { id: crypto.randomUUID(), role: "assistant", content: reply },
+          {
+            id: crypto.randomUUID(),
+            role: "assistant" as const,
+            content: reply,
+          },
         ]);
       }
     } finally {

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -139,7 +139,8 @@ export default function ClientCasePage({
 
   useEffect(() => {
     if (
-      navigator.mediaDevices?.getUserMedia &&
+      "mediaDevices" in navigator &&
+      typeof navigator.mediaDevices.getUserMedia === "function" &&
       (location.protocol === "https:" || location.hostname === "localhost")
     ) {
       setHasCamera(true);

--- a/src/app/components/EditableText.tsx
+++ b/src/app/components/EditableText.tsx
@@ -12,7 +12,7 @@ export default function EditableText({
   onSubmit: (v: string) => Promise<void> | void;
   onClear?: () => Promise<void> | void;
   placeholder?: string;
-  options?: string[];
+  options?: readonly string[];
 }) {
   const [editing, setEditing] = useState(false);
   const [text, setText] = useState(value);

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -42,7 +42,6 @@ export interface Case {
   closed?: boolean;
   note?: string | null;
   photoNotes?: Record<string, string | null>;
-  sessionId?: string | null;
   archived?: boolean;
 }
 

--- a/src/lib/credits.ts
+++ b/src/lib/credits.ts
@@ -16,14 +16,17 @@ const updateBalance = db.prepare(
 );
 const selectBalance = db.prepare("SELECT credits FROM user WHERE id = ?");
 
-const txAdd = db.transaction((userId: string, amount: number) => {
+const txAdd = db.transaction(((userId: string, amount: number) => {
   const id = crypto.randomUUID();
   const createdAt = new Date().toISOString();
   insertTx.run(id, userId, amount, createdAt);
   updateBalance.run(amount, userId);
   const row = selectBalance.get(userId) as { credits: number } | undefined;
   return row?.credits ?? 0;
-});
+}) as (userId: string, amount: number) => unknown) as (
+  userId: string,
+  amount: number,
+) => number;
 
 export function addCredits(userId: string, amount: number): number {
   return txAdd(userId, amount);

--- a/src/lib/usStates.ts
+++ b/src/lib/usStates.ts
@@ -50,4 +50,4 @@ export const US_STATES = [
   "WI",
   "WY",
   "DC",
-];
+] as const;

--- a/test/uploadRoute.test.ts
+++ b/test/uploadRoute.test.ts
@@ -3,7 +3,15 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { Worker } from "node:worker_threads";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type MockInstance,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 vi.mock("next/headers", () => ({ cookies: () => ({ get: vi.fn() }) }));
 
 let dataDir: string;
@@ -11,7 +19,7 @@ let tmpDir: string;
 let mod: typeof import("@/app/api/upload/route");
 let caseStore: typeof import("@/lib/caseStore");
 let caseAnalysis: typeof import("@/lib/caseAnalysis");
-let cancelSpy: ReturnType<typeof vi.spyOn>;
+let cancelSpy: MockInstance | undefined;
 
 const terminateMock = vi.fn();
 const worker = Object.assign(new EventEmitter(), {

--- a/types/better-sqlite3.d.ts
+++ b/types/better-sqlite3.d.ts
@@ -9,6 +9,8 @@ declare module "better-sqlite3" {
     prepare<T = unknown>(sql: string): Statement<T>;
     exec(sql: string): this;
     close(): void;
+    // biome-ignore lint/suspicious/noExplicitAny: upstream library lacks types
+    transaction<T extends (...args: any[]) => any>(fn: T): T;
   }
 
   interface DatabaseConstructor {


### PR DESCRIPTION
## Summary
- drop redundant `sessionId` field from `Case`
- clean up case chat constants
- fix camera availability check
- allow readonly arrays in `EditableText`
- type transaction method for better-sqlite3
- adjust credit API route context types
- tweak admin rule normalization
- update tests for lint order

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685a01371850832b9688652dd5d94d8a