### PR TITLE
Inline compose draft in chat

### DIFF
--- a/docs/case-chat-actions.md
+++ b/docs/case-chat-actions.md
@@ -17,8 +17,8 @@ This produces a **Notify Owner** button in the chat.
 
 Available actions:
 
-- `[action:compose]` — **Draft Report**: open a form to compose an email report
-  to the appropriate authority.
+- `[action:compose]` — **Draft Report**: display an editable email draft inline
+  in the chat so the user can send it directly to the appropriate authority.
 - `[action:followup]` — **Follow Up**: send another email in an existing thread
   to ask about citation status.
 - `[action:notify-owner]` — **Notify Owner**: create an anonymous email warning


### PR DESCRIPTION
## Summary
- show compose draft inline within CaseChat instead of a modal
- clarify compose action description in docs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a203d4914832b89cc7bf430a2731c