### PR TITLE
Show email draft inside chat

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -2,10 +2,14 @@
 import { apiFetch } from "@/apiClient";
 import ThumbnailImage from "@/components/thumbnail-image";
 import { caseActions } from "@/lib/caseActions";
+import type { EmailDraft } from "@/lib/caseReport";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
+import type { ReportModule } from "@/lib/reportModules";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+import { useNotify } from "../../components/NotificationProvider";
 import styles from "./CaseChat.module.css";
+import DraftPreview from "./draft/DraftPreview";
 
 interface Message {
   id: string;
@@ -39,6 +43,13 @@ export default function CaseChat({
   const inputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
   const [photoMap, setPhotoMap] = useState<Record<string, string>>({});
+  const [draftData, setDraftData] = useState<{
+    email: EmailDraft;
+    attachments: string[];
+    module: ReportModule;
+  } | null>(null);
+  const [draftLoading, setDraftLoading] = useState(false);
+  const notify = useNotify();
 
   const storageKey = `case-chat-${caseId}`;
 
@@ -89,6 +100,24 @@ export default function CaseChat({
     setPhotoMap(map);
   }
 
+  async function openDraft() {
+    setDraftLoading(true);
+    setDraftData(null);
+    const res = await apiFetch(`/api/cases/${caseId}/report`);
+    if (res.ok) {
+      const data = (await res.json()) as {
+        email: EmailDraft;
+        attachments: string[];
+        module: ReportModule;
+      };
+      setDraftData(data);
+    } else {
+      const err = await res.json().catch(() => ({}));
+      notify(err.error || "Failed to draft report");
+    }
+    setDraftLoading(false);
+  }
+
   async function seed() {
     setLoading(true);
     abortRef.current?.abort();
@@ -129,6 +158,8 @@ export default function CaseChat({
 
   function handleClose() {
     setOpen(false);
+    setDraftData(null);
+    setDraftLoading(false);
     if (messages.length > 0 && sessionId) {
       const firstUser = messages.find((m) => m.role === "user");
       const summary =
@@ -226,7 +257,13 @@ export default function CaseChat({
             <button
               key={`${act.id}-${idx}`}
               type="button"
-              onClick={() => router.push(act.href(caseId))}
+              onClick={() => {
+                if (act.id === "compose") {
+                  void openDraft();
+                } else {
+                  router.push(act.href(caseId));
+                }
+              }}
               className="bg-blue-600 text-white px-2 py-1 rounded mx-1"
             >
               {act.label}
@@ -413,6 +450,22 @@ export default function CaseChat({
               <div className="text-left" key="typing">
                 <span
                   className={`${styles.bubble} ${styles.assistant} ${styles.typing}`}
+                />
+              </div>
+            )}
+            {draftLoading && (
+              <div className="text-left" key="draft-loading">
+                <span className="text-sm">
+                  Drafting email based on case information...
+                </span>
+              </div>
+            )}
+            {draftData && (
+              <div className="text-left" key="draft-preview">
+                <DraftPreview
+                  caseId={caseId}
+                  data={draftData}
+                  onClose={() => setDraftData(null)}
                 />
               </div>
             )}

--- a/src/app/cases/[id]/ComposeWrapper.tsx
+++ b/src/app/cases/[id]/ComposeWrapper.tsx
@@ -1,6 +1,9 @@
 "use client";
+import type { EmailDraft } from "@/lib/caseReport";
 import type { Case } from "@/lib/caseStore";
+import type { ReportModule } from "@/lib/reportModules";
 import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import ClientCasePage from "./ClientCasePage";
 import DraftModal from "./draft/DraftModal";
 
@@ -12,12 +15,44 @@ export default function ComposeWrapper({
   caseId: string;
 }) {
   const router = useRouter();
+  const [draftData, setDraftData] = useState<{
+    email: EmailDraft;
+    attachments: string[];
+    module: ReportModule;
+  } | null>(null);
+
+  useEffect(() => {
+    interface HistoryState {
+      draftData?: {
+        email: EmailDraft;
+        attachments: string[];
+        module: ReportModule;
+      };
+    }
+    const st: HistoryState | null =
+      typeof window !== "undefined" ? (history.state as HistoryState) : null;
+    if (st?.draftData) {
+      setDraftData(st.draftData);
+    }
+  }, []);
+
+  function handleClose() {
+    router.push(`/cases/${caseId}`);
+    if (typeof history !== "undefined") {
+      const st = history.state ?? {};
+      if (st.draftData) {
+        st.draftData = undefined;
+        history.replaceState(st, "", `/cases/${caseId}`);
+      }
+    }
+  }
   return (
     <>
       <ClientCasePage initialCase={caseData} caseId={caseId} />
       <DraftModal
         caseId={caseId}
-        onClose={() => router.push(`/cases/${caseId}`)}
+        initialData={draftData ?? undefined}
+        onClose={handleClose}
       />
     </>
   );

--- a/src/app/cases/[id]/draft/DraftModal.tsx
+++ b/src/app/cases/[id]/draft/DraftModal.tsx
@@ -16,15 +16,18 @@ interface DraftData {
 export default function DraftModal({
   caseId,
   onClose,
+  initialData,
 }: {
   caseId: string;
   onClose: () => void;
+  initialData?: DraftData | null;
 }) {
-  const [data, setData] = useState<DraftData | null>(null);
+  const [data, setData] = useState<DraftData | null>(initialData ?? null);
   const [fullScreen, setFullScreen] = useState(false);
   const notify = useNotify();
 
   useEffect(() => {
+    if (initialData) return;
     let canceled = false;
     apiFetch(`/api/cases/${caseId}/report`)
       .then(async (res) => {
@@ -42,7 +45,11 @@ export default function DraftModal({
     return () => {
       canceled = true;
     };
-  }, [caseId, onClose, notify]);
+  }, [caseId, initialData, onClose, notify]);
+
+  useEffect(() => {
+    if (initialData) setData(initialData);
+  }, [initialData]);
 
   return (
     <Dialog.Root open onOpenChange={(o) => !o && onClose()}>

--- a/src/app/cases/[id]/draft/DraftPreview.tsx
+++ b/src/app/cases/[id]/draft/DraftPreview.tsx
@@ -1,0 +1,88 @@
+"use client";
+import { apiFetch } from "@/apiClient";
+import type { EmailDraft } from "@/lib/caseReport";
+import type { ReportModule } from "@/lib/reportModules";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useNotify } from "../../../components/NotificationProvider";
+
+interface DraftData {
+  email: EmailDraft;
+  attachments: string[];
+  module: ReportModule;
+}
+
+export default function DraftPreview({
+  caseId,
+  data,
+  onClose,
+}: {
+  caseId: string;
+  data: DraftData;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const notify = useNotify();
+  const [sending, setSending] = useState(false);
+
+  function openCompose() {
+    const url = `/cases/${caseId}/compose`;
+    router.push(url).then(() => {
+      if (typeof history !== "undefined") {
+        const st = history.state ?? {};
+        history.replaceState({ ...st, draftData: data }, "", url);
+      }
+    });
+  }
+
+  async function send() {
+    setSending(true);
+    const res = await apiFetch(`/api/cases/${caseId}/report`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        subject: data.email.subject,
+        body: data.email.body,
+        attachments: data.attachments,
+      }),
+    });
+    if (res.ok) {
+      notify("Email sent");
+      onClose();
+    } else {
+      const err = await res.json().catch(() => ({}));
+      notify(err.error || "Failed to send email");
+    }
+    setSending(false);
+  }
+
+  const previewBody =
+    data.email.body.length > 80
+      ? `${data.email.body.slice(0, 77)}...`
+      : data.email.body;
+
+  return (
+    <div className="bg-blue-600 text-white px-2 py-1 rounded mx-1 text-xs space-y-1">
+      <button type="button" onClick={openCompose} className="text-left w-full">
+        <strong>{data.email.subject}</strong> {previewBody}
+      </button>
+      <div className="flex gap-1">
+        <button
+          type="button"
+          onClick={send}
+          disabled={sending}
+          className="bg-blue-800 text-white px-1 rounded disabled:opacity-50"
+        >
+          {sending ? "Sending..." : "Send"}
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="bg-gray-200 text-black px-1 rounded"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show an inline draft preview component inside CaseChat
- allow sending email from preview and open composer with pushState
- carry draft data across router navigation

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a203d4914832b89cc7bf430a2731c