### PR TITLE
Fix chat input positioning

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -674,10 +674,11 @@ export default function CaseChat({
               available: availableActions,
               unavailable: unavailableActions,
             }}
+            className="flex-1"
           >
             <div
               ref={scrollRef}
-              className="flex-1 overflow-y-auto p-2 space-y-2"
+              className="h-full overflow-y-auto p-2 space-y-2"
             >
               {messages.map((m) => (
                 <div

--- a/src/app/components/DebugWrapper.tsx
+++ b/src/app/components/DebugWrapper.tsx
@@ -37,11 +37,13 @@ export default function DebugWrapper({
   children,
   availableActions,
   unavailableActions,
+  className,
 }: {
   data: unknown;
   children: ReactNode;
   availableActions?: string[];
   unavailableActions?: string[];
+  className?: string;
 }) {
   const enabled = Boolean(config.NEXT_PUBLIC_BROWSER_DEBUG);
   const alt = useAltKey();
@@ -98,7 +100,7 @@ export default function DebugWrapper({
         onMouseLeave={() => {
           setRefHover(false);
         }}
-        className="inline-block"
+        className={className ?? "inline-block"}
       >
         {children}
       </div>


### PR DESCRIPTION
## Summary
- expose `className` prop in `DebugWrapper` to style the wrapper
- make chat scroll area a flex item so the input stays pinned to the bottom

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685b4bbf2ec4832bb745a0f287330bdb