### PR TITLE
Fix draft preview with expanded case chat

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -7,8 +7,8 @@ import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import type { ReportModule } from "@/lib/reportModules";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useNotify } from "../../components/NotificationProvider";
 import { FaCompressArrowsAlt, FaExpandArrowsAlt } from "react-icons/fa";
+import { useNotify } from "../../components/NotificationProvider";
 import styles from "./CaseChat.module.css";
 import DraftPreview from "./draft/DraftPreview";
 
@@ -411,6 +411,12 @@ export default function CaseChat({
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
   }, [messages]);
+
+  useEffect(() => {
+    if (scrollRef.current && (draftLoading || draftData)) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [draftLoading, draftData]);
 
   useEffect(() => {
     if (open && inputRef.current) inputRef.current.focus();


### PR DESCRIPTION
## Summary
- keep import order tidy in `CaseChat`
- scroll to bottom when draft preview loads so it's visible in expanded view

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ab145d788832b9fcf24e02829e052