### PR TITLE
Configure react-query with api client

### DIFF
--- a/src/app/queryClient.ts
+++ b/src/app/queryClient.ts
@@ -1,5 +1,19 @@
+import { apiFetch } from "@/apiClient";
 import { QueryClient } from "@tanstack/react-query";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      queryFn: async ({ queryKey }) => {
+        const path = Array.isArray(queryKey)
+          ? String(queryKey[0])
+          : String(queryKey);
+        const res = await apiFetch(path);
+        if (!res.ok) throw new Error(await res.text());
+        return res.json();
+      },
+    },
+  },
+});
 
 export default queryClient;


### PR DESCRIPTION
## Summary
- use the api client inside the global React Query client

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685be6699898832b8fb6c8dc01de36dc