### PR TITLE
Add photo note actions

### DIFF
--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -70,6 +70,7 @@ export const POST = withCaseAuthorization(
       "You may want to notify the vehicle owner. [action:notify-owner]",
       "The UI will replace the token with a button.",
       "You can also suggest edits with [edit:FIELD=VALUE] tokens (fields: vin, plate, state, note).",
+      "Add image notes with [photo-note:FILENAME=NOTE] where FILENAME is one of the photo filenames.",
       available.length > 0 ? `Available actions:\n${actionList}` : "",
     ]
       .filter(Boolean)

--- a/src/app/cases/__tests__/caseChatCurrent.test.tsx
+++ b/src/app/cases/__tests__/caseChatCurrent.test.tsx
@@ -6,6 +6,11 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
 }));
 
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async () => ({ ok: true, json: async () => ({ photos: [] }) })),
+);
+
 describe("CaseChat current session", () => {
   it("shows current chat option and updates summary", async () => {
     const { getByText, getByLabelText, getByPlaceholderText, findByText } =

--- a/src/app/cases/__tests__/caseChatFocus.test.tsx
+++ b/src/app/cases/__tests__/caseChatFocus.test.tsx
@@ -6,6 +6,11 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
 }));
 
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async () => ({ ok: true, json: async () => ({ photos: [] }) })),
+);
+
 describe("CaseChat input focus", () => {
   it("focuses the input when opened", () => {
     const { getByText, getByPlaceholderText } = render(<CaseChat caseId="1" />);

--- a/src/app/cases/__tests__/caseChatHistory.test.tsx
+++ b/src/app/cases/__tests__/caseChatHistory.test.tsx
@@ -6,6 +6,11 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
 }));
 
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async () => ({ ok: true, json: async () => ({ photos: [] }) })),
+);
+
 describe("CaseChat history", () => {
   it("saves chat to localStorage", async () => {
     localStorage.clear();

--- a/src/app/cases/__tests__/caseChatPhotoNote.test.tsx
+++ b/src/app/cases/__tests__/caseChatPhotoNote.test.tsx
@@ -1,0 +1,33 @@
+import CaseChat from "@/app/cases/[id]/CaseChat";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+const caseData = {
+  photos: ["/uploads/a.jpg"],
+  photoNotes: {},
+};
+
+describe("CaseChat photo note action", () => {
+  it("renders photo note button", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => caseData })),
+    );
+    const { getByText, getByPlaceholderText, findByText } = render(
+      <CaseChat caseId="1" onChat={async () => "[photo-note:a.jpg=test]"} />,
+    );
+    fireEvent.click(getByText("Chat"));
+    const input = getByPlaceholderText("Ask a question...");
+    fireEvent.change(input, { target: { value: "hi" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+    const label = await findByText('Add "test"');
+    const btn = label.closest("button") as HTMLButtonElement;
+    expect(btn.querySelector("img")?.getAttribute("src")).toContain(
+      "/uploads/thumbs/64/a.jpg",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- support photo-note actions in case chat
- allow CaseChat to fetch images and show thumbnails
- expose new photo-note token in chat API instructions
- test parsing of photo-note action tokens

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a1310791c832bb6c28a24364d2f7a