### PR TITLE
Fix draft preview for expanded CaseChat

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -7,8 +7,8 @@ import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import type { ReportModule } from "@/lib/reportModules";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useNotify } from "../../components/NotificationProvider";
 import { FaCompressArrowsAlt, FaExpandArrowsAlt } from "react-icons/fa";
+import { useNotify } from "../../components/NotificationProvider";
 import styles from "./CaseChat.module.css";
 import DraftPreview from "./draft/DraftPreview";
 
@@ -411,6 +411,13 @@ export default function CaseChat({
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
   }, [messages]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll when draft opens
+  useEffect(() => {
+    if (draftLoading || draftData) {
+      scrollToBottom();
+    }
+  }, [draftData, draftLoading]);
 
   useEffect(() => {
     if (open && inputRef.current) inputRef.current.focus();

--- a/src/app/cases/__tests__/caseChatDraftPreview.test.tsx
+++ b/src/app/cases/__tests__/caseChatDraftPreview.test.tsx
@@ -1,0 +1,43 @@
+import CaseChat from "@/app/cases/[id]/CaseChat";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+describe("CaseChat draft preview", () => {
+  it("shows draft preview when compose action clicked", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/report")) {
+          return {
+            ok: true,
+            json: async () => ({
+              email: { subject: "S", body: "B" },
+              attachments: [],
+              module: "mod",
+            }),
+          } as Response;
+        }
+        return { ok: true, json: async () => ({ photos: [] }) } as Response;
+      }),
+    );
+    const { getByText, getByPlaceholderText, findByText } = render(
+      <CaseChat caseId="1" onChat={async () => "[action:compose]"} />,
+    );
+    fireEvent.click(getByText("Chat"));
+    const input = getByPlaceholderText("Ask a question...");
+    fireEvent.change(input, { target: { value: "hi" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+    const composeBtn = await findByText("Draft Report");
+    fireEvent.click(composeBtn);
+    await waitFor(() =>
+      expect(
+        getByText("Drafting email based on case information..."),
+      ).toBeTruthy(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- keep imports ordered in CaseChat
- scroll CaseChat to bottom when showing draft preview
- test draft preview rendering

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ab145d788832b9fcf24e02829e052