### PR TITLE
Fix fetchRemote empty buffer handling

### DIFF
--- a/scripts/generateWebsiteImages.ts
+++ b/scripts/generateWebsiteImages.ts
@@ -80,6 +80,7 @@ function fetchRemote(dir: string, file: string): Buffer | null {
       const data = execSync(`git show origin/gh-pages:${p}`, {
         encoding: "buffer",
       });
+      if (!data || data.length === 0) throw new Error();
       return Buffer.from(data);
     } catch {
       // ignore

--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -1,11 +1,11 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import ThumbnailImage from "@/components/thumbnail-image";
+import { caseActions } from "@/lib/caseActions";
 import type { CaseChatAction, CaseChatReply } from "@/lib/caseChat";
 import type { EmailDraft } from "@/lib/caseReport";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import type { ReportModule } from "@/lib/reportModules";
-import { caseActions } from "@/lib/caseActions";
-import ThumbnailImage from "@/components/thumbnail-image";
 import { useRouter } from "next/navigation";
 import {
   type ReactNode,


### PR DESCRIPTION
## Summary
- handle empty git output in `fetchRemote`
- fix import order in CaseChatProvider

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685bf070db5c832b80cd8409a95c7b85