### PR TITLE
Add photo case chat actions

### DIFF
--- a/docs/case-chat-actions.md
+++ b/docs/case-chat-actions.md
@@ -25,6 +25,10 @@ Available actions:
   the vehicle owner about their violation.
 - `[action:ownership]` — **Request Ownership Info**: record the request for
   official ownership details from the state.
+- `[action:upload-photo]` — **Upload Photo**: select and upload an existing
+  picture to the current case.
+- `[action:take-photo]` — **Take Photo**: open the camera to capture a new
+  picture for the case.
 
 This list is populated from the `caseActions` export, so new actions become
 available to the chat UI automatically.

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,9 +1,13 @@
 "use client";
 
+import useAddFilesToCase from "@/app/useAddFilesToCase";
 import useNewCaseFromFiles from "@/app/useNewCaseFromFiles";
+import { useSearchParams } from "next/navigation";
 
 export default function UploadPage() {
-  const uploadCase = useNewCaseFromFiles();
+  const params = useSearchParams();
+  const caseId = params.get("case");
+  const uploadCase = caseId ? useAddFilesToCase(caseId) : useNewCaseFromFiles();
   return (
     <div className="p-8">
       <input

--- a/src/lib/caseActions.ts
+++ b/src/lib/caseActions.ts
@@ -34,4 +34,16 @@ export const caseActions: CaseAction[] = [
     description:
       "Record the steps for requesting official ownership details from the state. Use if the license plate is known but contact info is missing.",
   },
+  {
+    id: "upload-photo",
+    label: "Upload Photo",
+    href: (id) => `/upload?case=${id}`,
+    description: "Upload an existing photo to this case.",
+  },
+  {
+    id: "take-photo",
+    label: "Take Photo",
+    href: (id) => `/point?case=${id}`,
+    description: "Use your camera to take a new photo for this case.",
+  },
 ];


### PR DESCRIPTION
## Summary
- add `useAddFilesToCase` support in upload page
- expose `upload-photo` and `take-photo` chat actions
- document new chat actions for uploading and taking photos

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a1e951920832b9208e933ffd4b8d8