### PR TITLE
Improve debug tooltip behavior

### DIFF
--- a/src/app/components/DebugWrapper.tsx
+++ b/src/app/components/DebugWrapper.tsx
@@ -46,9 +46,6 @@ export default function DebugWrapper({
   useEffect(() => {
     if (alt && refHover) setOpen(true);
   }, [alt, refHover]);
-  useEffect(() => {
-    if (!refHover) setOpen(false);
-  }, [refHover]);
   const json = JSON.stringify(data, null, 2);
   const tokens = tokenize(json);
   if (!enabled) return <>{children}</>;
@@ -64,11 +61,13 @@ export default function DebugWrapper({
           >
             Copy
           </button>
-          <pre className="pt-4">{tokens}</pre>
+          <pre className="pt-4 whitespace-pre-wrap break-words">{tokens}</pre>
         </div>
       }
       open={show}
       onOpenChange={setOpen}
+      interactive
+      closeDelay={200}
     >
       <div
         onMouseEnter={() => {
@@ -77,7 +76,6 @@ export default function DebugWrapper({
         }}
         onMouseLeave={() => {
           setRefHover(false);
-          setOpen(false);
         }}
         className="inline-block"
       >

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -23,6 +23,7 @@ export default function Tooltip({
   open: controlledOpen,
   onOpenChange,
   interactive = false,
+  closeDelay = 0,
 }: {
   label: ReactElement | string;
   children: ReactElement;
@@ -30,6 +31,7 @@ export default function Tooltip({
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   interactive?: boolean;
+  closeDelay?: number;
 }) {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const open = controlledOpen ?? uncontrolledOpen;
@@ -45,6 +47,7 @@ export default function Tooltip({
     enabled: controlledOpen === undefined,
     move: false,
     handleClose: interactive ? safePolygon() : undefined,
+    delay: { close: closeDelay },
   });
   const focus = useFocus(context, { enabled: controlledOpen === undefined });
   const dismiss = useDismiss(context);


### PR DESCRIPTION
## Summary
- prevent CaseChat debug tooltip from closing when mousing over
- wrap tooltip text for better readability
- delay tooltip dismiss to make hovering easier

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ae580d590832ba80017be5b3c3a59