### PR TITLE
Add inline camera widget to chat

### DIFF
--- a/docs/case-chat-actions.md
+++ b/docs/case-chat-actions.md
@@ -28,7 +28,7 @@ Available actions:
 - `[action:upload-photo]` — **Upload Photo**: select and upload an existing
   picture to the current case.
 - `[action:take-photo]` — **Take Photo**: open the camera to capture a new
-  picture for the case.
+  picture for the case using an inline camera widget.
 
 This list is populated from the `caseActions` export, so new actions become
 available to the chat UI automatically.

--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef, useState } from "react";
 import { FaCompressArrowsAlt, FaExpandArrowsAlt } from "react-icons/fa";
 import { useNotify } from "../../components/NotificationProvider";
 import styles from "./CaseChat.module.css";
+import TakePhotoWidget from "./camera/TakePhotoWidget";
 import DraftPreview from "./draft/DraftPreview";
 
 interface Message {
@@ -61,6 +62,7 @@ export default function CaseChat({
     module: ReportModule;
   } | null>(null);
   const [draftLoading, setDraftLoading] = useState(false);
+  const [cameraOpen, setCameraOpen] = useState(false);
   const notify = useNotify();
 
   const storageKey = `case-chat-${caseId}`;
@@ -131,6 +133,10 @@ export default function CaseChat({
     setDraftLoading(false);
   }
 
+  function openCamera() {
+    setCameraOpen(true);
+  }
+
   async function seed() {
     setLoading(true);
     abortRef.current?.abort();
@@ -185,6 +191,7 @@ export default function CaseChat({
     setOpen(false);
     setDraftData(null);
     setDraftLoading(false);
+    setCameraOpen(false);
     if (controlledExpanded === undefined) {
       setExpandedState(false);
     } else {
@@ -298,6 +305,8 @@ export default function CaseChat({
               onClick={() => {
                 if (act.id === "compose") {
                   void openDraft();
+                } else if (act.id === "take-photo") {
+                  openCamera();
                 } else {
                   router.push(act.href(caseId));
                 }
@@ -535,6 +544,14 @@ export default function CaseChat({
                   caseId={caseId}
                   data={draftData}
                   onClose={() => setDraftData(null)}
+                />
+              </div>
+            )}
+            {cameraOpen && (
+              <div className="text-left" key="camera-widget">
+                <TakePhotoWidget
+                  caseId={caseId}
+                  onClose={() => setCameraOpen(false)}
                 />
               </div>
             )}

--- a/src/app/cases/[id]/camera/TakePhotoWidget.tsx
+++ b/src/app/cases/[id]/camera/TakePhotoWidget.tsx
@@ -1,0 +1,99 @@
+"use client";
+import useAddFilesToCase from "@/app/useAddFilesToCase";
+import { useEffect, useRef, useState } from "react";
+
+export default function TakePhotoWidget({
+  caseId,
+  onClose,
+}: {
+  caseId: string;
+  onClose: () => void;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const uploadCase = useAddFilesToCase(caseId);
+  const [error, setError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    let stream: MediaStream | null = null;
+    async function startCamera() {
+      if (!navigator.mediaDevices?.getUserMedia) {
+        setError("Camera API not available");
+        return;
+      }
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: "environment" },
+          audio: false,
+        });
+        const v = videoRef.current;
+        if (v) {
+          v.srcObject = stream;
+          v.setAttribute("autoplay", "");
+          v.setAttribute("muted", "");
+          v.setAttribute("playsinline", "");
+          v.onloadedmetadata = () => {
+            v.play().catch(() => {});
+          };
+        }
+      } catch {
+        setError("Unable to access camera");
+      }
+    }
+    void startCamera();
+    return () => {
+      if (stream) {
+        for (const t of stream.getTracks()) t.stop();
+      }
+    };
+  }, []);
+
+  async function takePicture() {
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+    if (!video || !canvas) return;
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    canvas.toBlob(async (blob) => {
+      if (!blob) return;
+      const file = new File([blob], "photo.jpg", { type: "image/jpeg" });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      setUploading(true);
+      await uploadCase(dt.files);
+      setUploading(false);
+      onClose();
+    }, "image/jpeg");
+  }
+
+  return (
+    <div className="bg-blue-600 text-white px-2 py-1 rounded mx-1 text-xs space-y-1 w-48">
+      <video ref={videoRef} className="w-full h-32 bg-black rounded">
+        <track kind="captions" label="" />
+      </video>
+      <canvas ref={canvasRef} className="hidden" />
+      {error && <div className="text-red-200 text-center">{error}</div>}
+      <div className="flex gap-1 justify-center">
+        <button
+          type="button"
+          onClick={takePicture}
+          disabled={uploading}
+          className="bg-blue-800 text-white px-1 rounded disabled:opacity-50"
+        >
+          {uploading ? "Uploading..." : "Take Case Photo"}
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="bg-gray-200 text-black px-1 rounded"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/cases/__tests__/caseChatTakePhoto.test.tsx
+++ b/src/app/cases/__tests__/caseChatTakePhoto.test.tsx
@@ -1,0 +1,39 @@
+import CaseChat from "@/app/cases/[id]/CaseChat";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+const caseData = { photos: [] };
+
+describe("CaseChat take photo action", () => {
+  it("renders inline camera widget", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => caseData })),
+    );
+    (
+      navigator as unknown as {
+        mediaDevices: { getUserMedia: () => Promise<unknown> };
+      }
+    ).mediaDevices = {
+      getUserMedia: vi.fn(async () => ({ getTracks: () => [] })),
+    };
+    Object.defineProperty(HTMLMediaElement.prototype, "srcObject", {
+      writable: true,
+      value: null,
+    });
+    const { getByText, getByPlaceholderText, findByText } = render(
+      <CaseChat caseId="1" onChat={async () => "[action:take-photo]"} />,
+    );
+    fireEvent.click(getByText("Chat"));
+    const input = getByPlaceholderText("Ask a question...");
+    fireEvent.change(input, { target: { value: "hi" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+    const actionBtn = await findByText("Take Photo");
+    fireEvent.click(actionBtn);
+    expect(await findByText("Take Case Photo")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- implement `TakePhotoWidget` for capturing photos directly in CaseChat
- trigger the widget via the `take-photo` chat action
- document updated behaviour for `[action:take-photo]`
- test chat camera widget rendering

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aeee1df7c832b958c9d7851798a7d