### PR TITLE
feat: update upload hooks

### DIFF
--- a/src/app/cases/__tests__/caseChatTakePhoto.test.tsx
+++ b/src/app/cases/__tests__/caseChatTakePhoto.test.tsx
@@ -1,4 +1,5 @@
 import CaseChat from "@/app/cases/[id]/CaseChat";
+import QueryProvider from "@/app/query-provider";
 import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -26,16 +27,18 @@ describe("CaseChat take photo action", () => {
       value: null,
     });
     const { getByText, getByPlaceholderText, findByText } = render(
-      <CaseChat
-        caseId="1"
-        onChat={async () => ({
-          reply: {
-            response: "",
-            actions: [{ id: "take-photo" }],
-            noop: false,
-          },
-        })}
-      />,
+      <QueryProvider>
+        <CaseChat
+          caseId="1"
+          onChat={async () => ({
+            reply: {
+              response: "",
+              actions: [{ id: "take-photo" }],
+              noop: false,
+            },
+          })}
+        />
+      </QueryProvider>,
     );
     fireEvent.click(getByText("Chat"));
     const input = getByPlaceholderText("Ask a question...");

--- a/src/app/cases/__tests__/dragOverlayPosition.test.tsx
+++ b/src/app/cases/__tests__/dragOverlayPosition.test.tsx
@@ -1,5 +1,6 @@
 import ClientCasesPage from "@/app/cases/ClientCasesPage";
 import ClientCasePage from "@/app/cases/[id]/ClientCasePage";
+import QueryProvider from "@/app/query-provider";
 import type { Case } from "@/lib/caseStore";
 import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -45,7 +46,11 @@ const baseCase: Case = {
 
 describe("drag overlays", () => {
   it("uses absolute positioning in cases list", () => {
-    const { container } = render(<ClientCasesPage initialCases={[baseCase]} />);
+    const { container } = render(
+      <QueryProvider>
+        <ClientCasesPage initialCases={[baseCase]} />
+      </QueryProvider>,
+    );
     const target = container.firstElementChild as HTMLElement;
     fireEvent.dragEnter(target);
     const overlay = container.querySelector("div.absolute.inset-0");
@@ -54,7 +59,9 @@ describe("drag overlays", () => {
 
   it("uses absolute positioning in single case page", () => {
     const { container } = render(
-      <ClientCasePage initialCase={baseCase} caseId="1" />,
+      <QueryProvider>
+        <ClientCasePage initialCase={baseCase} caseId="1" />
+      </QueryProvider>,
     );
     const target = container.firstElementChild as HTMLElement;
     fireEvent.dragEnter(target);

--- a/src/app/cases/__tests__/filterCaseStates.test.tsx
+++ b/src/app/cases/__tests__/filterCaseStates.test.tsx
@@ -1,4 +1,5 @@
 import ClientCasesPage from "@/app/cases/ClientCasesPage";
+import QueryProvider from "@/app/query-provider";
 import type { Case } from "@/lib/caseStore";
 import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -39,7 +40,9 @@ const closedCase: Case = { ...baseCase, id: "2", closed: true };
 describe("case state filter", () => {
   it("toggles closed case visibility", () => {
     const { getByLabelText, queryByText } = render(
-      <ClientCasesPage initialCases={[baseCase, closedCase]} />,
+      <QueryProvider>
+        <ClientCasesPage initialCases={[baseCase, closedCase]} />
+      </QueryProvider>,
     );
     expect(queryByText(/Case 2/)).toBeNull();
     const select = getByLabelText(/show/i) as HTMLSelectElement;

--- a/src/app/components/__tests__/NavBar.test.tsx
+++ b/src/app/components/__tests__/NavBar.test.tsx
@@ -1,3 +1,4 @@
+import QueryProvider from "@/app/query-provider";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -20,14 +21,22 @@ vi.mock("@/app/useSession", () => ({
 describe("NavBar", () => {
   it("shows point and shoot link on normal pages", () => {
     mockedUsePathname.mockReturnValue("/cases");
-    render(<NavBar />);
+    render(
+      <QueryProvider>
+        <NavBar />
+      </QueryProvider>,
+    );
     expect(screen.getByText("Point & Shoot")).toBeInTheDocument();
     expect(screen.getByText("Map View")).toBeInTheDocument();
   });
 
   it("hides the nav except for cases on /point", () => {
     mockedUsePathname.mockReturnValue("/point");
-    render(<NavBar />);
+    render(
+      <QueryProvider>
+        <NavBar />
+      </QueryProvider>,
+    );
     expect(screen.queryByText("Point & Shoot")).toBeNull();
     expect(screen.getByText("Cases")).toBeInTheDocument();
   });

--- a/src/app/useAddFilesToCase.ts
+++ b/src/app/useAddFilesToCase.ts
@@ -1,12 +1,17 @@
 "use client";
 
 import { apiFetch } from "@/apiClient";
+import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useNotify } from "./components/NotificationProvider";
 
 export default function useAddFilesToCase(caseId: string) {
   const router = useRouter();
   const notify = useNotify();
+  const uploadMutation = useMutation({
+    mutationFn: async (formData: FormData) =>
+      apiFetch("/api/upload", { method: "POST", body: formData }),
+  });
   return async (files: FileList | null) => {
     if (!files || files.length === 0) return;
     const results = await Promise.all(
@@ -14,10 +19,7 @@ export default function useAddFilesToCase(caseId: string) {
         const formData = new FormData();
         formData.append("photo", file);
         formData.append("caseId", caseId);
-        return apiFetch("/api/upload", {
-          method: "POST",
-          body: formData,
-        });
+        return uploadMutation.mutateAsync(formData);
       }),
     );
     if (results.some((r) => !r.ok)) {

--- a/src/app/useNewCaseFromFiles.ts
+++ b/src/app/useNewCaseFromFiles.ts
@@ -1,12 +1,17 @@
 "use client";
 
 import { apiFetch } from "@/apiClient";
+import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useNotify } from "./components/NotificationProvider";
 
 export default function useNewCaseFromFiles() {
   const router = useRouter();
   const notify = useNotify();
+  const uploadMutation = useMutation({
+    mutationFn: async (formData: FormData) =>
+      apiFetch("/api/upload", { method: "POST", body: formData }),
+  });
   return async (files: FileList | null) => {
     if (!files || files.length === 0) return;
     const id = Date.now().toString();
@@ -17,10 +22,7 @@ export default function useNewCaseFromFiles() {
         const formData = new FormData();
         formData.append("photo", file);
         formData.append("caseId", id);
-        const upload = apiFetch("/api/upload", {
-          method: "POST",
-          body: formData,
-        });
+        const upload = uploadMutation.mutateAsync(formData);
         if (idx === 0) {
           upload.then(() => {
             sessionStorage.removeItem(`preview-${id}`);


### PR DESCRIPTION
## Summary
- switch upload hooks to use `useMutation`
- wrap related tests with `QueryProvider`

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685bf2c3dd64832b88cf66141ea5b88e