### PR TITLE
Add case page subcomponents

### DIFF
--- a/src/app/cases/[id]/components/AnalysisStatus.tsx
+++ b/src/app/cases/[id]/components/AnalysisStatus.tsx
@@ -1,0 +1,119 @@
+"use client";
+import AnalysisInfo from "@/app/components/AnalysisInfo";
+import type { Case } from "@/lib/caseStore";
+import type { LlmProgress } from "@/lib/openai";
+
+export default function AnalysisStatus({
+  caseData,
+  progress,
+  readOnly,
+  plateNumberOverridden,
+  plateStateOverridden,
+  updatePlateNumber,
+  updatePlateState,
+  clearPlateNumber,
+  clearPlateState,
+  retryAnalysis,
+}: {
+  caseData: Case;
+  progress: LlmProgress | null;
+  readOnly: boolean;
+  plateNumberOverridden: boolean;
+  plateStateOverridden: boolean;
+  updatePlateNumber: (v: string) => Promise<void>;
+  updatePlateState: (v: string) => Promise<void>;
+  clearPlateNumber: () => Promise<void>;
+  clearPlateState: () => Promise<void>;
+  retryAnalysis: () => Promise<void>;
+}) {
+  const progressDescription = progress
+    ? `${progress.steps ? `Step ${progress.step} of ${progress.steps}: ` : ""}${
+        progress.stage === "upload"
+          ? progress.index > 0
+            ? `Uploading ${progress.index} of ${progress.total} photos (${Math.floor((progress.index / progress.total) * 100)}%)`
+            : "Uploading photos..."
+          : progress.done
+            ? "Processing results..."
+            : `Analyzing... ${progress.received} of ${progress.total} tokens`
+      }`
+    : caseData.analysisStatus === "pending"
+      ? "Analyzing photo..."
+      : caseData.analysisStatus === "canceled"
+        ? "Analysis canceled."
+        : "Analysis failed.";
+
+  const failureReason = caseData.analysisError
+    ? caseData.analysisError === "truncated"
+      ? "Analysis failed because the AI response was cut off."
+      : caseData.analysisError === "parse"
+        ? "Analysis failed due to invalid JSON from the AI."
+        : caseData.analysisError === "images"
+          ? "Analysis failed because no images were provided or some photo files were missing."
+          : "Analysis failed because the AI response did not match the expected format."
+    : caseData.analysisStatusCode && caseData.analysisStatusCode >= 400
+      ? "Analysis failed. Please try again later."
+      : "Analysis failed.";
+
+  if (caseData.analysis) {
+    return (
+      <AnalysisInfo
+        analysis={caseData.analysis}
+        onPlateChange={readOnly ? undefined : updatePlateNumber}
+        onStateChange={readOnly ? undefined : updatePlateState}
+        onClearPlate={
+          readOnly
+            ? undefined
+            : plateNumberOverridden
+              ? clearPlateNumber
+              : undefined
+        }
+        onClearState={
+          readOnly
+            ? undefined
+            : plateStateOverridden
+              ? clearPlateState
+              : undefined
+        }
+      />
+    );
+  }
+
+  if (caseData.analysisStatus === "canceled") {
+    return <p className="text-sm text-red-600">Analysis canceled.</p>;
+  }
+
+  if (caseData.analysisStatus === "pending" && progress) {
+    return (
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        {progressDescription}
+      </p>
+    );
+  }
+
+  return (
+    <div className="text-sm text-red-600 flex flex-col gap-1">
+      <p>{failureReason}</p>
+      {readOnly ? null : (
+        <button
+          type="button"
+          onClick={retryAnalysis}
+          className="underline w-fit"
+        >
+          Retry
+        </button>
+      )}
+      <details>
+        <summary className="cursor-pointer underline">More info</summary>
+        <p className="mt-1">
+          Last attempt: {new Date(caseData.updatedAt).toLocaleString()}
+        </p>
+        <p className="mt-1">Possible causes:</p>
+        <ul className="list-disc ml-4">
+          <li>Missing photo files</li>
+          <li>Invalid JSON response</li>
+          <li>Server error</li>
+        </ul>
+      </details>
+    </div>
+  );
+}

