### PR TITLE
feat: setup react-query provider

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { getServerSession } from "next-auth";
 import AuthProvider from "./auth-provider";
 import NavBar from "./components/NavBar";
 import NotificationProvider from "./components/NotificationProvider";
+import QueryProvider from "./query-provider";
 import "./globals.css";
 
 export const runtime = "nodejs";
@@ -22,12 +23,14 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <body className="antialiased">
-        <NotificationProvider>
-          <AuthProvider session={session}>
-            <NavBar />
-            {children}
-          </AuthProvider>
-        </NotificationProvider>
+        <QueryProvider>
+          <NotificationProvider>
+            <AuthProvider session={session}>
+              <NavBar />
+              {children}
+            </AuthProvider>
+          </NotificationProvider>
+        </QueryProvider>
       </body>
     </html>
   );

--- a/src/app/query-provider.tsx
+++ b/src/app/query-provider.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import queryClient from "./queryClient";
+
+export default function QueryProvider({
+  children,
+}: { children: React.ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {process.env.NODE_ENV === "development" && (
+        <ReactQueryDevtools initialIsOpen={false} />
+      )}
+    </QueryClientProvider>
+  );
+}

--- a/src/app/queryClient.ts
+++ b/src/app/queryClient.ts
@@ -1,0 +1,5 @@
+import { QueryClient } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
+
+export default queryClient;


### PR DESCRIPTION
## Summary
- add a singleton `QueryClient`
- wrap the app in `QueryClientProvider`
- enable ReactQueryDevtools during development

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685be2810a14832bb7929d97ab90f692