### PR TITLE
Improve case chat button guidance

### DIFF
--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -29,7 +29,7 @@ export const POST = withCaseAuthorization(
     const actionList = caseActions
       .map((a) => `- ${a.label} [${a.id}]: ${a.description}`)
       .join("\\n");
-    const system = `You are a helpful legal assistant for the Photo To Citation app. The user is asking about a case with these details:\nViolation: ${analysis?.violationType || ""}\nDescription: ${analysis?.details || ""}\nLocation: ${location}\nLicense Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}\nNumber of photos: ${c.photos.length}. ${contextLines ? `\nImage contexts:\n${contextLines}` : ""}. \nTo include an action button, insert a token like [action:compose] in your reply. Write the token exactly with no spaces or label text inside. The UI will replace it with a button. Available actions:\n${actionList}`;
+    const system = `You are a helpful legal assistant for the Photo To Citation app. The user is asking about a case with these details:\nViolation: ${analysis?.violationType || ""}\nDescription: ${analysis?.details || ""}\nLocation: ${location}\nLicense Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}\nNumber of photos: ${c.photos.length}. ${contextLines ? `\nImage contexts:\n${contextLines}` : ""}. \nTo include an action button, insert a token like [action:compose] in your reply. Write the token exactly with no spaces or label text inside.\nFor example: \nYou may want to notify the vehicle owner. [action:notify-owner]\nThe UI will replace the token with a button. Available actions:\n${actionList}`;
 
     const messages: ChatCompletionMessageParam[] = [
       { role: "system", content: system },

--- a/src/app/cases/__tests__/caseChatCurrent.test.tsx
+++ b/src/app/cases/__tests__/caseChatCurrent.test.tsx
@@ -1,6 +1,10 @@
 import CaseChat from "@/app/cases/[id]/CaseChat";
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
 
 describe("CaseChat current session", () => {
   it("shows current chat option and updates summary", async () => {

--- a/src/app/cases/__tests__/caseChatFocus.test.tsx
+++ b/src/app/cases/__tests__/caseChatFocus.test.tsx
@@ -1,6 +1,10 @@
 import CaseChat from "@/app/cases/[id]/CaseChat";
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
 
 describe("CaseChat input focus", () => {
   it("focuses the input when opened", () => {

--- a/src/app/cases/__tests__/caseChatHistory.test.tsx
+++ b/src/app/cases/__tests__/caseChatHistory.test.tsx
@@ -1,6 +1,10 @@
 import CaseChat from "@/app/cases/[id]/CaseChat";
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
 
 describe("CaseChat history", () => {
   it("saves chat to localStorage", async () => {


### PR DESCRIPTION
## Summary
- expand case chat system prompt with a concrete button example
- mock `useRouter` in CaseChat tests to avoid Next.js router errors

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a02906d94832bbf0ebd30e34da990