### PR TITLE
Gate console logs with env check

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,7 @@
 import { getCasbinRules, listUsers } from "@/lib/adminStore";
 import { authOptions } from "@/lib/authOptions";
 import { withAuthorization } from "@/lib/authz";
+import { log } from "@/lib/logger";
 import { getServerSession } from "next-auth/next";
 import AdminPageClient from "./AdminPageClient";
 
@@ -13,7 +14,7 @@ const handler = withAuthorization(
     { session }: { session?: { user?: { role?: string } } },
   ) => {
     const s = session ?? (await getServerSession(authOptions));
-    console.log("admin page session", s?.user?.role);
+    log("admin page session", s?.user?.role);
     if (s?.user?.role !== "admin" && s?.user?.role !== "superadmin") {
       return new Response(null, { status: 403 });
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 export { dynamic } from "./cases/page";
 import { withBasePath } from "@/basePath";
 import { authOptions } from "@/lib/authOptions";
+import { log } from "@/lib/logger";
 import isMobile from "is-mobile";
 import { getServerSession } from "next-auth/next";
 import { headers } from "next/headers";
@@ -9,7 +10,7 @@ import LoggedOutLanding from "./LoggedOutLanding";
 
 export default async function Home() {
   const session = await getServerSession(authOptions);
-  console.log("home session", !!session);
+  log("home session", !!session);
   const ua = (await headers()).get("user-agent") ?? "";
   const isMobileBrowser = isMobile({ ua });
   if (!session) {

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { signIn } from "@/app/useSession";
 import { withBasePath } from "@/basePath";
+import { log } from "@/lib/logger";
 import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 
@@ -28,7 +29,7 @@ export default function SignInPage() {
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          console.log("Submitting sign in", email);
+          log("Submitting sign in", email);
           signIn("email", { email, callbackUrl: withBasePath("/") });
         }}
         className="p-4 flex flex-col gap-2"

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,7 @@ import { DrizzleAdapter } from "@auth/drizzle-adapter";
 import { eq, sql } from "drizzle-orm";
 import { config } from "./config";
 import { migrationsReady } from "./db";
+import { log } from "./logger";
 import { orm } from "./orm";
 import { users } from "./schema";
 
@@ -14,7 +15,7 @@ export function authAdapter() {
   return {
     ...base,
     async createUser(data: AdapterUser & { id?: string }) {
-      console.log("authAdapter.createUser", data.email);
+      log("authAdapter.createUser", data.email);
       if (!data.id) data.id = crypto.randomUUID();
       if (!base.createUser) throw new Error("createUser not implemented");
       return base.createUser(data);
@@ -44,7 +45,7 @@ export async function seedSuperAdmin(newUser?: {
       newUser ?? orm.select().from(users).orderBy(sql`rowid`).limit(1).get();
   }
   if (target) {
-    console.log("seeding super admin", newUser?.email);
+    log("seeding super admin", newUser?.email);
     orm
       .update(users)
       .set({ role: "superadmin" })

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -7,6 +7,7 @@ import EmailProvider from "next-auth/providers/email";
 import { authAdapter, seedSuperAdmin } from "./auth";
 import { config } from "./config";
 import { sendEmail } from "./email";
+import { log } from "./logger";
 
 if (!config.NEXTAUTH_SECRET) {
   console.error(
@@ -19,7 +20,7 @@ export const authOptions: NextAuthOptions = {
   providers: [
     EmailProvider({
       async sendVerificationRequest({ identifier, url }) {
-        console.log("sendVerificationRequest", identifier);
+        log("sendVerificationRequest", identifier);
         if (config.TEST_APIS) {
           (global as Record<string, unknown>).verificationUrl = url;
           const filePath = path.join(os.tmpdir(), "verification-url.txt");
@@ -27,7 +28,7 @@ export const authOptions: NextAuthOptions = {
           return;
         }
         await sendEmail({ to: identifier, subject: "Sign in", body: url });
-        console.log("Verification email sent", identifier);
+        log("Verification email sent", identifier);
       },
       from: config.SMTP_FROM,
     }),
@@ -39,7 +40,7 @@ export const authOptions: NextAuthOptions = {
       session,
       user,
     }: { session: Session; user: User & { role?: string } }) {
-      console.log("session callback", user.id);
+      log("session callback", user.id);
       if (session.user) {
         (session.user as User & { role?: string }).role = user.role;
         (session.user as User & { id: string }).id = user.id;
@@ -49,7 +50,7 @@ export const authOptions: NextAuthOptions = {
   },
   events: {
     async createUser({ user }) {
-      console.log("new user", user.id);
+      log("new user", user.id);
       try {
         await seedSuperAdmin({ id: user.id, email: user.email ?? null });
       } catch (err) {

--- a/src/lib/caseReport.ts
+++ b/src/lib/caseReport.ts
@@ -1,11 +1,12 @@
 import path from "node:path";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import { z } from "zod";
-import "./zod-setup";
 import type { Case, SentEmail } from "./caseStore";
 import { getLlm } from "./llm";
+import { log } from "./logger";
 import type { ReportModule } from "./reportModules";
 import { getViolationCode } from "./violationCodes";
+import "./zod-setup";
 
 function logBadResponse(
   attempt: number,
@@ -123,7 +124,7 @@ export async function draftFollowUp(
   historyEmails: SentEmail[] = caseData.sentEmails ?? [],
   sender?: { name?: string | null; email?: string | null },
 ): Promise<EmailDraft> {
-  console.log(
+  log(
     `draftFollowUp recipient=${recipient} history=${historyEmails
       .map((m) => `${m.sentAt}:${m.subject}`)
       .join("|")}`,
@@ -172,7 +173,7 @@ Ask about the current citation status and mention that photos are attached again
     { role: "user", content: prompt } as ChatCompletionMessageParam,
   ];
 
-  console.log(`draftFollowUp prompt: ${prompt.replace(/\n/g, " ")}`);
+  log(`draftFollowUp prompt: ${prompt.replace(/\n/g, " ")}`);
 
   const messages: ChatCompletionMessageParam[] = [...baseMessages];
   const { client, model } = getLlm("draft_email");

--- a/src/lib/docsmitProvider.ts
+++ b/src/lib/docsmitProvider.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import FormData from "form-data";
 import { config } from "./config";
+import { log } from "./logger";
 import type {
   MailingAddress,
   SnailMailOptions,
@@ -164,7 +165,7 @@ const provider: SnailMailProvider = {
       statusText = "queued";
     } else if (res.status === 402) {
       shortfall = (await res.json()).shortfall as number | undefined;
-      console.log("Docsmit payment required", { shortfall });
+      log("Docsmit payment required", { shortfall });
       statusText = "shortfall";
     } else {
       statusText = "error";

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import nodemailer from "nodemailer";
 import { config } from "./config";
 import { addSentEmail } from "./emailStore";
+import { log } from "./logger";
 
 export interface EmailOptions {
   /** @zod.email */
@@ -17,7 +18,7 @@ export async function sendEmail({
   body,
   attachments = [],
 }: EmailOptions): Promise<void> {
-  console.log("sendEmail", to, subject);
+  log("sendEmail", to, subject);
 
   const finalTo = config.MOCK_EMAIL_TO || to;
   if (config.EMAIL_FILE) {
@@ -28,7 +29,7 @@ export async function sendEmail({
       attachments,
       sentAt: new Date().toISOString(),
     });
-    console.log("mock email stored", finalTo);
+    log("mock email stored", finalTo);
     return;
   }
 
@@ -67,5 +68,5 @@ export async function sendEmail({
       path: path.join(process.cwd(), "public", p.replace(/^\//, "")),
     })),
   });
-  console.log("email sent", to);
+  log("email sent", to);
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,5 @@
+export function log(...args: unknown[]): void {
+  if (process.env.NODE_ENV !== "production") {
+    console.log(...args);
+  }
+}

--- a/src/lib/snailMail.ts
+++ b/src/lib/snailMail.ts
@@ -1,6 +1,7 @@
 import docsmitProvider from "./docsmitProvider";
 import fileProvider from "./fileSnailMailProvider";
 import { runJob } from "./jobScheduler";
+import { log } from "./logger";
 import "./zod-setup";
 
 export interface MailingAddress {
@@ -50,7 +51,7 @@ export const snailMailProviders: Record<string, SnailMailProvider> = {
     label: "Mock Snail Mail Provider",
     docs: "A no-op provider used during development.",
     async send(opts) {
-      console.log("mock snail mail", opts);
+      log("mock snail mail", opts);
       return {
         id: `mock-${Date.now()}`,
         status: "queued",

--- a/src/lib/vinLookup.ts
+++ b/src/lib/vinLookup.ts
@@ -2,6 +2,7 @@ import { JSDOM } from "jsdom";
 import type { Case } from "./caseStore";
 import { updateCase } from "./caseStore";
 import { runJob } from "./jobScheduler";
+import { log } from "./logger";
 import {
   type VinSource,
   defaultVinSources,
@@ -44,10 +45,10 @@ export async function lookupVin(
         const body = src.buildBody(plate, state);
         init.body = typeof body === "string" ? body : JSON.stringify(body);
       }
-      console.log("VIN lookup request", { url, options: init });
+      log("VIN lookup request", { url, options: init });
       const res = await fetch(url, init);
       const text = await res.text();
-      console.log("VIN lookup response", { status: res.status, body: text });
+      log("VIN lookup response", { status: res.status, body: text });
       if (!res.ok) {
         recordVinSourceFailure(src.id);
         continue;
@@ -75,10 +76,10 @@ export async function fetchCaseVin(caseData: Case): Promise<void> {
   try {
     const vin = await lookupVin(plate, state);
     if (vin) {
-      console.log("VIN fetch successful", vin);
+      log("VIN fetch successful", vin);
       updateCase(caseData.id, { vin });
     } else {
-      console.log("VIN fetch unsuccessful");
+      log("VIN fetch unsuccessful");
     }
   } catch (err) {
     console.error("Failed to fetch VIN", err);


### PR DESCRIPTION
## Summary
- add a small logger that only logs outside production
- replace `console.log` with `log` in auth and case utilities
- sort imports per Biome

## Testing
- `npm run lint`
- `npm test` *(fails: invariant expected app router to be mounted)*

------
https://chatgpt.com/codex/tasks/task_e_685a010c8070832b94ad11c7970c5d15