### PR TITLE
Refactor case page to use context

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -1,451 +1,44 @@
 "use client";
 
-import { apiEventSource, apiFetch } from "@/apiClient";
 import CaseChat from "@/app/cases/[id]/CaseChat";
 import useDragReset from "@/app/cases/useDragReset";
 import CaseLayout from "@/app/components/CaseLayout";
 import CaseProgressGraph from "@/app/components/CaseProgressGraph";
 import DebugWrapper from "@/app/components/DebugWrapper";
-import useCaseAnalysisActive from "@/app/useCaseAnalysisActive";
 import { useSession } from "@/app/useSession";
-import { withBasePath } from "@/basePath";
 import type { Case } from "@/lib/caseStore";
-import {
-  getCaseOwnerContact,
-  getCasePlateNumber,
-  getCasePlateState,
-  getCaseVin,
-  getRepresentativePhoto,
-  hasViolation,
-} from "@/lib/caseUtils";
-import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
-import { useNotify } from "../../components/NotificationProvider";
-import { CaseProvider } from "./CaseContext";
+import { getCaseOwnerContact, hasViolation } from "@/lib/caseUtils";
+import { useEffect, useState } from "react";
+import { CaseProvider, useCaseContext } from "./CaseContext";
 import CaseDetails from "./components/CaseDetails";
 import CaseExtraInfo from "./components/CaseExtraInfo";
 import CaseHeader from "./components/CaseHeader";
 import ClaimBanner from "./components/ClaimBanner";
 import PhotoSection from "./components/PhotoSection";
