### PR TITLE
fix: clarify case chat prompt edit actions

### DIFF
--- a/docs/case-chat-actions.md
+++ b/docs/case-chat-actions.md
@@ -18,7 +18,8 @@ Example:
 The chat UI renders the `response` as text and creates a button for each entry in `actions`:
 
 - `id` &mdash; opens the corresponding page from `caseActions`.
-- `field` and `value` &mdash; apply an edit to the case.
+- `field` and `value` &mdash; apply an edit to the case. Supported fields:
+  `vin`, `plate`, `state`, and `note`.
 - `photo` and `note` &mdash; append a note to a photo.
 
 The LLM receives a list of available actions formatted like:

--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -70,6 +70,9 @@ export const POST = withCaseAuthorization(
       "When there is no user question yet, decide if you should proactively suggest a next action or useful observation.",
       "If you have nothing helpful, set response to [noop].",
       `Reply in JSON matching this schema: ${schemaDesc}`,
+      "Use {id: ID} objects for case actions.",
+      "Use {field: FIELD, value: VALUE} to edit the case (fields: vin, plate, state, note).",
+      "Use {photo: FILENAME, note: NOTE} to append a note to a photo.",
       available.length > 0 ? `Available actions:\n${actionList}` : "",
     ]
       .filter(Boolean)


### PR DESCRIPTION
## Summary
- document supported CaseChat edit fields
- instruct the LLM how to use edit and photo note actions in CaseChat

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685b1200648c832ba7bd56a825bba36d