### PR TITLE
Improve debug tooltip wrapping

### DIFF
--- a/src/app/components/DebugWrapper.tsx
+++ b/src/app/components/DebugWrapper.tsx
@@ -64,11 +64,12 @@ export default function DebugWrapper({
           >
             Copy
           </button>
-          <pre className="pt-4">{tokens}</pre>
+          <pre className="pt-4 whitespace-pre-wrap break-words">{tokens}</pre>
         </div>
       }
       open={show}
       onOpenChange={setOpen}
+      interactive
     >
       <div
         onMouseEnter={() => {
@@ -77,7 +78,6 @@ export default function DebugWrapper({
         }}
         onMouseLeave={() => {
           setRefHover(false);
-          setOpen(false);
         }}
         className="inline-block"
       >


### PR DESCRIPTION
## Summary
- update debug tooltip to remain open while hovered
- ensure debug output wraps within tooltip

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae580d590832ba80017be5b3c3a59