### PR TITLE
Fix active tab highlight in user settings

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -41,14 +41,22 @@ export default function UserSettingsPage() {
         <button
           type="button"
           onClick={() => setTab("profile")}
-          className="bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
+          className={
+            tab === "profile"
+              ? "bg-blue-600 text-white px-2 py-1 rounded"
+              : "bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
+          }
         >
           Profile
         </button>
         <button
           type="button"
           onClick={() => setTab("credits")}
-          className="bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
+          className={
+            tab === "credits"
+              ? "bg-blue-600 text-white px-2 py-1 rounded"
+              : "bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
+          }
         >
           Credits
         </button>


### PR DESCRIPTION
## Summary
- highlight the active tab on the user settings page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a8a179a44832b9fbac5fed336b3a6