### PR TITLE
Fix case chat noop instructions and extend stories

### DIFF
--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -67,7 +67,7 @@ export const POST = withCaseAuthorization(
       `Number of photos: ${c.photos.length}.`,
       contextLines ? `Image contexts:\n${contextLines}` : "",
       "When there is no user question yet, decide if you should proactively suggest a next action or useful observation.",
-      "If you have nothing helpful, set response to [noop].",
+      "If you have nothing helpful, set noop to true.",
       `Reply in JSON matching this schema: ${schemaDesc}`,
       available.length > 0 ? `Available actions:\n${actionList}` : "",
     ]

--- a/src/app/cases/[id]/CaseChat.stories.tsx
+++ b/src/app/cases/[id]/CaseChat.stories.tsx
@@ -128,3 +128,33 @@ export const MixedActions: Story = {
     return <CaseChat caseId="1" onChat={async () => reply} />;
   },
 };
+
+export const NoActions: Story = {
+  render: () => {
+    usePhotoStub();
+    const reply: CaseChatReply = {
+      response: "Nothing to do",
+      actions: [],
+      noop: false,
+    };
+    return <CaseChat caseId="1" onChat={async () => reply} />;
+  },
+};
+
+export const Conversation: Story = {
+  render: () => {
+    usePhotoStub();
+    const replies: CaseChatReply[] = [
+      { response: "First", actions: [{ id: "compose" }], noop: false },
+      {
+        response: "Second",
+        actions: [{ field: "state", value: "CA" }],
+        noop: false,
+      },
+    ];
+    let i = 0;
+    return (
+      <CaseChat caseId="1" onChat={async () => replies[i++] ?? replies[1]} />
+    );
+  },
+};


### PR DESCRIPTION
## Summary
- clarify `noop` instructions in the case chat API prompt
- add `NoActions` and `Conversation` stories for CaseChat

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685af02c8b88832ba716a736e32d7c24