### PR TITLE
Handle LLM server failures in Case Chat

### DIFF
--- a/src/app/cases/[id]/CaseChat.module.css
+++ b/src/app/cases/[id]/CaseChat.module.css
@@ -42,6 +42,20 @@
   border-color: transparent rgb(229, 231, 235) transparent transparent;
 }
 
+.error {
+  background-color: rgb(220, 38, 38); /* red-600 */
+  color: white;
+}
+.error::after {
+  content: "";
+  position: absolute;
+  bottom: 0.25rem;
+  left: -0.25rem;
+  border-width: 0.4rem 0.4rem 0.4rem 0;
+  border-style: solid;
+  border-color: transparent rgb(220, 38, 38) transparent transparent;
+}
+
 @media (prefers-color-scheme: dark) {
   .assistant {
     background-color: rgb(55, 65, 81); /* gray-700 */


### PR DESCRIPTION
## Summary
- surface Case Chat LLM failures
- return error codes from the chat API
- style chat error bubbles

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b059ed5a0832b9d008369173297f3