### PR TITLE
Fix overflow in chat input

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -694,11 +694,11 @@ export default function CaseChat({
               available: availableActions,
               unavailable: unavailableActions,
             }}
-            className="flex-1"
+            className="flex flex-col flex-1 min-h-0"
           >
             <div
               ref={scrollRef}
-              className="h-full overflow-y-auto p-2 space-y-2"
+              className="flex-1 overflow-y-auto p-2 space-y-2"
             >
               {messages.map((m) => (
                 <div

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -21,8 +21,8 @@ import {
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useNotify } from "../../components/NotificationProvider";
-import CaseDetails from "./components/CaseDetails";
 import { CaseProvider } from "./CaseContext";
+import CaseDetails from "./components/CaseDetails";
 import CaseExtraInfo from "./components/CaseExtraInfo";
 import CaseHeader from "./components/CaseHeader";
 import ClaimBanner from "./components/ClaimBanner";


### PR DESCRIPTION
## Summary
- reorder imports in `ClientCasePage`
- keep chat input anchored by making the debug wrapper a flex container and ensuring the message list can scroll

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685b54588848832ba4a9cdb9b8c5c868