### PR TITLE
Fix case chat actions for notes

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -3,8 +3,8 @@ import { apiFetch } from "@/apiClient";
 import DebugWrapper from "@/app/components/DebugWrapper";
 import ThumbnailImage from "@/components/thumbnail-image";
 import { caseActions } from "@/lib/caseActions";
-import type { EmailDraft } from "@/lib/caseReport";
 import type { CaseChatAction, CaseChatReply } from "@/lib/caseChat";
+import type { EmailDraft } from "@/lib/caseReport";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import type { ReportModule } from "@/lib/reportModules";
 import { useRouter } from "next/navigation";
@@ -144,6 +144,8 @@ export default function CaseChat({
         const result = await onChat([]);
         if (typeof result === "string") {
           reply = result;
+        } else if ("response" in result) {
+          reply = result;
         } else {
           reply = result.reply;
           if (result.system) setSystemPrompt(result.system);
@@ -156,7 +158,10 @@ export default function CaseChat({
           signal: controller.signal,
         });
         if (res.ok) {
-          const data = (await res.json()) as { reply: CaseChatReply; system: string };
+          const data = (await res.json()) as {
+            reply: CaseChatReply;
+            system: string;
+          };
           reply = data.reply;
           setSystemPrompt(data.system);
         }
@@ -370,6 +375,8 @@ export default function CaseChat({
         const result = await onChat(list);
         if (typeof result === "string") {
           reply = result;
+        } else if ("response" in result) {
+          reply = result;
         } else {
           reply = result.reply;
           if (result.system) setSystemPrompt(result.system);
@@ -382,7 +389,10 @@ export default function CaseChat({
           signal: controller.signal,
         });
         if (res.ok) {
-          const data = (await res.json()) as { reply: CaseChatReply; system: string };
+          const data = (await res.json()) as {
+            reply: CaseChatReply;
+            system: string;
+          };
           reply = data.reply;
           setSystemPrompt(data.system);
         }


### PR DESCRIPTION
## Summary
- allow CaseChat to accept unwrapped replies when handling seed and chat requests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685afb670f8c832bbbc4cee338560ea9