+import useCaseActions from "./useCaseActions";
 
 function ClientCasePage({
-  initialCase,
   caseId,
-  initialIsAdmin = false,
   readOnly = false,
-}: {
-  initialCase: Case | null;
-  caseId: string;
-  initialIsAdmin?: boolean;
-  readOnly?: boolean;
-}) {
-  const [caseData, setCaseData] = useState<Case | null>(initialCase);
-  const analysisActive = useCaseAnalysisActive(
-    caseId,
-    caseData?.public ?? false,
-  );
-  const [preview, setPreview] = useState<string | null>(null);
-  const [selectedPhoto, setSelectedPhoto] = useState<string | null>(
-    initialCase ? getRepresentativePhoto(initialCase) : null,
-  );
-  const [plate, setPlate] = useState<string>(
-    initialCase ? getCasePlateNumber(initialCase) || "" : "",
-  );
-  const [plateState, setPlateState] = useState<string>(
-    initialCase ? getCasePlateState(initialCase) || "" : "",
-  );
-  const [vin, setVin] = useState<string>(
-    initialCase ? getCaseVin(initialCase) || "" : "",
-  );
-  const [note, setNote] = useState<string>(initialCase?.note || "");
-  const [photoNote, setPhotoNote] = useState<string>("");
-  const [members, setMembers] = useState<
-    Array<{
-      userId: string;
-      role: string;
-      name: string | null;
-      email: string | null;
-    }>
-  >([]);
-  const [copied, setCopied] = useState(false);
-  const [reanalyzingPhoto, setReanalyzingPhoto] = useState<string | null>(null);
+}: { caseId: string; readOnly?: boolean }) {
+  const { caseData, uploadFiles } = useCaseContext();
+  const { reanalyzingPhoto } = useCaseActions();
   const { data: session } = useSession();
-  const isAdmin =
-    session?.user?.role === "admin" ||
-    session?.user?.role === "superadmin" ||
-    initialIsAdmin;
-  const router = useRouter();
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const [hasCamera, setHasCamera] = useState(false);
   const [dragging, setDragging] = useState(false);
   const [hideClaimBanner, setHideClaimBanner] = useState(false);
   const [chatExpanded, setChatExpanded] = useState(false);
-  const notify = useNotify();
-  const showClaimBanner = Boolean(
-    caseData?.sessionId && !session?.user && !hideClaimBanner,
-  );
+  const [preview, setPreview] = useState<string | null>(null);
 
-  /* -------------------------------------------------------------------- */
-  /*                               EFFECTS                                */
-  /* -------------------------------------------------------------------- */
-
-  useDragReset(() => {
-    setDragging(false);
-  });
-
-  useEffect(() => {
-    void caseId;
-    setHideClaimBanner(false);
-  }, [caseId]);
-
-  useEffect(() => {
-    void caseData?.sessionId;
-    if (!caseData?.sessionId) {
-      setHideClaimBanner(false);
-    }
-  }, [caseData?.sessionId]);
-
-  useEffect(() => {
-    if (
-      "mediaDevices" in navigator &&
-      typeof navigator.mediaDevices.getUserMedia === "function" &&
-      (location.protocol === "https:" || location.hostname === "localhost")
-    ) {
-      setHasCamera(true);
-    }
-  }, []);
+  useDragReset(() => setDragging(false));
 
   useEffect(() => {
     const stored = sessionStorage.getItem(`preview-${caseId}`);
     if (stored) setPreview(stored);
-    apiFetch(`/api/cases/${caseId}`).then(async (res) => {
-      if (res.ok) {
-        const data = (await res.json()) as Case;
-        setCaseData(data);
-      }
-    });
-    apiFetch(`/api/cases/${caseId}/members`).then(async (res) => {
-      if (res.ok) setMembers(await res.json());
-    });
-    const es = apiEventSource("/api/cases/stream");
-    es.onmessage = (e) => {
-      const data = JSON.parse(e.data) as Case & { deleted?: boolean };
-      if (data.id !== caseId) return;
-      if (data.deleted) {
-        setCaseData(null);
-      } else {
-        setCaseData(data);
-        sessionStorage.removeItem(`preview-${caseId}`);
-      }
-    };
-    return () => es.close();
   }, [caseId]);
 
-  useEffect(() => {
-    if (caseData) {
-      setPlate(getCasePlateNumber(caseData) || "");
-      setPlateState(getCasePlateState(caseData) || "");
-      setVin(getCaseVin(caseData) || "");
-      setNote(caseData.note || "");
-      setSelectedPhoto((prev) => {
-        const all = new Set<string>([
-          ...caseData.photos,
-          ...(caseData.threadImages ?? []).map((img) => img.url),
-        ]);
-        return prev && all.has(prev) ? prev : getRepresentativePhoto(caseData);
-      });
-    }
-  }, [caseData]);
-
-  useEffect(() => {
-    if (caseData && selectedPhoto) {
-      setPhotoNote(caseData.photoNotes?.[selectedPhoto] || "");
-    }
-  }, [caseData, selectedPhoto]);
-
-  useEffect(() => {
-    if (caseData?.analysisStatus !== "pending") {
-      setReanalyzingPhoto(null);
-    }
-  }, [caseData?.analysisStatus]);
-
-  /* -------------------------------------------------------------------- */
-  /*                            API helpers                               */
-  /* -------------------------------------------------------------------- */
-
-  async function uploadFiles(files: FileList) {
-    if (!files || files.length === 0) return;
-    const results = await Promise.all(
-      Array.from(files).map((file) => {
-        const formData = new FormData();
-        formData.append("photo", file);
-        formData.append("caseId", caseId);
-        return apiFetch("/api/upload", {
-          method: "POST",
-          body: formData,
-        });
-      }),
-    );
-    if (results.some((r) => !r.ok)) {
-      notify("Failed to upload one or more files.");
-      return;
-    }
-    const res = await apiFetch(`/api/cases/${caseId}`);
-    if (res.ok) {
-      const data = (await res.json()) as Case;
-      setCaseData(data);
-    } else {
-      notify("Failed to refresh case after upload.");
-    }
-    router.refresh();
-    if (fileInputRef.current) fileInputRef.current.value = "";
-  }
-
-  async function handleUpload(e: React.ChangeEvent<HTMLInputElement>) {
-    const files = e.target.files;
-    if (files) await uploadFiles(files);
-  }
-
-  async function refreshCase() {
-    const res = await apiFetch(`/api/cases/${caseId}`);
-    if (res.ok) {
-      const data = (await res.json()) as Case;
-      setCaseData(data);
-    } else {
-      notify("Failed to refresh case.");
-    }
-  }
-
-  async function updateVehicle(plateNum: string, plateSt: string) {
-    const res = await apiFetch(`/api/cases/${caseId}/override`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        vehicle: {
-          licensePlateNumber: plateNum || undefined,
-          licensePlateState: plateSt || undefined,
-        },
-      }),
-    });
-    if (!res.ok) {
-      notify("Failed to update vehicle information.");
-      return;
-    }
-    await refreshCase();
-  }
-
-  async function updatePlateNumber(value: string) {
-    setPlate(value);
-    await updateVehicle(value, plateState);
-  }
-
-  async function updatePlateStateFn(value: string) {
-    setPlateState(value);
-    await updateVehicle(plate, value);
-  }
-
-  async function clearPlateNumber() {
-    setPlate("");
-    await updateVehicle("", plateState);
-  }
-
-  async function clearPlateState() {
-    setPlateState("");
-    await updateVehicle(plate, "");
-  }
-
-  async function updateVinFn(value: string) {
-    setVin(value);
-    const res = await apiFetch(`/api/cases/${caseId}/vin`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ vin: value || null }),
-    });
-    if (!res.ok) {
-      notify("Failed to update VIN.");
-      return;
-    }
-    await refreshCase();
-  }
-
-  async function clearVin() {
-    setVin("");
-    const res = await apiFetch(`/api/cases/${caseId}/vin`, {
-      method: "DELETE",
-    });
-    if (!res.ok) {
-      notify("Failed to clear VIN.");
-      return;
-    }
-    await refreshCase();
-  }
-
-  async function updateCaseNoteFn(value: string) {
-    setNote(value);
-    const res = await apiFetch(`/api/cases/${caseId}/note`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ note: value || null }),
-    });
-    if (!res.ok) {
-      notify("Failed to update note.");
-      return;
-    }
-    await refreshCase();
-  }
-
-  async function updatePhotoNoteFn(value: string) {
-    if (!selectedPhoto) return;
-    setPhotoNote(value);
-    const res = await apiFetch(`/api/cases/${caseId}/photo-note`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ photo: selectedPhoto, note: value || null }),
-    });
-    if (!res.ok) {
-      notify("Failed to update note.");
-      return;
-    }
-    await refreshCase();
-  }
-
-  async function togglePublic() {
-    const res = await apiFetch(`/api/cases/${caseId}/public`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ public: !(caseData?.public ?? false) }),
-    });
-    if (!res.ok) {
-      notify("Failed to update visibility.");
-      return;
-    }
-    await refreshCase();
-  }
-
-  async function toggleClosed() {
-    const res = await apiFetch(`/api/cases/${caseId}/closed`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ closed: !(caseData?.closed ?? false) }),
-    });
-    if (!res.ok) {
-      notify("Failed to update status.");
-      return;
-    }
-    await refreshCase();
-  }
-
-  async function toggleArchived() {
-    const res = await apiFetch(`/api/cases/${caseId}/archived`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ archived: !(caseData?.archived ?? false) }),
-    });
-    if (!res.ok) {
-      notify("Failed to update status.");
-      return;
-    }
-    await refreshCase();
-  }
-
-  async function copyPublicUrl() {
-    const url = `${window.location.origin}${withBasePath(
-      `/public/cases/${caseId}`,
-    )}`;
-    await navigator.clipboard.writeText(url);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }
-
-  async function reanalyzePhoto(
-    photo: string,
-    detailsEl?: HTMLDetailsElement | null,
-  ) {
-    const url = `/api/cases/${caseId}/reanalyze-photo?photo=${encodeURIComponent(
-      photo,
-    )}`;
-    if (caseData) setCaseData({ ...caseData, analysisStatus: "pending" });
-    setReanalyzingPhoto(photo);
-    const res = await apiFetch(url, { method: "POST" });
-    if (res.ok) {
-      if (detailsEl) {
-        detailsEl.open = false;
-      }
-    } else {
-      notify("Failed to reanalyze photo.");
-    }
-    await refreshCase();
-  }
-
-  async function retryAnalysis() {
-    if (caseData) setCaseData({ ...caseData, analysisStatus: "pending" });
-    const res = await apiFetch(`/api/cases/${caseId}/reanalyze`, {
-      method: "POST",
-    });
-    if (!res.ok) {
-      notify("Failed to retry analysis.");
-    }
-    await refreshCase();
-  }
-
-  async function removePhoto(photo: string) {
-    const delRes = await apiFetch(`/api/cases/${caseId}/photos`, {
-      method: "DELETE",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ photo }),
-    });
-    if (!delRes.ok) {
-      notify("Failed to remove photo.");
-      return;
-    }
-    const res = await apiFetch(`/api/cases/${caseId}`);
-    if (res.ok) {
-      const data = (await res.json()) as Case;
-      setCaseData(data);
-    } else {
-      notify("Failed to refresh case after removing photo.");
-    }
-    router.refresh();
-    const confirmed = window.confirm("Photo removed. Reanalyze this case now?");
-    if (confirmed) {
-      await apiFetch(`/api/cases/${caseId}/reanalyze`, { method: "POST" });
-      router.refresh();
-    }
-  }
-
-  async function refreshMembers() {
-    const res = await apiFetch(`/api/cases/${caseId}/members`);
-    if (res.ok) setMembers(await res.json());
-  }
-
-  async function inviteMember(userId: string) {
-    if (!userId) return;
-    const res = await apiFetch(`/api/cases/${caseId}/invite`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ userId }),
-    });
-    if (!res.ok) {
-      notify("Failed to invite collaborator.");
-      return;
-    }
-    await refreshMembers();
-  }
-
-  async function removeMember(uid: string) {
-    const res = await apiFetch(`/api/cases/${caseId}/members/${uid}`, {
-      method: "DELETE",
-    });
-    if (!res.ok) {
-      notify("Failed to remove collaborator.");
-      return;
-    }
-    await refreshMembers();
-  }
-
-  /* -------------------------------------------------------------------- */
-  /*                              RENDER                                  */
-  /* -------------------------------------------------------------------- */
+  const showClaimBanner = Boolean(
+    caseData?.sessionId && !session?.user && !hideClaimBanner,
+  );
 
   if (!caseData) {
     return (
@@ -464,49 +57,7 @@ function ClientCasePage({
 
   const violationIdentified =
     caseData.analysisStatus === "complete" && hasViolation(caseData.analysis);
-
-  const vinOverridden = caseData.vinOverride !== null;
-  const plateNumberOverridden =
-    caseData.analysisOverrides?.vehicle?.licensePlateNumber !== undefined;
-  const plateStateOverridden =
-    caseData.analysisOverrides?.vehicle?.licensePlateState !== undefined;
   const ownerContact = getCaseOwnerContact(caseData);
-  const isOwner = members.some(
-    (m) => m.userId === session?.user?.id && m.role === "owner",
-  );
-  const canManageMembers = isAdmin || isOwner;
-
-  const progress =
-    caseData.analysisStatus === "pending" && caseData.analysisProgress
-      ? caseData.analysisProgress
-      : null;
-  const isPhotoReanalysis = Boolean(
-    reanalyzingPhoto && caseData.analysisStatus === "pending",
-  );
-  const requestValue = progress
-    ? progress.stage === "upload"
-      ? progress.index > 0
-        ? (progress.index / progress.total) * 100
-        : undefined
-      : Math.min((progress.received / progress.total) * 100, 100)
-    : undefined;
-  const progressDescription = progress
-    ? `${progress.steps ? `Step ${progress.step} of ${progress.steps}: ` : ""}${
-        progress.stage === "upload"
-          ? progress.index > 0
-            ? `Uploading ${progress.index} of ${progress.total} photos (${Math.floor(
-                (progress.index / progress.total) * 100,
-              )}%)`
-            : "Uploading photos..."
-          : progress.done
-            ? "Processing results..."
-            : `Analyzing... ${progress.received} of ${progress.total} tokens`
-      }`
-    : caseData.analysisStatus === "pending"
-      ? "Analyzing photo..."
-      : caseData.analysisStatus === "canceled"
-        ? "Analysis canceled."
-        : "Analysis failed.";
 
   return (
     <div
@@ -550,83 +101,18 @@ function ClientCasePage({
         }
       >
         <CaseLayout
-          header={
-            <CaseHeader
-              caseId={caseId}
-              caseData={caseData}
-              ownerContact={ownerContact}
-              isAdmin={isAdmin}
-              readOnly={readOnly}
-              violationIdentified={violationIdentified}
-              progress={progress}
-              isPhotoReanalysis={isPhotoReanalysis}
-              copyPublicUrl={copyPublicUrl}
-              copied={copied}
-            />
-          }
+          header={<CaseHeader caseId={caseId} readOnly={readOnly} />}
           left={<CaseProgressGraph caseData={caseData} />}
           right={
             <>
               <DebugWrapper data={caseData}>
-                <CaseDetails
-                  caseData={caseData}
-                  progress={progress}
-                  readOnly={readOnly}
-                  ownerContact={ownerContact}
-                  vin={vin}
-                  vinOverridden={vinOverridden}
-                  note={note}
-                  plateNumberOverridden={plateNumberOverridden}
-                  plateStateOverridden={plateStateOverridden}
-                  updateVin={updateVinFn}
-                  clearVin={clearVin}
-                  updateNote={updateCaseNoteFn}
-                  updatePlateNumber={updatePlateNumber}
-                  updatePlateState={updatePlateStateFn}
-                  clearPlateNumber={clearPlateNumber}
-                  clearPlateState={clearPlateState}
-                  retryAnalysis={retryAnalysis}
-                  canTogglePublic={(isAdmin || session?.user) && !readOnly}
-                  canToggleStatus={(isAdmin || isOwner) && !readOnly}
-                  togglePublic={togglePublic}
-                  toggleClosed={toggleClosed}
-                  toggleArchived={toggleArchived}
-                  members={members}
-                  canManageMembers={canManageMembers}
-                  inviteMember={inviteMember}
-                  removeMember={removeMember}
-                />
+                <CaseDetails readOnly={readOnly} />
               </DebugWrapper>
-
-              <PhotoSection
-                caseId={caseId}
-                caseData={caseData}
-                selectedPhoto={selectedPhoto}
-                setSelectedPhoto={setSelectedPhoto}
-                handleUpload={handleUpload}
-                fileInputRef={fileInputRef}
-                hasCamera={hasCamera}
-                removePhoto={removePhoto}
-                readOnly={readOnly}
-                isPhotoReanalysis={isPhotoReanalysis}
-                reanalyzingPhoto={reanalyzingPhoto}
-                requestValue={requestValue}
-                progress={progress}
-                progressDescription={progressDescription}
-                analysisActive={analysisActive}
-                photoNote={photoNote}
-                updatePhotoNote={updatePhotoNoteFn}
-                reanalyzePhoto={reanalyzePhoto}
-              />
+              <PhotoSection caseId={caseId} readOnly={readOnly} />
             </>
           }
         >
-          <CaseExtraInfo
-            caseId={caseId}
-            caseData={caseData}
-            selectedPhoto={selectedPhoto}
-            setSelectedPhoto={setSelectedPhoto}
-          />
+          <CaseExtraInfo caseId={caseId} />
         </CaseLayout>
       </div>
       {readOnly || !dragging ? null : (
@@ -652,12 +138,11 @@ function ClientCasePage({
 export default function ClientCasePageWithProvider(props: {
   initialCase: Case | null;
   caseId: string;
-  initialIsAdmin?: boolean;
   readOnly?: boolean;
 }) {
   return (
     <CaseProvider caseId={props.caseId} initialCase={props.initialCase}>
-      <ClientCasePage {...props} />
+      <ClientCasePage caseId={props.caseId} readOnly={props.readOnly} />
     </CaseProvider>
   );
 }

--- a/src/app/cases/[id]/components/AnalysisStatus.tsx
+++ b/src/app/cases/[id]/components/AnalysisStatus.tsx
@@ -1,46 +1,27 @@
 "use client";
 import AnalysisInfo from "@/app/components/AnalysisInfo";
-import type { Case } from "@/lib/caseStore";
-import type { LlmProgress } from "@/lib/openai";
+import { useCaseContext } from "../CaseContext";
+import useCaseActions from "../useCaseActions";
+import useCaseProgress from "../useCaseProgress";
 
 export default function AnalysisStatus({
-  caseData,
-  progress,
-  readOnly,
-  plateNumberOverridden,
-  plateStateOverridden,
-  updatePlateNumber,
-  updatePlateState,
-  clearPlateNumber,
-  clearPlateState,
-  retryAnalysis,
-}: {
-  caseData: Case;
-  progress: LlmProgress | null;
-  readOnly: boolean;
-  plateNumberOverridden: boolean;
-  plateStateOverridden: boolean;
-  updatePlateNumber: (v: string) => Promise<void>;
-  updatePlateState: (v: string) => Promise<void>;
-  clearPlateNumber: () => Promise<void>;
-  clearPlateState: () => Promise<void>;
-  retryAnalysis: () => Promise<void>;
-}) {
-  const progressDescription = progress
-    ? `${progress.steps ? `Step ${progress.step} of ${progress.steps}: ` : ""}${
-        progress.stage === "upload"
-          ? progress.index > 0
-            ? `Uploading ${progress.index} of ${progress.total} photos (${Math.floor((progress.index / progress.total) * 100)}%)`
-            : "Uploading photos..."
-          : progress.done
-            ? "Processing results..."
-            : `Analyzing... ${progress.received} of ${progress.total} tokens`
-      }`
-    : caseData.analysisStatus === "pending"
-      ? "Analyzing photo..."
-      : caseData.analysisStatus === "canceled"
-        ? "Analysis canceled."
-        : "Analysis failed.";
+  readOnly = false,
+}: { readOnly?: boolean }) {
+  const { caseData } = useCaseContext();
+  const {
+    updatePlateNumber,
+    updatePlateState,
+    clearPlateNumber,
+    clearPlateState,
+    retryAnalysis,
+    reanalyzingPhoto,
+  } = useCaseActions();
+  const { progress, progressDescription } = useCaseProgress(reanalyzingPhoto);
+
+  const plateNumberOverridden =
+    caseData.analysisOverrides?.vehicle?.licensePlateNumber !== undefined;
+  const plateStateOverridden =
+    caseData.analysisOverrides?.vehicle?.licensePlateState !== undefined;
 
   const failureReason = caseData.analysisError
     ? caseData.analysisError === "truncated"

--- a/src/app/cases/[id]/components/CaseExtraInfo.tsx
+++ b/src/app/cases/[id]/components/CaseExtraInfo.tsx
@@ -1,21 +1,12 @@
 "use client";
 import DebugWrapper from "@/app/components/DebugWrapper";
 import ThumbnailImage from "@/components/thumbnail-image";
-import type { Case } from "@/lib/caseStore";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
+import { useCaseContext } from "../CaseContext";
 import { baseName, buildThreads } from "../utils";
 
-export default function CaseExtraInfo({
-  caseId,
-  caseData,
-  selectedPhoto,
-  setSelectedPhoto,
-}: {
-  caseId: string;
-  caseData: Case;
-  selectedPhoto: string | null;
-  setSelectedPhoto: (photo: string) => void;
-}) {
+export default function CaseExtraInfo({ caseId }: { caseId: string }) {
+  const { caseData, selectedPhoto, setSelectedPhoto } = useCaseContext();
   const analysisImages = caseData.analysis?.images ?? {};
   const paperworkScans = (caseData.threadImages ?? []).map((img) => ({
     url: img.url,

--- a/src/app/cases/[id]/components/CaseHeader.tsx
+++ b/src/app/cases/[id]/components/CaseHeader.tsx
@@ -1,33 +1,26 @@
 "use client";
 import CaseToolbar from "@/app/components/CaseToolbar";
-import type { Case } from "@/lib/caseStore";
-import type { LlmProgress } from "@/lib/openai";
+import { useSession } from "@/app/useSession";
+import { getCaseOwnerContact, hasViolation } from "@/lib/caseUtils";
 import Link from "next/link";
 import { FaShare } from "react-icons/fa";
+import { useCaseContext } from "../CaseContext";
+import useCaseActions from "../useCaseActions";
+import useCaseProgress from "../useCaseProgress";
 
 export default function CaseHeader({
   caseId,
-  caseData,
-  ownerContact,
-  isAdmin,
   readOnly = false,
-  violationIdentified,
-  progress,
-  isPhotoReanalysis,
-  copyPublicUrl,
-  copied,
-}: {
-  caseId: string;
-  caseData: Case;
-  ownerContact?: string | null;
-  isAdmin: boolean;
-  readOnly?: boolean;
-  violationIdentified: boolean;
-  progress: LlmProgress | null;
-  isPhotoReanalysis: boolean;
-  copyPublicUrl: () => Promise<void>;
-  copied: boolean;
-}) {
+}: { caseId: string; readOnly?: boolean }) {
+  const { caseData } = useCaseContext();
+  const { copied, copyPublicUrl, reanalyzingPhoto } = useCaseActions();
+  const { progress, isPhotoReanalysis } = useCaseProgress(reanalyzingPhoto);
+  const { data: session } = useSession();
+  const isAdmin =
+    session?.user?.role === "admin" || session?.user?.role === "superadmin";
+  const ownerContact = getCaseOwnerContact(caseData);
+  const violationIdentified =
+    caseData.analysisStatus === "complete" && hasViolation(caseData.analysis);
   return (
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-2">

--- a/src/app/cases/[id]/components/MemberList.tsx
+++ b/src/app/cases/[id]/components/MemberList.tsx
@@ -1,5 +1,7 @@
 "use client";
+import { useSession } from "@/app/useSession";
 import { useState } from "react";
+import { useCaseContext } from "../CaseContext";
 
 export type Member = {
   userId: string;
@@ -9,19 +11,17 @@ export type Member = {
 };
 
 export default function MemberList({
-  members,
-  readOnly,
-  canManageMembers,
-  inviteMember,
-  removeMember,
-}: {
-  members: Member[];
-  readOnly: boolean;
-  canManageMembers: boolean;
-  inviteMember: (userId: string) => Promise<void>;
-  removeMember: (userId: string) => Promise<void>;
-}) {
+  readOnly = false,
+}: { readOnly?: boolean }) {
+  const { members, inviteMember, removeMember } = useCaseContext();
   const [inviteUserId, setInviteUserId] = useState("");
+  const { data: session } = useSession();
+  const isOwner = members.some(
+    (m) => m.userId === session?.user?.id && m.role === "owner",
+  );
+  const isAdmin =
+    session?.user?.role === "admin" || session?.user?.role === "superadmin";
+  const canManageMembers = isAdmin || isOwner;
   return (
     <div>
       <span className="font-semibold">Members:</span>

--- a/src/app/cases/[id]/components/PhotoSection.tsx
+++ b/src/app/cases/[id]/components/PhotoSection.tsx
@@ -1,52 +1,45 @@
 "use client";
 import CaseJobList from "@/app/components/CaseJobList";
-import type { Case } from "@/lib/caseStore";
-import type { LlmProgress } from "@/lib/openai";
+import { useEffect, useState } from "react";
+import { useCaseContext } from "../CaseContext";
+import useCaseActions from "../useCaseActions";
+import useCaseProgress from "../useCaseProgress";
 import PhotoGallery from "./PhotoGallery";
 import PhotoViewer from "./PhotoViewer";
 
 export default function PhotoSection({
   caseId,
-  caseData,
-  selectedPhoto,
-  setSelectedPhoto,
-  handleUpload,
-  fileInputRef,
-  hasCamera,
-  removePhoto,
-  readOnly,
-  isPhotoReanalysis,
-  reanalyzingPhoto,
-  requestValue,
-  progress,
-  progressDescription,
-  analysisActive,
-  photoNote,
-  updatePhotoNote,
-  reanalyzePhoto,
-}: {
-  caseId: string;
-  caseData: Case;
-  selectedPhoto: string | null;
-  setSelectedPhoto: (photo: string) => void;
-  handleUpload: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
-  fileInputRef: React.RefObject<HTMLInputElement> | null;
-  hasCamera: boolean;
-  removePhoto: (photo: string) => Promise<void>;
-  readOnly: boolean;
-  isPhotoReanalysis: boolean;
-  reanalyzingPhoto: string | null;
-  requestValue: number | undefined;
-  progress: LlmProgress | null;
-  progressDescription: string;
-  analysisActive: boolean;
-  photoNote: string;
-  updatePhotoNote: (value: string) => Promise<void>;
-  reanalyzePhoto: (
-    photo: string,
-    detailsEl?: HTMLDetailsElement | null,
-  ) => Promise<void>;
-}) {
+  readOnly = false,
+}: { caseId: string; readOnly?: boolean }) {
+  const { caseData, selectedPhoto, setSelectedPhoto, fileInputRef } =
+    useCaseContext();
+  const {
+    handleUpload,
+    removePhoto,
+    reanalyzePhoto,
+    reanalyzingPhoto,
+    updatePhotoNote,
+  } = useCaseActions();
+  const {
+    progress,
+    progressDescription,
+    requestValue,
+    analysisActive,
+    isPhotoReanalysis,
+  } = useCaseProgress(reanalyzingPhoto);
+  const [hasCamera, setHasCamera] = useState(false);
+  useEffect(() => {
+    if (
+      "mediaDevices" in navigator &&
+      typeof navigator.mediaDevices.getUserMedia === "function" &&
+      (location.protocol === "https:" || location.hostname === "localhost")
+    ) {
+      setHasCamera(true);
+    }
+  }, []);
+  const photoNote = selectedPhoto
+    ? caseData.photoNotes?.[selectedPhoto] || ""
+    : "";
   return (
     <>
       <CaseJobList caseId={caseId} isPublic={caseData.public} />
@@ -62,7 +55,7 @@ export default function PhotoSection({
           analysisActive={analysisActive}
           readOnly={readOnly}
           photoNote={photoNote}
-          updatePhotoNote={updatePhotoNote}
+          updatePhotoNote={(v) => updatePhotoNote(selectedPhoto, v)}
           removePhoto={removePhoto}
           reanalyzePhoto={reanalyzePhoto}
         />

--- a/src/app/cases/[id]/useCaseActions.ts
+++ b/src/app/cases/[id]/useCaseActions.ts
@@ -1,0 +1,221 @@
+"use client";
+
+import { apiFetch } from "@/apiClient";
+import { withBasePath } from "@/basePath";
+import type { Case } from "@/lib/caseStore";
+import { getCasePlateNumber, getCasePlateState } from "@/lib/caseUtils";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useNotify } from "../../components/NotificationProvider";
+import { useCaseContext } from "./CaseContext";
+
+export default function useCaseActions() {
+  const {
+    caseId,
+    caseData,
+    setCaseData,
+    refreshCase,
+    updateVehicle,
+    inviteMember,
+    removeMember,
+    uploadFiles,
+    handleUpload,
+    fileInputRef,
+  } = useCaseContext();
+  const notify = useNotify();
+  const router = useRouter();
+  const [copied, setCopied] = useState(false);
+  const [reanalyzingPhoto, setReanalyzingPhoto] = useState<string | null>(null);
+
+  async function updateVin(value: string) {
+    const res = await apiFetch(`/api/cases/${caseId}/vin`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ vin: value || null }),
+    });
+    if (!res.ok) {
+      notify("Failed to update VIN.");
+      return;
+    }
+    await refreshCase();
+  }
+
+  async function clearVin() {
+    const res = await apiFetch(`/api/cases/${caseId}/vin`, {
+      method: "DELETE",
+    });
+    if (!res.ok) {
+      notify("Failed to clear VIN.");
+      return;
+    }
+    await refreshCase();
+  }
+
+  async function updateNote(value: string) {
+    const res = await apiFetch(`/api/cases/${caseId}/note`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ note: value || null }),
+    });
+    if (!res.ok) {
+      notify("Failed to update note.");
+      return;
+    }
+    await refreshCase();
+  }
+
+  async function updatePhotoNote(photo: string, value: string) {
+    const res = await apiFetch(`/api/cases/${caseId}/photo-note`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ photo, note: value || null }),
+    });
+    if (!res.ok) {
+      notify("Failed to update note.");
+      return;
+    }
+    await refreshCase();
+  }
+
+  async function togglePublic() {
+    const res = await apiFetch(`/api/cases/${caseId}/public`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ public: !(caseData?.public ?? false) }),
+    });
+    if (!res.ok) {
+      notify("Failed to update visibility.");
+      return;
+    }
+    await refreshCase();
+  }
+
+  async function toggleClosed() {
+    const res = await apiFetch(`/api/cases/${caseId}/closed`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ closed: !(caseData?.closed ?? false) }),
+    });
+    if (!res.ok) {
+      notify("Failed to update status.");
+      return;
+    }
+    await refreshCase();
+  }
+
+  async function toggleArchived() {
+    const res = await apiFetch(`/api/cases/${caseId}/archived`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ archived: !(caseData?.archived ?? false) }),
+    });
+    if (!res.ok) {
+      notify("Failed to update status.");
+      return;
+    }
+    await refreshCase();
+  }
+
+  async function copyPublicUrl() {
+    const url = `${window.location.origin}${withBasePath(`/public/cases/${caseId}`)}`;
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  async function reanalyzePhoto(
+    photo: string,
+    detailsEl?: HTMLDetailsElement | null,
+  ) {
+    const url = `/api/cases/${caseId}/reanalyze-photo?photo=${encodeURIComponent(photo)}`;
+    if (caseData) setCaseData({ ...caseData, analysisStatus: "pending" });
+    setReanalyzingPhoto(photo);
+    const res = await apiFetch(url, { method: "POST" });
+    if (res.ok) {
+      if (detailsEl) detailsEl.open = false;
+    } else {
+      notify("Failed to reanalyze photo.");
+    }
+    await refreshCase();
+  }
+
+  async function retryAnalysis() {
+    if (caseData) setCaseData({ ...caseData, analysisStatus: "pending" });
+    const res = await apiFetch(`/api/cases/${caseId}/reanalyze`, {
+      method: "POST",
+    });
+    if (!res.ok) notify("Failed to retry analysis.");
+    await refreshCase();
+  }
+
+  async function removePhoto(photo: string) {
+    const delRes = await apiFetch(`/api/cases/${caseId}/photos`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ photo }),
+    });
+    if (!delRes.ok) {
+      notify("Failed to remove photo.");
+      return;
+    }
+    const res = await apiFetch(`/api/cases/${caseId}`);
+    if (res.ok) {
+      const data = (await res.json()) as Case;
+      setCaseData(data);
+    } else {
+      notify("Failed to refresh case after removing photo.");
+    }
+    router.refresh();
+    const confirmed = window.confirm("Photo removed. Reanalyze this case now?");
+    if (confirmed) {
+      await apiFetch(`/api/cases/${caseId}/reanalyze`, { method: "POST" });
+      router.refresh();
+    }
+  }
+
+  function updatePlateNumber(value: string) {
+    const state = getCasePlateState(caseData as Case) || "";
+    return updateVehicle(value, state);
+  }
+
+  function updatePlateState(value: string) {
+    const plate = getCasePlateNumber(caseData as Case) || "";
+    return updateVehicle(plate, value);
+  }
+
+  function clearPlateNumber() {
+    const state = getCasePlateState(caseData as Case) || "";
+    return updateVehicle("", state);
+  }
+
+  function clearPlateState() {
+    const plate = getCasePlateNumber(caseData as Case) || "";
+    return updateVehicle(plate, "");
+  }
+
+  return {
+    copied,
+    copyPublicUrl,
+    reanalyzingPhoto,
+    setReanalyzingPhoto,
+    updateVin,
+    clearVin,
+    updateNote,
+    updatePhotoNote,
+    togglePublic,
+    toggleClosed,
+    toggleArchived,
+    reanalyzePhoto,
+    retryAnalysis,
+    removePhoto,
+    updatePlateNumber,
+    updatePlateState,
+    clearPlateNumber,
+    clearPlateState,
+    inviteMember,
+    removeMember,
+    uploadFiles,
+    handleUpload,
+    fileInputRef,
+  };
+}

