### PR TITLE
Add photo actions to case chat

### DIFF
--- a/docs/case-chat-actions.md
+++ b/docs/case-chat-actions.md
@@ -25,6 +25,8 @@ Available actions:
   the vehicle owner about their violation.
 - `[action:ownership]` — **Request Ownership Info**: record the request for
   official ownership details from the state.
+- `[action:upload-photo]` — **Upload Photo**: add an existing image to the case.
+- `[action:take-photo]` — **Take Photo**: open the camera to capture new evidence.
 
 This list is populated from the `caseActions` export, so new actions become
 available to the chat UI automatically.

--- a/src/lib/caseActions.ts
+++ b/src/lib/caseActions.ts
@@ -34,4 +34,17 @@ export const caseActions: CaseAction[] = [
     description:
       "Record the steps for requesting official ownership details from the state. Use if the license plate is known but contact info is missing.",
   },
+  {
+    id: "upload-photo",
+    label: "Upload Photo",
+    href: (id) => `/point?case=${id}`,
+    description:
+      "Open the photo upload interface to add an existing image to the case.",
+  },
+  {
+    id: "take-photo",
+    label: "Take Photo",
+    href: (id) => `/point?case=${id}`,
+    description: "Use the device camera to capture a new photo for the case.",
+  },
 ];


### PR DESCRIPTION
## Summary
- add `upload-photo` and `take-photo` case chat actions
- document the new actions for chat tokens

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a1e951920832b9208e933ffd4b8d8