### PR TITLE
Fix case chat action instructions

### DIFF
--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -27,7 +27,7 @@ export const POST = withCaseAuthorization(
           .join("\n")
       : "";
     const actionList = caseActions
-      .map((a) => `- ${a.label} [${a.id}]: ${a.description}`)
+      .map((a) => `- ${a.label} [action:${a.id}]: ${a.description}`)
       .join("\\n");
     const system = `You are a helpful legal assistant for the Photo To Citation app. The user is asking about a case with these details:\nViolation: ${analysis?.violationType || ""}\nDescription: ${analysis?.details || ""}\nLocation: ${location}\nLicense Plate: ${vehicle.licensePlateState || ""} ${vehicle.licensePlateNumber || ""}\nNumber of photos: ${c.photos.length}. ${contextLines ? `\nImage contexts:\n${contextLines}` : ""}. When there is no user question yet, decide if you should proactively suggest a next action or useful observation. If you have nothing helpful, reply with [noop]. \nTo include an action button, insert a token like [action:compose] in your reply. Write the token exactly with no spaces or label text inside.\nFor example: \nYou may want to notify the vehicle owner. [action:notify-owner]\nThe UI will replace the token with a button. Available actions:\n${actionList}`;
 


### PR DESCRIPTION
## Summary
- fix action list formatting to include action tokens for case chat

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a0c174d34832b99c0e7aaf7cba19a