### PR TITLE
fix: merge analysis overrides

### DIFF
--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -380,7 +380,21 @@ export function setCaseAnalysisOverrides(
 ): Case | undefined {
   const before = getCaseRow(id);
   if (!before) return undefined;
-  const updated = { ...before, analysisOverrides: overrides };
+  let merged: Partial<ViolationReport> | null;
+  if (overrides === null) {
+    merged = null;
+  } else {
+    const prev = before.analysisOverrides ?? {};
+    merged = {
+      ...prev,
+      ...overrides,
+      vehicle: {
+        ...(prev.vehicle ?? {}),
+        ...(overrides.vehicle ?? {}),
+      },
+    };
+  }
+  const updated = { ...before, analysisOverrides: merged };
   saveCase(updated);
   const after = applyOverrides(updated);
   if (after) {

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -94,6 +94,25 @@ describe("caseStore", () => {
     expect(cleared?.analysis?.vehicle?.model).toBeUndefined();
   });
 
+  it("merges override fields", () => {
+    const { createCase, setCaseAnalysisOverrides, getCase } = caseStore;
+    const c = createCase(
+      "/merge.jpg",
+      null,
+      undefined,
+      "2020-01-10T00:00:00.000Z",
+    );
+    setCaseAnalysisOverrides(c.id, {
+      vehicle: { licensePlateNumber: "ABC123" },
+    });
+    setCaseAnalysisOverrides(c.id, {
+      vehicle: { licensePlateState: "IL" },
+    });
+    const merged = getCase(c.id);
+    expect(merged?.analysis?.vehicle?.licensePlateNumber).toBe("ABC123");
+    expect(merged?.analysis?.vehicle?.licensePlateState).toBe("IL");
+  });
+
   it("computes the representative photo", () => {
     const { createCase, addCasePhoto, getCase } = caseStore;
     const c = createCase("/b.jpg", null, undefined, "2020-01-05T00:00:00.000Z");


### PR DESCRIPTION
## Summary
- merge analysis overrides instead of replacing
- test merged overrides for plate/state fields

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a12bc6180832b88570aa73e981bfa