### PR TITLE
Implement interactive tooltip for inline email draft

### DIFF
--- a/src/app/cases/[id]/draft/DraftPreview.tsx
+++ b/src/app/cases/[id]/draft/DraftPreview.tsx
@@ -1,6 +1,9 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import ThumbnailImage from "@/components/thumbnail-image";
+import Tooltip from "@/components/ui/tooltip";
 import type { EmailDraft } from "@/lib/caseReport";
+import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import type { ReportModule } from "@/lib/reportModules";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -61,11 +64,28 @@ export default function DraftPreview({
       ? `${data.email.body.slice(0, 77)}...`
       : data.email.body;
 
-  return (
-    <div className="bg-blue-600 text-white px-2 py-1 rounded mx-1 text-xs space-y-1">
-      <button type="button" onClick={openCompose} className="text-left w-full">
-        <strong>{data.email.subject}</strong> {previewBody}
-      </button>
+  const tooltipContent = (
+    <div className="bg-white text-black p-2 rounded shadow space-y-2 max-w-sm">
+      <div>
+        <strong>{data.email.subject}</strong>
+        <pre className="whitespace-pre-wrap text-xs mt-1">
+          {data.email.body}
+        </pre>
+      </div>
+      {data.attachments.length > 0 && (
+        <div className="flex gap-1 flex-wrap">
+          {data.attachments.map((p) => (
+            <ThumbnailImage
+              key={p}
+              src={getThumbnailUrl(p, 64)}
+              alt="attachment"
+              width={64}
+              height={48}
+              imgClassName="object-contain"
+            />
+          ))}
+        </div>
+      )}
       <div className="flex gap-1">
         <button
           type="button"
@@ -80,9 +100,22 @@ export default function DraftPreview({
           onClick={onClose}
           className="bg-gray-200 text-black px-1 rounded"
         >
-          Close
+          Dismiss
+        </button>
+        <button type="button" onClick={openCompose} className="underline">
+          Open Draft
         </button>
       </div>
+    </div>
+  );
+
+  return (
+    <div className="bg-blue-600 text-white px-2 py-1 rounded mx-1 text-xs">
+      <Tooltip label={tooltipContent} placement="top">
+        <span className="cursor-pointer">
+          <strong>{data.email.subject}</strong> {previewBody}
+        </span>
+      </Tooltip>
     </div>
   );
 }

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -4,6 +4,7 @@ import {
   type Placement,
   flip,
   offset,
+  safePolygon,
   shift,
   useDismiss,
   useFloating,
@@ -41,6 +42,8 @@ export default function Tooltip({
   const hover = useHover(context, {
     enabled: controlledOpen === undefined,
     move: false,
+    handleClose: safePolygon(),
+    delay: { open: 100, close: 100 },
   });
   const focus = useFocus(context, { enabled: controlledOpen === undefined });
   const dismiss = useDismiss(context);


### PR DESCRIPTION
## Summary
- show DraftPreview details in a tooltip
- allow selecting text and interaction via safe polygon hover handling
- update Tooltip component to keep tooltip open while hovering

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aa74fd24c832ba5caf2397efe26fd