### PR TITLE
fix: restore inline draft preview with scroll

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -7,8 +7,8 @@ import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import type { ReportModule } from "@/lib/reportModules";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useNotify } from "../../components/NotificationProvider";
 import { FaCompressArrowsAlt, FaExpandArrowsAlt } from "react-icons/fa";
+import { useNotify } from "../../components/NotificationProvider";
 import styles from "./CaseChat.module.css";
 import DraftPreview from "./draft/DraftPreview";
 
@@ -411,6 +411,12 @@ export default function CaseChat({
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
   }, [messages]);
+
+  useEffect(() => {
+    if (scrollRef.current && (draftLoading || draftData)) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [draftData, draftLoading]);
 
   useEffect(() => {
     if (open && inputRef.current) inputRef.current.focus();


### PR DESCRIPTION
## Summary
- ensure draft preview scrolls into view
- reorder imports for linting

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ab145d788832b9fcf24e02829e052