### PR TITLE
Fix case chat scroll button visibility

### DIFF
--- a/src/app/cases/__tests__/caseChatCurrent.test.tsx
+++ b/src/app/cases/__tests__/caseChatCurrent.test.tsx
@@ -17,7 +17,9 @@ describe("CaseChat current session", () => {
       render(
         <CaseChat
           caseId="1"
-          onChat={async () => ({ response: "ok", actions: [], noop: false })}
+          onChat={async () => ({
+            reply: { response: "ok", actions: [], noop: false },
+          })}
         />,
       );
     fireEvent.click(getByText("Chat"));

--- a/src/app/cases/__tests__/caseChatHistory.test.tsx
+++ b/src/app/cases/__tests__/caseChatHistory.test.tsx
@@ -18,7 +18,9 @@ describe("CaseChat history", () => {
       render(
         <CaseChat
           caseId="1"
-          onChat={async () => ({ response: "ok", actions: [], noop: false })}
+          onChat={async () => ({
+            reply: { response: "ok", actions: [], noop: false },
+          })}
         />,
       );
     fireEvent.click(getByText("Chat"));

--- a/src/app/cases/__tests__/caseChatPhotoNote.test.tsx
+++ b/src/app/cases/__tests__/caseChatPhotoNote.test.tsx
@@ -21,9 +21,11 @@ describe("CaseChat photo note action", () => {
       <CaseChat
         caseId="1"
         onChat={async () => ({
-          response: "here",
-          actions: [{ photo: "a.jpg", note: "test" }],
-          noop: false,
+          reply: {
+            response: "here",
+            actions: [{ photo: "a.jpg", note: "test" }],
+            noop: false,
+          },
         })}
       />,
     );

--- a/src/app/cases/__tests__/caseChatScrollButton.test.tsx
+++ b/src/app/cases/__tests__/caseChatScrollButton.test.tsx
@@ -12,15 +12,25 @@ vi.stubGlobal(
 );
 
 describe("CaseChat scroll button", () => {
-  it("shows button when input focused", () => {
-    const { getByText, getByPlaceholderText, queryByText } = render(
+  it("shows button when scrolled away from bottom", () => {
+    const { getByText, queryByText, container } = render(
       <CaseChat caseId="1" />,
     );
     fireEvent.click(getByText("Chat"));
-    const input = getByPlaceholderText("Ask a question...");
-    fireEvent.focus(input);
+    const scroll = container.querySelector(".overflow-y-auto") as HTMLElement;
+    Object.defineProperty(scroll, "scrollHeight", {
+      value: 200,
+      configurable: true,
+    });
+    Object.defineProperty(scroll, "clientHeight", {
+      value: 100,
+      configurable: true,
+    });
+    scroll.scrollTop = 50;
+    fireEvent.scroll(scroll);
     expect(getByText("Jump to latest")).toBeTruthy();
-    fireEvent.blur(input);
+    scroll.scrollTop = 100;
+    fireEvent.scroll(scroll);
     expect(queryByText("Jump to latest")).toBeNull();
   });
 });

--- a/src/app/cases/__tests__/caseChatTakePhoto.test.tsx
+++ b/src/app/cases/__tests__/caseChatTakePhoto.test.tsx
@@ -26,7 +26,16 @@ describe("CaseChat take photo action", () => {
       value: null,
     });
     const { getByText, getByPlaceholderText, findByText } = render(
-      <CaseChat caseId="1" onChat={async () => "[action:take-photo]"} />,
+      <CaseChat
+        caseId="1"
+        onChat={async () => ({
+          reply: {
+            response: "",
+            actions: [{ id: "take-photo" }],
+            noop: false,
+          },
+        })}
+      />,
     );
     fireEvent.click(getByText("Chat"));
     const input = getByPlaceholderText("Ask a question...");


### PR DESCRIPTION
## Summary
- show "Jump to latest" button only when chat is scrolled up
- adapt API response handling for CaseChatReply
- update chat tests for new reply shape and scroll button logic

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b060343a0832ba0956c1e59e031ff