### PR TITLE
Enhance inline draft preview

### DIFF
--- a/src/app/cases/[id]/draft/DraftPreview.tsx
+++ b/src/app/cases/[id]/draft/DraftPreview.tsx
@@ -1,7 +1,11 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import ThumbnailImage from "@/components/thumbnail-image";
+import Tooltip from "@/components/ui/tooltip";
 import type { EmailDraft } from "@/lib/caseReport";
+import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import type { ReportModule } from "@/lib/reportModules";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useNotify } from "../../../components/NotificationProvider";
@@ -61,11 +65,61 @@ export default function DraftPreview({
       ? `${data.email.body.slice(0, 77)}...`
       : data.email.body;
 
+  const tooltipContent = (
+    <div className="bg-white text-black p-2 rounded shadow max-w-sm space-y-2">
+      <div className="font-semibold text-sm">{data.email.subject}</div>
+      <pre className="whitespace-pre-wrap text-xs">{data.email.body}</pre>
+      {data.attachments.length > 0 && (
+        <div className="flex gap-1 flex-wrap">
+          {data.attachments.map((p) => (
+            <ThumbnailImage
+              key={p}
+              src={getThumbnailUrl(p, 128)}
+              alt="attachment"
+              width={96}
+              height={72}
+              imgClassName="object-contain"
+            />
+          ))}
+        </div>
+      )}
+      <div className="flex gap-1 flex-wrap">
+        <button
+          type="button"
+          onClick={send}
+          disabled={sending}
+          className="bg-blue-800 text-white px-1 rounded text-xs disabled:opacity-50"
+        >
+          {sending ? "Sending..." : "Send"}
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="bg-gray-200 text-black px-1 rounded text-xs"
+        >
+          Close
+        </button>
+        <Link
+          href={`/cases/${caseId}/compose`}
+          className="bg-blue-600 text-white px-1 rounded text-xs"
+        >
+          Full Editor
+        </Link>
+      </div>
+    </div>
+  );
+
   return (
     <div className="bg-blue-600 text-white px-2 py-1 rounded mx-1 text-xs space-y-1">
-      <button type="button" onClick={openCompose} className="text-left w-full">
-        <strong>{data.email.subject}</strong> {previewBody}
-      </button>
+      <Tooltip label={tooltipContent} interactive>
+        <button
+          type="button"
+          onClick={openCompose}
+          className="text-left w-full"
+        >
+          <strong>{data.email.subject}</strong> {previewBody}
+        </button>
+      </Tooltip>
       <div className="flex gap-1">
         <button
           type="button"

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -4,6 +4,7 @@ import {
   type Placement,
   flip,
   offset,
+  safePolygon,
   shift,
   useDismiss,
   useFloating,
@@ -21,12 +22,14 @@ export default function Tooltip({
   placement = "top",
   open: controlledOpen,
   onOpenChange,
+  interactive = false,
 }: {
   label: ReactElement | string;
   children: ReactElement;
   placement?: Placement;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  interactive?: boolean;
 }) {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const open = controlledOpen ?? uncontrolledOpen;
@@ -41,6 +44,7 @@ export default function Tooltip({
   const hover = useHover(context, {
     enabled: controlledOpen === undefined,
     move: false,
+    handleClose: interactive ? safePolygon() : undefined,
   });
   const focus = useFocus(context, { enabled: controlledOpen === undefined });
   const dismiss = useDismiss(context);


### PR DESCRIPTION
## Summary
- add interactive tooltip option
- show full draft in tooltip with attachments

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685aa74fd24c832ba5caf2397efe26fd