### PR TITLE
Persist case chat session state

### DIFF
--- a/src/app/cases/__tests__/caseChatScrollButton.test.tsx
+++ b/src/app/cases/__tests__/caseChatScrollButton.test.tsx
@@ -12,6 +12,9 @@ vi.stubGlobal(
 );
 
 describe("CaseChat scroll button", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
   it("shows button when scrolled away from bottom", () => {
     const { getByText, queryByText, container } = render(
       <CaseChat caseId="1" />,


### PR DESCRIPTION
## Summary
- remember case chat open status and session using localStorage
- keep chat tab open across navigation within the same case
- clear stored state in scroll button tests

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685b47495274832b82fcc78998c842ec