### PR TITLE
Add photo note chat actions

### DIFF
--- a/docs/case-chat-actions.md
+++ b/docs/case-chat-actions.md
@@ -45,3 +45,17 @@ Example:
 The plate appears to be ABC123. [edit:plate=ABC123]
 ```
 This creates a button labeled **Set Plate to "ABC123"**. Clicking it updates the case.
+
+## Photo Notes
+
+You can also attach a note to a specific image. Use the token
+**`[photo-note:FILENAME=NOTE]`**, where `FILENAME` is the base name of the photo
+file (for example `IMG_0001.jpg`). The chat UI shows a button with a small
+thumbnail of the image and the note text. Clicking the button saves the note on
+that photo.
+
+Example:
+
+```
+The sign is hard to read in photo IMG_0001.jpg. [photo-note:IMG_0001.jpg=blurry sign]
+```

--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { withCaseAuthorization } from "@/lib/authz";
 import { caseActions } from "@/lib/caseActions";
 import { getCase } from "@/lib/caseStore";
@@ -53,6 +54,7 @@ export const POST = withCaseAuthorization(
     const actionList = available
       .map((a) => `- ${a.label} [action:${a.id}]: ${a.description}`)
       .join("\\n");
+    const photoList = c.photos.map((p) => path.basename(p)).join(", ");
     const system = [
       "You are a helpful legal assistant for the Photo To Citation app.",
       "The user is asking about a case with these details:",
@@ -70,6 +72,8 @@ export const POST = withCaseAuthorization(
       "You may want to notify the vehicle owner. [action:notify-owner]",
       "The UI will replace the token with a button.",
       "You can also suggest edits with [edit:FIELD=VALUE] tokens (fields: vin, plate, state, note).",
+      "Add a note to a specific image with [photo-note:FILENAME=NOTE]. Use one of these filenames:",
+      photoList,
       available.length > 0 ? `Available actions:\n${actionList}` : "",
     ]
       .filter(Boolean)


### PR DESCRIPTION
## Summary
- extend Case Chat to add `[photo-note:FILENAME=NOTE]` buttons that update image notes
- load case photos when opening chat and ignore fetch errors
- instruct the assistant about the new photo note syntax
- document photo note action tokens

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a1310791c832bb6c28a24364d2f7a