### PR TITLE
Add photo chat actions

### DIFF
--- a/docs/case-chat-actions.md
+++ b/docs/case-chat-actions.md
@@ -25,6 +25,10 @@ Available actions:
   the vehicle owner about their violation.
 - `[action:ownership]` — **Request Ownership Info**: record the request for
   official ownership details from the state.
+- `[action:upload-photo]` — **Upload Case Photo**: select images from the device
+  and attach them to the case.
+- `[action:take-photo]` — **Take Photo**: open the camera to capture a new
+  picture for the case.
 
 This list is populated from the `caseActions` export, so new actions become
 available to the chat UI automatically.

--- a/src/app/cases/[id]/UploadWrapper.tsx
+++ b/src/app/cases/[id]/UploadWrapper.tsx
@@ -1,0 +1,24 @@
+"use client";
+import type { Case } from "@/lib/caseStore";
+import { useRouter } from "next/navigation";
+import ClientCasePage from "./ClientCasePage";
+import UploadModal from "./upload/UploadModal";
+
+export default function UploadWrapper({
+  caseData,
+  caseId,
+}: {
+  caseData: Case | null;
+  caseId: string;
+}) {
+  const router = useRouter();
+  return (
+    <>
+      <ClientCasePage initialCase={caseData} caseId={caseId} />
+      <UploadModal
+        caseId={caseId}
+        onClose={() => router.push(`/cases/${caseId}`)}
+      />
+    </>
+  );
+}

--- a/src/app/cases/[id]/upload/UploadModal.tsx
+++ b/src/app/cases/[id]/upload/UploadModal.tsx
@@ -1,0 +1,53 @@
+"use client";
+import useAddFilesToCase from "@/app/useAddFilesToCase";
+import * as Dialog from "@radix-ui/react-dialog";
+import { useEffect, useRef } from "react";
+
+export default function UploadModal({
+  caseId,
+  onClose,
+}: {
+  caseId: string;
+  onClose: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const upload = useAddFilesToCase(caseId);
+
+  useEffect(() => {
+    inputRef.current?.click();
+  }, []);
+
+  async function handleChange(files: FileList | null) {
+    await upload(files);
+    onClose();
+  }
+
+  return (
+    <Dialog.Root open onOpenChange={(o) => !o && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
+        <Dialog.Content className="fixed inset-0 flex items-center justify-center p-4 z-50">
+          <div className="bg-white dark:bg-gray-900 rounded shadow p-4">
+            <input
+              ref={inputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              onChange={(e) => handleChange(e.target.files)}
+            />
+            <div className="flex justify-end mt-4">
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  className="bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded"
+                >
+                  Close
+                </button>
+              </Dialog.Close>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/app/cases/[id]/upload/page.tsx
+++ b/src/app/cases/[id]/upload/page.tsx
@@ -1,0 +1,14 @@
+import UploadWrapper from "@/app/cases/[id]/UploadWrapper";
+import { getCase } from "@/lib/caseStore";
+
+export const dynamic = "force-dynamic";
+
+export default async function UploadPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const c = getCase(id);
+  return <UploadWrapper caseData={c ?? null} caseId={id} />;
+}

--- a/src/lib/caseActions.ts
+++ b/src/lib/caseActions.ts
@@ -34,4 +34,18 @@ export const caseActions: CaseAction[] = [
     description:
       "Record the steps for requesting official ownership details from the state. Use if the license plate is known but contact info is missing.",
   },
+  {
+    id: "upload-photo",
+    label: "Upload Case Photo",
+    href: (id) => `/cases/${id}/upload`,
+    description:
+      "Select one or more images from the device and attach them to the case.",
+  },
+  {
+    id: "take-photo",
+    label: "Take Photo",
+    href: (id) => `/point?case=${id}`,
+    description:
+      "Open the camera interface to capture a new photo for this case.",
+  },
 ];


### PR DESCRIPTION
## Summary
- add Upload Case Photo and Take Photo case chat actions
- document new case chat actions
- implement UploadWrapper and modal for attaching photos

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a1e951920832b9208e933ffd4b8d8