### PR TITLE
chore: unify e2e smoke server config

### DIFF
--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -1,14 +1,13 @@
 import { getByRole } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { smokeEnv, smokePort } from "./smokeServer";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 
 beforeAll(async () => {
-  server = await startServer(3002, {
-    NEXTAUTH_SECRET: "secret",
-  });
+  server = await startServer(smokePort, smokeEnv);
 });
 
 afterAll(async () => {

--- a/test/e2e/freshDatabase.test.ts
+++ b/test/e2e/freshDatabase.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { smokeEnv, smokePort } from "./smokeServer";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
@@ -28,10 +29,8 @@ async function signIn(email: string) {
 
 beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-auth-"));
-  server = await startServer(3022, {
-    NEXTAUTH_SECRET: "secret",
-    NODE_ENV: "test",
-    SMTP_FROM: "test@example.com",
+  server = await startServer(smokePort, {
+    ...smokeEnv,
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -7,6 +7,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { createPhoto } from "./photo";
+import { smokeEnv, smokePort } from "./smokeServer";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
@@ -38,10 +39,8 @@ beforeAll(async () => {
     images: {},
   });
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
-  server = await startServer(3020, {
-    NEXTAUTH_SECRET: "secret",
-    NODE_ENV: "test",
-    SMTP_FROM: "test@example.com",
+  server = await startServer(smokePort, {
+    ...smokeEnv,
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     OPENAI_BASE_URL: stub.url,
   });

--- a/test/e2e/signinEmptyDb.test.ts
+++ b/test/e2e/signinEmptyDb.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
+import { smokeEnv, smokePort } from "./smokeServer";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
@@ -11,11 +12,9 @@ let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
 beforeAll(async () => {
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
-  server = await startServer(3013, {
+  server = await startServer(smokePort, {
+    ...smokeEnv,
     CASE_STORE_FILE: path.join(dataDir, "cases.sqlite"),
-    NEXTAUTH_SECRET: "secret",
-    NODE_ENV: "test",
-    SMTP_FROM: "test@example.com",
   });
   api = createApi(server);
 });

--- a/test/e2e/smokeServer.ts
+++ b/test/e2e/smokeServer.ts
@@ -1,0 +1,14 @@
+import os from "node:os";
+import path from "node:path";
+
+export const smokePort = 3050;
+
+export const smokeEnv: NodeJS.ProcessEnv = {
+  NEXTAUTH_SECRET: "secret",
+  NODE_ENV: "test",
+  SMTP_FROM: "test@example.com",
+};
+
+export function casesDb(filename = "cases.sqlite"): string {
+  return path.join(os.tmpdir(), filename);
+}

--- a/test/e2e/triage.test.ts
+++ b/test/e2e/triage.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { createAuthHelpers } from "./authHelpers";
 import { createPhoto } from "./photo";
+import { smokeEnv, smokePort } from "./smokeServer";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
@@ -19,7 +20,7 @@ async function createCase(): Promise<string> {
 }
 
 beforeAll(async () => {
-  server = await startServer(3040, { NEXTAUTH_SECRET: "secret" });
+  server = await startServer(smokePort, smokeEnv);
   api = createApi(server);
   ({ signIn } = createAuthHelpers(api, server));
   await signIn("user@example.com");


### PR DESCRIPTION
## Summary
- share smoke test server configuration
- use the common config when starting e2e smoke servers

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685bd8aa618c832b9f153661d4304eaa