### PR TITLE
Fix public cases runtime

### DIFF
--- a/src/app/api/public/cases/[id]/route.ts
+++ b/src/app/api/public/cases/[id]/route.ts
@@ -2,6 +2,8 @@ import { authorize } from "@/lib/authz";
 import { getCase } from "@/lib/caseStore";
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 export async function GET(
   _req: Request,
   { params }: { params: Promise<{ id: string }> },

--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -1,11 +1,11 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import ThumbnailImage from "@/components/thumbnail-image";
+import { caseActions } from "@/lib/caseActions";
 import type { CaseChatAction, CaseChatReply } from "@/lib/caseChat";
 import type { EmailDraft } from "@/lib/caseReport";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import type { ReportModule } from "@/lib/reportModules";
-import { caseActions } from "@/lib/caseActions";
-import ThumbnailImage from "@/components/thumbnail-image";
 import { useRouter } from "next/navigation";
 import {
   type ReactNode,


### PR DESCRIPTION
## Summary
- specify `nodejs` runtime for the public case API route
- tidy imports in `CaseChatProvider`

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685befdcea7c832baa9fd2ced249f976