### PR TITLE
feat: profile page uses react-query

### DIFF
--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -1,11 +1,11 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import ThumbnailImage from "@/components/thumbnail-image";
+import { caseActions } from "@/lib/caseActions";
 import type { CaseChatAction, CaseChatReply } from "@/lib/caseChat";
 import type { EmailDraft } from "@/lib/caseReport";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import type { ReportModule } from "@/lib/reportModules";
-import { caseActions } from "@/lib/caseActions";
-import ThumbnailImage from "@/components/thumbnail-image";
 import { useRouter } from "next/navigation";
 import {
   type ReactNode,

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,22 +1,38 @@
 "use client";
+import { apiFetch } from "@/apiClient";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useSession } from "../useSession";
 
 export default function ProfilePage() {
   const { data: session } = useSession();
+  const queryClient = useQueryClient();
+  const { data } = useQuery({
+    queryKey: ["/api/profile"],
+    enabled: !!session,
+  });
   const [name, setName] = useState("");
   const [image, setImage] = useState("");
 
   useEffect(() => {
-    if (session) {
-      fetch("/api/profile")
-        .then((r) => r.json())
-        .then((data) => {
-          setName(data.name ?? "");
-          setImage(data.image ?? "");
-        });
+    if (data) {
+      setName(data.name ?? "");
+      setImage(data.image ?? "");
     }
-  }, [session]);
+  }, [data]);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      await apiFetch("/api/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, image }),
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/profile"] });
+    },
+  });
 
   if (!session) {
     return <div className="p-8">You are not logged in.</div>;
@@ -25,13 +41,9 @@ export default function ProfilePage() {
   return (
     <form
       className="p-8 flex flex-col gap-2"
-      onSubmit={async (e) => {
+      onSubmit={(e) => {
         e.preventDefault();
-        await fetch("/api/profile", {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name, image }),
-        });
+        mutation.mutate();
       }}
     >
       <h1 className="text-xl font-bold mb-4">User Profile</h1>


### PR DESCRIPTION
## Summary
- load user profile via `useQuery`
- update profile with `useMutation` and `apiFetch`

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685bea95fea4832ba2f182efa269e152