### PR TITLE
Improve debug tooltip behavior

### DIFF
--- a/src/app/components/DebugWrapper.tsx
+++ b/src/app/components/DebugWrapper.tsx
@@ -64,11 +64,12 @@ export default function DebugWrapper({
           >
             Copy
           </button>
-          <pre className="pt-4">{tokens}</pre>
+          <pre className="pt-4 whitespace-pre-wrap break-words">{tokens}</pre>
         </div>
       }
       open={show}
       onOpenChange={setOpen}
+      interactive
     >
       <div
         onMouseEnter={() => {


### PR DESCRIPTION
## Summary
- prevent CaseChat debug tooltip from closing when mousing over
- wrap tooltip text for better readability

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ae580d590832ba80017be5b3c3a59