### PR TITLE
Filter completed case actions from chat seed

### DIFF
--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -1,9 +1,32 @@
 import { withCaseAuthorization } from "@/lib/authz";
 import { caseActions } from "@/lib/caseActions";
 import { getCase } from "@/lib/caseStore";
+import { getCaseOwnerContactInfo } from "@/lib/caseUtils";
 import { getLlm } from "@/lib/llm";
+import { reportModules } from "@/lib/reportModules";
 import { NextResponse } from "next/server";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+
+function actionCompleted(
+  c: import("@/lib/caseStore").Case,
+  id: string,
+): boolean {
+  const authority = reportModules["oak-park"].authorityEmail;
+  switch (id) {
+    case "compose":
+      return (c.sentEmails ?? []).some((e) => e.to === authority);
+    case "followup":
+      return (c.sentEmails ?? []).some((e) => e.to === authority && e.replyTo);
+    case "notify-owner": {
+      const owner = getCaseOwnerContactInfo(c)?.email;
+      return owner ? (c.sentEmails ?? []).some((e) => e.to === owner) : false;
+    }
+    case "ownership":
+      return (c.ownershipRequests ?? []).length > 0;
+    default:
+      return false;
+  }
+}
 
 export const POST = withCaseAuthorization(
   { obj: "cases", act: "read" },
@@ -26,7 +49,8 @@ export const POST = withCaseAuthorization(
           .map(([name, info]) => `Photo ${name}: ${info.context || ""}`)
           .join("\n")
       : "";
-    const actionList = caseActions
+    const available = caseActions.filter((a) => !actionCompleted(c, a.id));
+    const actionList = available
       .map((a) => `- ${a.label} [${a.id}]: ${a.description}`)
       .join("\\n");
     const system = [
@@ -46,8 +70,10 @@ export const POST = withCaseAuthorization(
       "You may want to notify the vehicle owner. [action:notify-owner]",
       "The UI will replace the token with a button.",
       "You can also suggest edits with [edit:FIELD=VALUE] tokens (fields: vin, plate, state, note).",
-      `Available actions:\n${actionList}`
-    ].filter(Boolean).join("\n");
+      available.length > 0 ? `Available actions:\n${actionList}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n");
 
     const messages: ChatCompletionMessageParam[] = [
       { role: "system", content: system },


### PR DESCRIPTION
## Summary
- detect completed case actions when generating chat conversation seeds
- skip listing actions that were already done

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a0f4d02b8832bbbb3387c0e27486c