--- a/src/app/cases/[id]/components/CaseDetails.tsx
+++ b/src/app/cases/[id]/components/CaseDetails.tsx
@@ -1,0 +1,182 @@
+"use client";
+import EditableText from "@/app/components/EditableText";
+import MapPreview from "@/app/components/MapPreview";
+import type { Case } from "@/lib/caseStore";
+import { getOfficialCaseGps } from "@/lib/caseUtils";
+import type { LlmProgress } from "@/lib/openai";
+import AnalysisStatus from "./AnalysisStatus";
+import MemberList, { type Member } from "./MemberList";
+
+export default function CaseDetails({
+  caseData,
+  progress,
+  readOnly,
+  ownerContact,
+  vin,
+  vinOverridden,
+  note,
+  plateNumberOverridden,
+  plateStateOverridden,
+  updateVin,
+  clearVin,
+  updateNote,
+  updatePlateNumber,
+  updatePlateState,
+  clearPlateNumber,
+  clearPlateState,
+  retryAnalysis,
+  canTogglePublic,
+  canToggleStatus,
+  togglePublic,
+  toggleClosed,
+  toggleArchived,
+  members,
+  canManageMembers,
+  inviteMember,
+  removeMember,
+}: {
+  caseData: Case;
+  progress: LlmProgress | null;
+  readOnly: boolean;
+  ownerContact: string | null;
+  vin: string;
+  vinOverridden: boolean;
+  note: string;
+  plateNumberOverridden: boolean;
+  plateStateOverridden: boolean;
+  updateVin: (v: string) => Promise<void>;
+  clearVin: () => Promise<void>;
+  updateNote: (v: string) => Promise<void>;
+  updatePlateNumber: (v: string) => Promise<void>;
+  updatePlateState: (v: string) => Promise<void>;
+  clearPlateNumber: () => Promise<void>;
+  clearPlateState: () => Promise<void>;
+  retryAnalysis: () => Promise<void>;
+  canTogglePublic: boolean;
+  canToggleStatus: boolean;
+  togglePublic: () => Promise<void>;
+  toggleClosed: () => Promise<void>;
+  toggleArchived: () => Promise<void>;
+  members: Member[];
+  canManageMembers: boolean;
+  inviteMember: (userId: string) => Promise<void>;
+  removeMember: (userId: string) => Promise<void>;
+}) {
+  const gps = getOfficialCaseGps(caseData);
+  return (
+    <div className="order-first bg-gray-100 dark:bg-gray-800 p-4 rounded flex flex-col gap-2 text-sm">
+      <AnalysisStatus
+        caseData={caseData}
+        progress={progress}
+        readOnly={readOnly}
+        plateNumberOverridden={plateNumberOverridden}
+        plateStateOverridden={plateStateOverridden}
+        updatePlateNumber={updatePlateNumber}
+        updatePlateState={updatePlateState}
+        clearPlateNumber={clearPlateNumber}
+        clearPlateState={clearPlateState}
+        retryAnalysis={retryAnalysis}
+      />
+      {ownerContact ? (
+        <p>
+          <span className="font-semibold">Owner:</span> {ownerContact}
+        </p>
+      ) : null}
+      <p>
+        <span className="font-semibold">Created:</span>{" "}
+        {new Date(caseData.createdAt).toLocaleString()}
+      </p>
+      <p>
+        <span className="font-semibold">Visibility:</span>{" "}
+        {caseData.public ? "Public" : "Private"}
+        {canTogglePublic ? (
+          <button
+            type="button"
+            onClick={togglePublic}
+            className="ml-2 text-blue-500 underline"
+            data-testid="toggle-public-button"
+          >
+            Make {caseData.public ? "Private" : "Public"}
+          </button>
+        ) : null}
+      </p>
+      <p>
+        <span className="font-semibold">Status:</span>{" "}
+        {caseData.archived ? "Archived" : caseData.closed ? "Closed" : "Open"}
+        {canToggleStatus ? (
+          <>
+            <button
+              type="button"
+              onClick={toggleClosed}
+              className="ml-2 text-blue-500 underline"
+            >
+              Mark {caseData.closed ? "Open" : "Closed"}
+            </button>
+            <button
+              type="button"
+              onClick={toggleArchived}
+              className="ml-2 text-blue-500 underline"
+            >
+              {caseData.archived ? "Unarchive" : "Archive"}
+            </button>
+          </>
+        ) : null}
+      </p>
+      {caseData.streetAddress ? (
+        <p>
+          <span className="font-semibold">Address:</span>{" "}
+          {caseData.streetAddress}
+        </p>
+      ) : null}
+      {caseData.intersection ? (
+        <p>
+          <span className="font-semibold">Intersection:</span>{" "}
+          {caseData.intersection}
+        </p>
+      ) : null}
+      {gps ? (
+        <MapPreview
+          lat={gps.lat}
+          lon={gps.lon}
+          width={600}
+          height={300}
+          className="w-full aspect-[2/1] md:max-w-xl"
+          link={`https://www.google.com/maps?q=${gps.lat},${gps.lon}`}
+        />
+      ) : null}
+      <p>
+        <span className="font-semibold">VIN:</span>{" "}
+        {readOnly ? (
+          <span>{vin || ""}</span>
+        ) : (
+          <EditableText
+            value={vin}
+            onSubmit={updateVin}
+            onClear={vinOverridden ? clearVin : undefined}
+            placeholder="VIN"
+          />
+        )}
+      </p>
+      <p>
+        <span className="font-semibold">Note:</span>{" "}
+        {readOnly ? (
+          <span>{note || ""}</span>
+        ) : (
+          <EditableText
+            value={note}
+            onSubmit={updateNote}
+            onClear={note ? () => updateNote("") : undefined}
+            placeholder="Add note"
+          />
+        )}
+      </p>
+      <MemberList
+        members={members}
+        readOnly={readOnly}
+        canManageMembers={canManageMembers}
+        inviteMember={inviteMember}
+        removeMember={removeMember}
+      />
+    </div>
+  );
+}

