### PR TITLE
Fix jump to latest button visibility

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -456,7 +456,7 @@ export default function CaseChat({
     }
   }, [messages]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: update on open or messages
+  // biome-ignore lint/correctness/useExhaustiveDependencies: update on open, messages, or size changes
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -467,10 +467,15 @@ export default function CaseChat({
     }
     update();
     el.addEventListener("scroll", update);
+    window.addEventListener("resize", update);
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
     return () => {
       el.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+      observer.disconnect();
     };
-  }, [open, messages]);
+  }, [open, messages, expanded]);
 
   useEffect(() => {
     if (open && inputRef.current) inputRef.current.focus();

--- a/src/app/cases/__tests__/caseChatScrollButton.test.tsx
+++ b/src/app/cases/__tests__/caseChatScrollButton.test.tsx
@@ -33,4 +33,29 @@ describe("CaseChat scroll button", () => {
     fireEvent.scroll(scroll);
     expect(queryByText("Jump to latest")).toBeNull();
   });
+
+  it("updates button visibility when container resizes", () => {
+    const { getByText, queryByText, container } = render(
+      <CaseChat caseId="1" />,
+    );
+    fireEvent.click(getByText("Chat"));
+    const scroll = container.querySelector(".overflow-y-auto") as HTMLElement;
+    Object.defineProperty(scroll, "scrollHeight", {
+      value: 200,
+      configurable: true,
+    });
+    Object.defineProperty(scroll, "clientHeight", {
+      value: 100,
+      configurable: true,
+    });
+    scroll.scrollTop = 50;
+    fireEvent.scroll(scroll);
+    expect(getByText("Jump to latest")).toBeTruthy();
+    Object.defineProperty(scroll, "clientHeight", {
+      value: 200,
+      configurable: true,
+    });
+    fireEvent(window, new Event("resize"));
+    expect(queryByText("Jump to latest")).toBeNull();
+  });
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -2,6 +2,20 @@ import "@testing-library/jest-dom";
 import React, { type ImgHTMLAttributes } from "react";
 import { type TestContext, afterEach, beforeEach, vi } from "vitest";
 
+if (typeof window !== "undefined" && !("ResizeObserver" in window)) {
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  (
+    window as unknown as { ResizeObserver: typeof ResizeObserver }
+  ).ResizeObserver = ResizeObserver;
+  (
+    globalThis as unknown as { ResizeObserver: typeof ResizeObserver }
+  ).ResizeObserver = ResizeObserver;
+}
+
 // Ensure stable auth configuration during tests
 process.env.NEXTAUTH_SECRET = "test-secret";
 process.env.VITEST = "1";


### PR DESCRIPTION
## Summary
- observe CaseChat scroll area resizing to show/hide the jump button
- test button visibility on resize
- polyfill `ResizeObserver` for tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b0d63b4cc832b94749b5f9f7cc9f9