### PR TITLE
Persist chat tab state

### DIFF
--- a/src/app/cases/__tests__/caseChatScrollButton.test.tsx
+++ b/src/app/cases/__tests__/caseChatScrollButton.test.tsx
@@ -12,6 +12,9 @@ vi.stubGlobal(
 );
 
 describe("CaseChat scroll button", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
   it("shows button when scrolled away from bottom", () => {
     const { getByText, queryByText, container } = render(
       <CaseChat caseId="1" />,


### PR DESCRIPTION
## Summary
- keep case chat state in `sessionStorage`
- restore chat session when navigating within a case
- clear sessionStorage between CaseChat tests

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685b47495274832b82fcc78998c842ec