--- a/src/app/cases/[id]/components/MemberList.tsx
+++ b/src/app/cases/[id]/components/MemberList.tsx
@@ -1,0 +1,69 @@
+"use client";
+import { useState } from "react";
+
+export type Member = {
+  userId: string;
+  role: string;
+  name: string | null;
+  email: string | null;
+};
+
+export default function MemberList({
+  members,
+  readOnly,
+  canManageMembers,
+  inviteMember,
+  removeMember,
+}: {
+  members: Member[];
+  readOnly: boolean;
+  canManageMembers: boolean;
+  inviteMember: (userId: string) => Promise<void>;
+  removeMember: (userId: string) => Promise<void>;
+}) {
+  const [inviteUserId, setInviteUserId] = useState("");
+  return (
+    <div>
+      <span className="font-semibold">Members:</span>
+      <ul className="ml-2 mt-1 flex flex-col gap-1">
+        {members.map((m) => (
+          <li key={m.userId} className="flex items-center gap-2">
+            <span className="flex-1">
+              {m.name ?? m.email ?? m.userId} ({m.role})
+            </span>
+            {readOnly || !canManageMembers || m.role === "owner" ? null : (
+              <button
+                type="button"
+                onClick={() => removeMember(m.userId)}
+                className="text-red-600"
+              >
+                Remove
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+      {readOnly || !canManageMembers ? null : (
+        <div className="flex gap-2 mt-2">
+          <input
+            type="text"
+            value={inviteUserId}
+            onChange={(e) => setInviteUserId(e.target.value)}
+            placeholder="User ID"
+            className="border rounded p-1 flex-1 bg-white dark:bg-gray-900"
+          />
+          <button
+            type="button"
+            onClick={() => {
+              inviteMember(inviteUserId);
+              setInviteUserId("");
+            }}
+            className="bg-blue-600 text-white px-2 py-1 rounded"
+          >
+            Invite
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/cases/[id]/components/PhotoSection.tsx
+++ b/src/app/cases/[id]/components/PhotoSection.tsx
@@ -1,0 +1,86 @@
+"use client";
+import CaseJobList from "@/app/components/CaseJobList";
+import type { Case } from "@/lib/caseStore";
+import type { LlmProgress } from "@/lib/openai";
+import PhotoGallery from "./PhotoGallery";
+import PhotoViewer from "./PhotoViewer";
+
+export default function PhotoSection({
+  caseId,
+  caseData,
+  selectedPhoto,
+  setSelectedPhoto,
+  handleUpload,
+  fileInputRef,
+  hasCamera,
+  removePhoto,
+  readOnly,
+  isPhotoReanalysis,
+  reanalyzingPhoto,
+  requestValue,
+  progress,
+  progressDescription,
+  analysisActive,
+  photoNote,
+  updatePhotoNote,
+  reanalyzePhoto,
+}: {
+  caseId: string;
+  caseData: Case;
+  selectedPhoto: string | null;
+  setSelectedPhoto: (photo: string) => void;
+  handleUpload: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
+  fileInputRef: React.RefObject<HTMLInputElement> | null;
+  hasCamera: boolean;
+  removePhoto: (photo: string) => Promise<void>;
+  readOnly: boolean;
+  isPhotoReanalysis: boolean;
+  reanalyzingPhoto: string | null;
+  requestValue: number | undefined;
+  progress: LlmProgress | null;
+  progressDescription: string;
+  analysisActive: boolean;
+  photoNote: string;
+  updatePhotoNote: (value: string) => Promise<void>;
+  reanalyzePhoto: (
+    photo: string,
+    detailsEl?: HTMLDetailsElement | null,
+  ) => Promise<void>;
+}) {
+  return (
+    <>
+      <CaseJobList caseId={caseId} isPublic={caseData.public} />
+      {selectedPhoto ? (
+        <PhotoViewer
+          caseData={caseData}
+          selectedPhoto={selectedPhoto}
+          progress={progress}
+          progressDescription={progressDescription}
+          requestValue={requestValue}
+          isPhotoReanalysis={isPhotoReanalysis}
+          reanalyzingPhoto={reanalyzingPhoto}
+          analysisActive={analysisActive}
+          readOnly={readOnly}
+          photoNote={photoNote}
+          updatePhotoNote={updatePhotoNote}
+          removePhoto={removePhoto}
+          reanalyzePhoto={reanalyzePhoto}
+        />
+      ) : null}
+      <PhotoGallery
+        caseId={caseId}
+        caseData={caseData}
+        selectedPhoto={selectedPhoto}
+        setSelectedPhoto={setSelectedPhoto}
+        handleUpload={handleUpload}
+        fileInputRef={fileInputRef}
+        hasCamera={hasCamera}
+        removePhoto={removePhoto}
+        readOnly={readOnly}
+        isPhotoReanalysis={isPhotoReanalysis}
+        reanalyzingPhoto={reanalyzingPhoto}
+        requestValue={requestValue}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- factor out case detail UI and member list
- separate photo viewer/gallery section
- show analysis status in its own component
- embed new components in ClientCasePage

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Could not locate the bindings file)*
- `npm run e2e:smoke` *(fails: Could not locate the bindings file)*

------
https://chatgpt.com/codex/tasks/task_e_685b47f2afc8832b8898b8a88cd64e99