### PR TITLE
Fix missing CaseChat actions

### DIFF
--- a/docs/case-chat-actions.md
+++ b/docs/case-chat-actions.md
@@ -1,6 +1,6 @@
 # Case Chat Actions
 
-Case Chat replies are JSON objects with a `response` string, an `actions` array, and a `noop` boolean. Each action may reference a case action, suggest an edit, or add a photo note. When `noop` is `true` the assistant had nothing useful to add, even if it produced conversational text.
+Case Chat replies are JSON objects with a `response` string, an `actions` array, and a `noop` boolean. Each action may reference a case action, suggest an edit, or add a photo note. When `noop` is `true` the assistant had nothing useful to add, so `response` should be an empty string.
 
 Example:
 ```json
@@ -20,3 +20,5 @@ The chat UI renders the `response` as text and creates a button for each entry i
 - `id` &mdash; opens the corresponding page from `caseActions`.
 - `field` and `value` &mdash; apply an edit to the case.
 - `photo` and `note` &mdash; append a note to a photo.
+
+If there is nothing useful to add, return `{ "response": "", "actions": [], "noop": true }`.

--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -67,7 +67,7 @@ export const POST = withCaseAuthorization(
       `Number of photos: ${c.photos.length}.`,
       contextLines ? `Image contexts:\n${contextLines}` : "",
       "When there is no user question yet, decide if you should proactively suggest a next action or useful observation.",
-      "If you have nothing helpful, set response to [noop].",
+      "If you have nothing helpful, set noop to true and response to an empty string.",
       `Reply in JSON matching this schema: ${schemaDesc}`,
       available.length > 0 ? `Available actions:\n${actionList}` : "",
     ]

--- a/src/app/cases/[id]/CaseChat.stories.tsx
+++ b/src/app/cases/[id]/CaseChat.stories.tsx
@@ -128,3 +128,11 @@ export const MixedActions: Story = {
     return <CaseChat caseId="1" onChat={async () => reply} />;
   },
 };
+
+export const Noop: Story = {
+  render: () => {
+    usePhotoStub();
+    const reply: CaseChatReply = { response: "", actions: [], noop: true };
+    return <CaseChat caseId="1" onChat={async () => reply} />;
+  },
+};


### PR DESCRIPTION
## Summary
- clarify `noop` usage in Case Chat prompt
- document how to send a noop response
- add a Storybook story demonstrating the noop case

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685af02c8b88832ba716a736e32d7c24