### PR TITLE
Fix chat input layout

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -694,11 +694,10 @@ export default function CaseChat({
               available: availableActions,
               unavailable: unavailableActions,
             }}
-            className="flex-1"
           >
             <div
               ref={scrollRef}
-              className="h-full overflow-y-auto p-2 space-y-2"
+              className="flex-1 min-h-0 overflow-y-auto p-2 space-y-2"
             >
               {messages.map((m) => (
                 <div

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -21,8 +21,8 @@ import {
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useNotify } from "../../components/NotificationProvider";
-import CaseDetails from "./components/CaseDetails";
 import { CaseProvider } from "./CaseContext";
+import CaseDetails from "./components/CaseDetails";
 import CaseExtraInfo from "./components/CaseExtraInfo";
 import CaseHeader from "./components/CaseHeader";
 import ClaimBanner from "./components/ClaimBanner";


### PR DESCRIPTION
## Summary
- adjust import order in `ClientCasePage`
- ensure chat messages area flexes correctly so the input stays pinned to the bottom

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b54588848832ba4a9cdb9b8c5c868