### PR TITLE
Add photo actions to case chat

### DIFF
--- a/docs/case-chat-actions.md
+++ b/docs/case-chat-actions.md
@@ -25,6 +25,10 @@ Available actions:
   the vehicle owner about their violation.
 - `[action:ownership]` — **Request Ownership Info**: record the request for
   official ownership details from the state.
+- `[action:upload-photo]` — **Upload Case Photo**: upload another image as
+  evidence for the case.
+- `[action:take-photo]` — **Take Photo**: open the camera to capture a new photo
+  for this case.
 
 This list is populated from the `caseActions` export, so new actions become
 available to the chat UI automatically.

--- a/src/lib/caseActions.ts
+++ b/src/lib/caseActions.ts
@@ -34,4 +34,17 @@ export const caseActions: CaseAction[] = [
     description:
       "Record the steps for requesting official ownership details from the state. Use if the license plate is known but contact info is missing.",
   },
+  {
+    id: "upload-photo",
+    label: "Upload Case Photo",
+    href: (id) => `/point?case=${id}`,
+    description:
+      "Upload an additional photo for this case, such as evidence or a better view of the violation.",
+  },
+  {
+    id: "take-photo",
+    label: "Take Photo",
+    href: (id) => `/point?case=${id}`,
+    description: "Open the camera to capture a new photo for this case.",
+  },
 ];


### PR DESCRIPTION
## Summary
- extend `caseActions` with `upload-photo` and `take-photo`
- document new chat actions

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a1e951920832b9208e933ffd4b8d8