### PR TITLE
Fix case chat actions and expand stories

### DIFF
--- a/src/app/cases/[id]/CaseChat.stories.tsx
+++ b/src/app/cases/[id]/CaseChat.stories.tsx
@@ -128,3 +128,27 @@ export const MixedActions: Story = {
     return <CaseChat caseId="1" onChat={async () => reply} />;
   },
 };
+
+export const NoActions: Story = {
+  render: () => {
+    usePhotoStub();
+    const reply: CaseChatReply = {
+      response: "All set!",
+      actions: [],
+      noop: false,
+    };
+    return <CaseChat caseId="1" onChat={async () => reply} />;
+  },
+};
+
+export const Noop: Story = {
+  render: () => {
+    usePhotoStub();
+    const reply: CaseChatReply = {
+      response: "",
+      actions: [],
+      noop: true,
+    };
+    return <CaseChat caseId="1" onChat={async () => reply} />;
+  },
+};

--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -291,13 +291,14 @@ export default function CaseChat({
     abortRef.current = controller;
     try {
       let reply: CaseChatReply | null = null;
+      const base = list.map(({ role, content }) => ({ role, content }));
       if (onChat) {
-        reply = await onChat(list);
+        reply = await onChat(base);
       } else {
         const res = await apiFetch(`/api/cases/${caseId}/chat`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ messages: list }),
+          body: JSON.stringify({ messages: base }),
           signal: controller.signal,
         });
         if (res.ok) {


### PR DESCRIPTION
## Summary
- sanitize CaseChat messages before sending to the API so OpenAI only sees `role` and `content`
- add extra Storybook stories for CaseChat

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685af02c8b88832ba716a736e32d7c24