### PR TITLE
Refactor large case page

### DIFF
--- a/src/app/cases/[id]/components/CaseExtraInfo.tsx
+++ b/src/app/cases/[id]/components/CaseExtraInfo.tsx
@@ -1,0 +1,109 @@
+"use client";
+import DebugWrapper from "@/app/components/DebugWrapper";
+import ThumbnailImage from "@/components/thumbnail-image";
+import type { Case } from "@/lib/caseStore";
+import { getThumbnailUrl } from "@/lib/clientThumbnails";
+import { baseName, buildThreads } from "../utils";
+
+export default function CaseExtraInfo({
+  caseId,
+  caseData,
+  selectedPhoto,
+  setSelectedPhoto,
+}: {
+  caseId: string;
+  caseData: Case;
+  selectedPhoto: string | null;
+  setSelectedPhoto: (photo: string) => void;
+}) {
+  const analysisImages = caseData.analysis?.images ?? {};
+  const paperworkScans = (caseData.threadImages ?? []).map((img) => ({
+    url: img.url,
+    time: img.uploadedAt,
+  }));
+  const paperworkPhotos = caseData.photos.filter(
+    (p) => analysisImages[baseName(p)]?.paperwork,
+  );
+  const allPaperwork = [
+    ...paperworkPhotos.map((p) => ({ url: p, time: caseData.photoTimes[p] })),
+    ...paperworkScans,
+  ];
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {caseData.sentEmails && caseData.sentEmails.length > 0 ? (
+        <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded flex flex-col gap-2">
+          <h2 className="font-semibold">Email Log</h2>
+          <ul className="flex flex-col gap-2 text-sm">
+            {buildThreads(caseData).map((mail) => (
+              <li
+                key={mail.sentAt}
+                id={`email-${mail.sentAt}`}
+                className="flex flex-col gap-1"
+              >
+                <span>
+                  {new Date(mail.sentAt).toLocaleString()} - {mail.subject}
+                </span>
+                <span className="text-gray-500 dark:text-gray-400">
+                  To: {mail.to}
+                </span>
+                <span className="text-gray-500 dark:text-gray-400 whitespace-pre-wrap">
+                  {mail.body}
+                </span>
+                <a
+                  href={`/cases/${caseId}/thread/${encodeURIComponent(mail.sentAt)}`}
+                  className="self-start text-blue-500 underline"
+                >
+                  View Thread
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {allPaperwork.length > 0 ? (
+        <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded flex flex-col gap-2">
+          <h2 className="font-semibold">Paperwork</h2>
+          <div className="flex gap-2 flex-wrap">
+            {allPaperwork.map(({ url, time }) => {
+              const info = {
+                url,
+                time,
+                analysis: analysisImages[baseName(url)] ?? null,
+              };
+              return (
+                <DebugWrapper key={url} data={info}>
+                  <div className="relative">
+                    <button
+                      type="button"
+                      onClick={() => setSelectedPhoto(url)}
+                      className={
+                        selectedPhoto === url
+                          ? "ring-2 ring-blue-500"
+                          : "ring-1 ring-transparent"
+                      }
+                    >
+                      <div className="relative w-20 aspect-[4/3]">
+                        <ThumbnailImage
+                          src={getThumbnailUrl(url, 128)}
+                          alt="paperwork"
+                          width={80}
+                          height={60}
+                          imgClassName="object-contain"
+                        />
+                      </div>
+                      {time ? (
+                        <span className="absolute bottom-1 left-1 bg-black/60 text-white text-xs rounded px-1">
+                          {new Date(time).toLocaleDateString()}
+                        </span>
+                      ) : null}
+                    </button>
+                  </div>
+                </DebugWrapper>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/cases/[id]/components/CaseHeader.tsx
+++ b/src/app/cases/[id]/components/CaseHeader.tsx
@@ -1,0 +1,64 @@
+"use client";
+import CaseToolbar from "@/app/components/CaseToolbar";
+import type { Case } from "@/lib/caseStore";
+import type { LlmProgress } from "@/lib/openai";
+import Link from "next/link";
+import { FaShare } from "react-icons/fa";
+
+export default function CaseHeader({
+  caseId,
+  caseData,
+  ownerContact,
+  isAdmin,
+  readOnly = false,
+  violationIdentified,
+  progress,
+  isPhotoReanalysis,
+  copyPublicUrl,
+  copied,
+}: {
+  caseId: string;
+  caseData: Case;
+  ownerContact?: string | null;
+  isAdmin: boolean;
+  readOnly?: boolean;
+  violationIdentified: boolean;
+  progress: LlmProgress | null;
+  isPhotoReanalysis: boolean;
+  copyPublicUrl: () => Promise<void>;
+  copied: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <Link href="/cases" className="text-blue-500 underline md:hidden">
+          Back to Cases
+        </Link>
+        <h1 className="text-xl font-semibold">Case {caseData.id}</h1>
+        {caseData.public ? (
+          <button
+            type="button"
+            onClick={copyPublicUrl}
+            aria-label="Copy public link"
+            className="text-blue-500 hover:text-blue-700"
+          >
+            <FaShare />
+          </button>
+        ) : null}
+        {copied ? (
+          <span className="text-sm text-green-600">Copied!</span>
+        ) : null}
+      </div>
+      <CaseToolbar
+        caseId={caseId}
+        disabled={!violationIdentified}
+        hasOwner={Boolean(ownerContact)}
+        progress={isPhotoReanalysis ? null : progress}
+        canDelete={isAdmin}
+        closed={caseData.closed}
+        archived={caseData.archived}
+        readOnly={readOnly}
+      />
+    </div>
+  );
+}

--- a/src/app/cases/[id]/components/ClaimBanner.tsx
+++ b/src/app/cases/[id]/components/ClaimBanner.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { signIn } from "@/app/useSession";
+import { withBasePath } from "@/basePath";
+
+export default function ClaimBanner({
+  show,
+  onDismiss,
+  className,
+}: {
+  show: boolean;
+  onDismiss: () => void;
+  className?: string;
+}) {
+  if (!show) return null;
+  return (
+    <div
+      className={`bg-yellow-100 border border-yellow-300 text-yellow-800 p-2 flex items-center justify-between ${className ?? ""}`}
+    >
+      <span>
+        Sign in to claim this case or it will be lost when the session ends.
+      </span>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() =>
+            signIn(undefined, { callbackUrl: withBasePath("/claim") })
+          }
+          className="underline"
+        >
+          Sign In
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss"
+          className="text-xl leading-none"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/cases/[id]/components/PhotoGallery.tsx
+++ b/src/app/cases/[id]/components/PhotoGallery.tsx
@@ -1,0 +1,111 @@
+"use client";
+import AddImageMenu from "@/app/components/AddImageMenu";
+import DebugWrapper from "@/app/components/DebugWrapper";
+import ThumbnailImage from "@/components/thumbnail-image";
+import { Progress } from "@/components/ui/progress";
+import type { Case } from "@/lib/caseStore";
+import { getThumbnailUrl } from "@/lib/clientThumbnails";
+import { baseName } from "../utils";
+
+export default function PhotoGallery({
+  caseId,
+  caseData,
+  selectedPhoto,
+  setSelectedPhoto,
+  handleUpload,
+  fileInputRef,
+  hasCamera,
+  removePhoto,
+  readOnly,
+  isPhotoReanalysis,
+  reanalyzingPhoto,
+  requestValue,
+}: {
+  caseId: string;
+  caseData: Case;
+  selectedPhoto: string | null;
+  setSelectedPhoto: (photo: string) => void;
+  handleUpload: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
+  fileInputRef: React.RefObject<HTMLInputElement> | null;
+  hasCamera: boolean;
+  removePhoto: (photo: string) => Promise<void>;
+  readOnly: boolean;
+  isPhotoReanalysis: boolean;
+  reanalyzingPhoto: string | null;
+  requestValue: number | undefined;
+}) {
+  const analysisImages = caseData.analysis?.images ?? {};
+  const evidencePhotos = caseData.photos.filter(
+    (p) => !analysisImages[baseName(p)]?.paperwork,
+  );
+  return (
+    <div className="flex gap-2 flex-wrap">
+      {evidencePhotos.map((p) => {
+        const info = {
+          url: p,
+          takenAt: caseData.photoTimes[p] ?? null,
+          gps: caseData.photoGps?.[p] ?? null,
+          analysis: analysisImages[baseName(p)] ?? null,
+        };
+        return (
+          <DebugWrapper key={p} data={info}>
+            <div className="relative group">
+              <button
+                type="button"
+                onClick={() => setSelectedPhoto(p)}
+                className={
+                  selectedPhoto === p
+                    ? "ring-2 ring-blue-500"
+                    : "ring-1 ring-transparent"
+                }
+              >
+                <div className="relative w-20 aspect-[4/3]">
+                  <ThumbnailImage
+                    src={getThumbnailUrl(p, 128)}
+                    alt="case photo"
+                    width={80}
+                    height={60}
+                    imgClassName="object-contain"
+                  />
+                  {isPhotoReanalysis && reanalyzingPhoto === p ? (
+                    <div className="absolute top-0 left-0 right-0">
+                      <Progress
+                        value={requestValue}
+                        indeterminate={requestValue === undefined}
+                      />
+                    </div>
+                  ) : null}
+                </div>
+                {(() => {
+                  const t = caseData.photoTimes[p];
+                  return t ? (
+                    <span className="absolute bottom-1 left-1 bg-black/60 text-white text-xs rounded px-1">
+                      {new Date(t).toLocaleDateString()}
+                    </span>
+                  ) : null;
+                })()}
+              </button>
+              {readOnly ? null : (
+                <button
+                  type="button"
+                  onClick={() => removePhoto(p)}
+                  className="absolute -top-1 -right-1 bg-red-600 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs opacity-0 group-hover:opacity-100 transition-opacity"
+                >
+                  ×
+                </button>
+              )}
+            </div>
+          </DebugWrapper>
+        );
+      })}
+      {readOnly ? null : (
+        <AddImageMenu
+          caseId={caseId}
+          hasCamera={hasCamera}
+          fileInputRef={fileInputRef}
+          onChange={handleUpload}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/cases/[id]/components/PhotoViewer.stories.tsx
+++ b/src/app/cases/[id]/components/PhotoViewer.stories.tsx
@@ -1,0 +1,42 @@
+import type { Case } from "@/lib/caseStore";
+import type { Meta, StoryObj } from "@storybook/react";
+import PhotoViewer from "./PhotoViewer";
+
+const meta: Meta<typeof PhotoViewer> = {
+  component: PhotoViewer,
+  title: "Components/PhotoViewer",
+};
+export default meta;
+
+type Story = StoryObj<typeof PhotoViewer>;
+
+const base: Case = {
+  id: "1",
+  photos: ["https://placehold.co/600x400"],
+  photoTimes: {},
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  analysis: null,
+  analysisStatus: "pending",
+  public: false,
+};
+
+export const Default: Story = {
+  render: () => (
+    <PhotoViewer
+      caseData={base}
+      selectedPhoto={base.photos[0]}
+      progress={null}
+      progressDescription="Analyzing..."
+      requestValue={50}
+      isPhotoReanalysis={false}
+      reanalyzingPhoto={null}
+      analysisActive={false}
+      readOnly={false}
+      photoNote=""
+      updatePhotoNote={async () => {}}
+      removePhoto={async () => {}}
+      reanalyzePhoto={async () => {}}
+    />
+  ),
+};

--- a/src/app/cases/[id]/components/PhotoViewer.tsx
+++ b/src/app/cases/[id]/components/PhotoViewer.tsx
@@ -1,0 +1,144 @@
+"use client";
+import EditableText from "@/app/components/EditableText";
+import ImageHighlights from "@/app/components/ImageHighlights";
+import useCloseOnOutsideClick from "@/app/useCloseOnOutsideClick";
+import { Progress } from "@/components/ui/progress";
+import type { Case } from "@/lib/caseStore";
+import type { LlmProgress } from "@/lib/openai";
+import Image from "next/image";
+import { useRef } from "react";
+
+export default function PhotoViewer({
+  caseData,
+  selectedPhoto,
+  progress,
+  progressDescription,
+  requestValue,
+  isPhotoReanalysis,
+  reanalyzingPhoto,
+  analysisActive,
+  readOnly,
+  photoNote,
+  updatePhotoNote,
+  removePhoto,
+  reanalyzePhoto,
+}: {
+  caseData: Case;
+  selectedPhoto: string;
+  progress: LlmProgress | null;
+  progressDescription: string;
+  requestValue: number | undefined;
+  isPhotoReanalysis: boolean;
+  reanalyzingPhoto: string | null;
+  analysisActive: boolean;
+  readOnly: boolean;
+  photoNote: string;
+  updatePhotoNote: (value: string) => Promise<void>;
+  removePhoto: (photo: string) => Promise<void>;
+  reanalyzePhoto: (
+    photo: string,
+    detailsEl?: HTMLDetailsElement | null,
+  ) => Promise<void>;
+}) {
+  const photoMenuRef = useRef<HTMLDetailsElement>(null);
+  useCloseOnOutsideClick(photoMenuRef);
+  const t = caseData.photoTimes[selectedPhoto];
+  return (
+    <>
+      <div className="relative w-full aspect-[3/2] md:max-w-2xl shrink-0">
+        <Image
+          src={selectedPhoto}
+          alt="uploaded"
+          fill
+          className="object-contain"
+        />
+        {isPhotoReanalysis && reanalyzingPhoto === selectedPhoto ? (
+          <div className="absolute top-0 left-0 right-0">
+            <Progress
+              value={requestValue}
+              indeterminate={requestValue === undefined}
+            />
+          </div>
+        ) : null}
+        {readOnly ? null : (
+          <details
+            ref={photoMenuRef}
+            className="absolute top-1 right-1 text-white"
+            onToggle={() => {
+              if (photoMenuRef.current?.open) {
+                photoMenuRef.current
+                  .querySelector<HTMLElement>("button, a")
+                  ?.focus();
+              }
+            }}
+          >
+            <summary
+              className="cursor-pointer select-none bg-black/40 rounded px-1 opacity-70"
+              aria-label="Photo actions menu"
+            >
+              ⋮
+            </summary>
+            <div
+              className="absolute right-0 mt-1 bg-white dark:bg-gray-900 border rounded shadow text-black dark:text-white"
+              role="menu"
+            >
+              <button
+                type="button"
+                onClick={(e) =>
+                  reanalyzePhoto(
+                    selectedPhoto,
+                    e.currentTarget.closest("details"),
+                  )
+                }
+                className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+                disabled={
+                  caseData.analysisStatus === "pending" && analysisActive
+                }
+              >
+                Reanalyze Photo
+              </button>
+              <button
+                type="button"
+                onClick={() => removePhoto(selectedPhoto)}
+                className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+              >
+                Delete Image
+              </button>
+            </div>
+          </details>
+        )}
+        {caseData.analysis ? (
+          <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white p-2 space-y-1 text-sm">
+            <ImageHighlights
+              analysis={caseData.analysis}
+              photo={selectedPhoto}
+            />
+            {progress ? <p>{progressDescription}</p> : null}
+          </div>
+        ) : (
+          <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white p-2 text-sm">
+            {progressDescription}
+          </div>
+        )}
+      </div>
+      {t ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Taken {new Date(t).toLocaleString()}
+        </p>
+      ) : null}
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        <span className="font-semibold">Note:</span>{" "}
+        {readOnly ? (
+          <span>{photoNote || ""}</span>
+        ) : (
+          <EditableText
+            value={photoNote}
+            onSubmit={updatePhotoNote}
+            onClear={photoNote ? () => updatePhotoNote("") : undefined}
+            placeholder="Add note"
+          />
+        )}
+      </p>
+    </>
+  );
+}

--- a/src/app/cases/[id]/utils.ts
+++ b/src/app/cases/[id]/utils.ts
@@ -1,0 +1,26 @@
+import type { Case, SentEmail } from "@/lib/caseStore";
+
+export function buildThreads(c: Case): SentEmail[] {
+  const mails = c.sentEmails ?? [];
+  const threads = new Map<string, SentEmail>();
+  for (const mail of mails) {
+    let root = mail;
+    while (root.replyTo) {
+      const parent = mails.find((m) => m.sentAt === root.replyTo);
+      if (!parent) break;
+      root = parent;
+    }
+    const current = threads.get(root.sentAt);
+    if (!current || new Date(mail.sentAt) > new Date(current.sentAt)) {
+      threads.set(root.sentAt, mail);
+    }
+  }
+  return Array.from(threads.values()).sort(
+    (a, b) => new Date(a.sentAt).getTime() - new Date(b.sentAt).getTime(),
+  );
+}
+
+export function baseName(filePath: string): string {
+  const parts = filePath.split(/[\\/]/);
+  return parts[parts.length - 1];
+}

--- a/src/app/cases/__tests__/claimBanner.test.tsx
+++ b/src/app/cases/__tests__/claimBanner.test.tsx
@@ -1,0 +1,17 @@
+import ClaimBanner from "@/app/cases/[id]/components/ClaimBanner";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+describe("ClaimBanner", () => {
+  it("renders when show is true", () => {
+    const { getByText } = render(<ClaimBanner show onDismiss={() => {}} />);
+    expect(getByText(/claim this case/i)).toBeTruthy();
+  });
+
+  it("renders nothing when show is false", () => {
+    const { container } = render(
+      <ClaimBanner show={false} onDismiss={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/test/e2e/claimBanner.test.ts
+++ b/test/e2e/claimBanner.test.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getByText } from "@testing-library/dom";
+import { JSDOM } from "jsdom";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createApi } from "./api";
+import { createPhoto } from "./photo";
+import { type TestServer, startServer } from "./startServer";
+
+let server: TestServer;
+let api: (path: string, opts?: RequestInit) => Promise<Response>;
+let dataDir: string;
+
+beforeAll(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
+  server = await startServer(3035, {
+    CASE_STORE_FILE: path.join(dataDir, "cases.sqlite"),
+    NEXTAUTH_SECRET: "secret",
+    NODE_ENV: "test",
+  });
+  api = createApi(server);
+});
+
+afterAll(async () => {
+  await server.close();
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("claim banner", () => {
+  it("shows banner for anonymous case", async () => {
+    const file = createPhoto("a");
+    const form = new FormData();
+    form.append("photo", file);
+    const res = await api("/api/upload", { method: "POST", body: form });
+    const { caseId } = (await res.json()) as { caseId: string };
+    const page = await api(`/cases/${caseId}`).then((r) => r.text());
+    const dom = new JSDOM(page);
+    const banner = getByText(dom.window.document, /claim this case/i);
+    expect(banner).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- break `ClientCasePage` into smaller components
- add context-friendly `CaseHeader`, `ClaimBanner`, `PhotoViewer`, `PhotoGallery`, and `CaseExtraInfo`
- cover `ClaimBanner` with unit tests and new e2e test
- document `PhotoViewer` via Storybook story

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_e_685b0ede8384832ba66f1460ec552218