--- a/src/app/cases/[id]/useCaseProgress.ts
+++ b/src/app/cases/[id]/useCaseProgress.ts
@@ -1,0 +1,63 @@
+"use client";
+import useCaseAnalysisActive from "@/app/useCaseAnalysisActive";
+import type { LlmProgress } from "@/lib/openai";
+import { useCaseContext } from "./CaseContext";
+
+export default function useCaseProgress(reanalyzingPhoto: string | null) {
+  const { caseId, caseData } = useCaseContext();
+  const analysisActive = useCaseAnalysisActive(
+    caseId,
+    caseData?.public ?? false,
+  );
+
+  const progress: LlmProgress | null =
+    caseData?.analysisStatus === "pending" && caseData.analysisProgress
+      ? caseData.analysisProgress
+      : null;
+
+  const isPhotoReanalysis = Boolean(
+    reanalyzingPhoto && caseData?.analysisStatus === "pending",
+  );
+
+  const requestValue = progress
+    ? progress.stage === "upload"
+      ? progress.index > 0
+        ? (progress.index / progress.total) * 100
+        : undefined
+      : Math.min((progress.received / progress.total) * 100, 100)
+    : undefined;
+
+  let progressDescription = "";
+  if (progress) {
+    const prefix = progress.steps
+      ? `Step ${progress.step} of ${progress.steps}: `
+      : "";
+    if (progress.stage === "upload") {
+      progressDescription =
+        prefix +
+        (progress.index > 0
+          ? `Uploading ${progress.index} of ${progress.total} photos (${Math.floor((progress.index / progress.total) * 100)}%)`
+          : "Uploading photos...");
+    } else {
+      progressDescription =
+        prefix +
+        (progress.done
+          ? "Processing results..."
+          : `Analyzing... ${progress.received} of ${progress.total} tokens`);
+    }
+  } else if (caseData?.analysisStatus === "pending") {
+    progressDescription = "Analyzing photo...";
+  } else if (caseData?.analysisStatus === "canceled") {
+    progressDescription = "Analysis canceled.";
+  } else {
+    progressDescription = "Analysis failed.";
+  }
+
+  return {
+    progress,
+    progressDescription,
+    requestValue,
+    analysisActive,
+    isPhotoReanalysis,
+  };
+}


### PR DESCRIPTION
## Summary
- rework `ClientCasePage` to rely on `CaseContext`
- add `useCaseActions` and `useCaseProgress` hooks
- simplify child components to consume context
- update imports and lint

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685b59334224832ba5145dae3e43b5ca