### PR TITLE
Fix case chat actions

### DIFF
--- a/docs/case-chat-actions.md
+++ b/docs/case-chat-actions.md
@@ -20,3 +20,12 @@ The chat UI renders the `response` as text and creates a button for each entry i
 - `id` &mdash; opens the corresponding page from `caseActions`.
 - `field` and `value` &mdash; apply an edit to the case.
 - `photo` and `note` &mdash; append a note to a photo.
+
+The LLM receives a list of available actions formatted like:
+
+```
+- Draft Report (id: compose) - Open a form to draft an email report.
+- Follow Up (id: followup) - Send a follow up email.
+```
+
+Use the `id` value from that list when populating the `actions` array.

--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -53,7 +53,7 @@ export const POST = withCaseAuthorization(
       : "";
     const available = caseActions.filter((a) => !actionCompleted(c, a.id));
     const actionList = available
-      .map((a) => `- ${a.label}: ${a.description}`)
+      .map((a) => `- ${a.label} (id: ${a.id}) - ${a.description}`)
       .join("\\n");
     const schemaDesc =
       "{ response: string, actions: [{ id?: string, field?: string, value?: string, photo?: string, note?: string }], noop: boolean }";

--- a/src/app/cases/[id]/CaseChat.stories.tsx
+++ b/src/app/cases/[id]/CaseChat.stories.tsx
@@ -128,3 +128,27 @@ export const MixedActions: Story = {
     return <CaseChat caseId="1" onChat={async () => reply} />;
   },
 };
+
+export const ResponseOnly: Story = {
+  render: () => {
+    usePhotoStub();
+    const reply: CaseChatReply = {
+      response: "Just a regular response",
+      actions: [],
+      noop: false,
+    };
+    return <CaseChat caseId="1" onChat={async () => reply} />;
+  },
+};
+
+export const Noop: Story = {
+  render: () => {
+    usePhotoStub();
+    const reply: CaseChatReply = {
+      response: "",
+      actions: [],
+      noop: true,
+    };
+    return <CaseChat caseId="1" onChat={async () => reply} />;
+  },
+};


### PR DESCRIPTION
## Summary
- display action IDs in LLM prompt so replies include them
- document action IDs for case chat
- add more CaseChat stories for Storybook

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685af02c8b88832ba716a736e32d7c24