### PR TITLE
Fix server hang after case load

### DIFF
--- a/src/app/cases/[id]/CaseContext.tsx
+++ b/src/app/cases/[id]/CaseContext.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { apiEventSource, apiFetch } from "@/apiClient";
+import useCaseAnalysisActive from "@/app/useCaseAnalysisActive";
 import type { Case } from "@/lib/caseStore";
 import { getRepresentativePhoto } from "@/lib/caseUtils";
 import { useRouter } from "next/navigation";
@@ -28,6 +29,7 @@ interface CaseContextValue {
   uploadFiles: (files: FileList) => Promise<void>;
   handleUpload: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
   removeMember: (userId: string) => Promise<void>;
+  analysisActive: boolean;
 }
 
 const CaseContext = createContext<CaseContextValue | null>(null);
@@ -49,6 +51,10 @@ export function CaseProvider({
   const notify = useNotify();
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const analysisActive = useCaseAnalysisActive(
+    caseId,
+    caseData?.public ?? false,
+  );
 
   useEffect(() => {
     apiFetch(`/api/cases/${caseId}`).then(async (res) => {
@@ -180,6 +186,7 @@ export function CaseProvider({
     uploadFiles,
     handleUpload,
     removeMember,
+    analysisActive,
   };
   return <CaseContext.Provider value={value}>{children}</CaseContext.Provider>;
 }

--- a/src/app/cases/[id]/useCaseProgress.ts
+++ b/src/app/cases/[id]/useCaseProgress.ts
@@ -1,14 +1,9 @@
 "use client";
-import useCaseAnalysisActive from "@/app/useCaseAnalysisActive";
 import type { LlmProgress } from "@/lib/openai";
 import { useCaseContext } from "./CaseContext";
 
 export default function useCaseProgress(reanalyzingPhoto: string | null) {
-  const { caseId, caseData } = useCaseContext();
-  const analysisActive = useCaseAnalysisActive(
-    caseId,
-    caseData?.public ?? false,
-  );
+  const { caseData, analysisActive } = useCaseContext();
 
   const progress: LlmProgress | null =
     caseData?.analysisStatus === "pending" && caseData.analysisProgress


### PR DESCRIPTION
## Summary
- keep analysis state in context
- reuse analysis info across case components so only one SSE connection is opened

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685be462f2dc832b9cc16f03ffd4ad37