### PR TITLE
Implement photo note actions in case chat

### DIFF
--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -49,6 +49,7 @@ export const POST = withCaseAuthorization(
           .map(([name, info]) => `Photo ${name}: ${info.context || ""}`)
           .join("\n")
       : "";
+    const photoNames = c.photos.map((p) => p.substring(p.lastIndexOf("/") + 1));
     const available = caseActions.filter((a) => !actionCompleted(c, a.id));
     const actionList = available
       .map((a) => `- ${a.label} [action:${a.id}]: ${a.description}`)
@@ -70,6 +71,8 @@ export const POST = withCaseAuthorization(
       "You may want to notify the vehicle owner. [action:notify-owner]",
       "The UI will replace the token with a button.",
       "You can also suggest edits with [edit:FIELD=VALUE] tokens (fields: vin, plate, state, note).",
+      "To add a note to a specific photo use [photo-note:FILENAME=NOTE] where FILENAME is from the list of photos.",
+      `Photos: ${photoNames.join(", ")}`,
       available.length > 0 ? `Available actions:\n${actionList}` : "",
     ]
       .filter(Boolean)

--- a/src/app/cases/__tests__/caseChatCurrent.test.tsx
+++ b/src/app/cases/__tests__/caseChatCurrent.test.tsx
@@ -6,6 +6,23 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
 }));
 
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async () => ({
+    ok: true,
+    json: async () => ({
+      id: "1",
+      photos: ["/uploads/foo.jpg"],
+      photoTimes: {},
+      createdAt: "",
+      updatedAt: "",
+      analysisStatus: "pending",
+      public: false,
+      closed: false,
+    }),
+  })),
+);
+
 describe("CaseChat current session", () => {
   it("shows current chat option and updates summary", async () => {
     const { getByText, getByLabelText, getByPlaceholderText, findByText } =

--- a/src/app/cases/__tests__/caseChatFocus.test.tsx
+++ b/src/app/cases/__tests__/caseChatFocus.test.tsx
@@ -6,6 +6,23 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
 }));
 
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async () => ({
+    ok: true,
+    json: async () => ({
+      id: "1",
+      photos: ["/uploads/foo.jpg"],
+      photoTimes: {},
+      createdAt: "",
+      updatedAt: "",
+      analysisStatus: "pending",
+      public: false,
+      closed: false,
+    }),
+  })),
+);
+
 describe("CaseChat input focus", () => {
   it("focuses the input when opened", () => {
     const { getByText, getByPlaceholderText } = render(<CaseChat caseId="1" />);

--- a/src/app/cases/__tests__/caseChatHistory.test.tsx
+++ b/src/app/cases/__tests__/caseChatHistory.test.tsx
@@ -6,6 +6,23 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
 }));
 
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async () => ({
+    ok: true,
+    json: async () => ({
+      id: "1",
+      photos: ["/uploads/foo.jpg"],
+      photoTimes: {},
+      createdAt: "",
+      updatedAt: "",
+      analysisStatus: "pending",
+      public: false,
+      closed: false,
+    }),
+  })),
+);
+
 describe("CaseChat history", () => {
   it("saves chat to localStorage", async () => {
     localStorage.clear();

--- a/src/app/cases/__tests__/caseChatPhotoNote.test.tsx
+++ b/src/app/cases/__tests__/caseChatPhotoNote.test.tsx
@@ -1,0 +1,43 @@
+import CaseChat from "@/app/cases/[id]/CaseChat";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async (input: RequestInfo | URL) => {
+    if ((input as string).includes("/api/cases/1")) {
+      return {
+        ok: true,
+        json: async () => ({
+          id: "1",
+          photos: ["/uploads/foo.jpg"],
+          photoTimes: {},
+          createdAt: "",
+          updatedAt: "",
+          analysisStatus: "pending",
+          public: false,
+          closed: false,
+        }),
+      } as Response;
+    }
+    return { ok: true, json: async () => ({ reply: "" }) } as Response;
+  }),
+);
+
+describe("CaseChat photo note token", () => {
+  it("renders photo note button", async () => {
+    const { getByText, getByPlaceholderText, findByText } = render(
+      <CaseChat caseId="1" onChat={async () => "[photo-note:foo.jpg=test]"} />,
+    );
+    fireEvent.click(getByText("Chat"));
+    const input = getByPlaceholderText("Ask a question...");
+    fireEvent.change(input, { target: { value: "hi" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+    const button = await findByText(/Add note to foo.jpg/);
+    expect(button).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- allow LLM replies to set notes on specific case photos via `[photo-note:...]` tokens
- display buttons with thumbnails for photo-note actions
- fetch case photos when chat opens
- document new token rules to the LLM
- add tests for photo note buttons and update existing tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a1310791c832bb6c28a24364d2f7a