### PR TITLE
Implement global cleanup for e2e tests

### DIFF
--- a/src/app/api/test/reset/route.ts
+++ b/src/app/api/test/reset/route.ts
@@ -1,0 +1,58 @@
+import { config } from "@/lib/config";
+import { db } from "@/lib/db";
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+export async function POST() {
+  if (!config.TEST_APIS) {
+    return new NextResponse(null, { status: 404 });
+  }
+  const tables = db
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT IN ('migrations', 'casbin_rules')",
+    )
+    .all() as Array<{ name: string }>;
+  for (const { name } of tables) {
+    db.prepare(`DELETE FROM ${name}`).run();
+  }
+  const casbinCount = db
+    .prepare("SELECT COUNT(*) as c FROM casbin_rules")
+    .get() as { c: number };
+  if (casbinCount.c === 0) {
+    const insert = db.prepare(
+      "INSERT INTO casbin_rules (ptype, v0, v1, v2) VALUES (?, ?, ?, ?)",
+    );
+    const seed = [
+      ["p", "anonymous", "public_cases", "read"],
+      ["p", "anonymous", "upload", "create"],
+      ["p", "user", "upload", "create"],
+      ["p", "user", "cases", "read"],
+      ["p", "user", "cases", "update"],
+      ["p", "user", "cases", "delete"],
+      ["p", "user", "snail_mail_providers", "read"],
+      ["p", "user", "vin_sources", "read"],
+      ["p", "user", "credits", "read"],
+      ["p", "user", "credits", "update"],
+      ["p", "admin", "admin", "read"],
+      ["p", "admin", "admin", "update"],
+      ["p", "admin", "users", "create"],
+      ["p", "admin", "users", "read"],
+      ["p", "admin", "users", "update"],
+      ["p", "admin", "users", "delete"],
+      ["p", "admin", "cases", "update"],
+      ["p", "admin", "cases", "delete"],
+      ["p", "admin", "snail_mail_providers", "update"],
+      ["p", "admin", "vin_sources", "update"],
+      ["p", "superadmin", "superadmin", "update"],
+      ["p", "superadmin", "superadmin", "read"],
+      ["g", "admin", "user", null],
+      ["g", "superadmin", "admin", null],
+    ];
+    const tx = db.transaction(() => {
+      for (const r of seed) insert.run(...r);
+    });
+    tx();
+  }
+  return new NextResponse(null, { status: 200 });
+}

--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -1,11 +1,11 @@
 "use client";
 import { apiFetch } from "@/apiClient";
+import ThumbnailImage from "@/components/thumbnail-image";
+import { caseActions } from "@/lib/caseActions";
 import type { CaseChatAction, CaseChatReply } from "@/lib/caseChat";
 import type { EmailDraft } from "@/lib/caseReport";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import type { ReportModule } from "@/lib/reportModules";
-import { caseActions } from "@/lib/caseActions";
-import ThumbnailImage from "@/components/thumbnail-image";
 import { useRouter } from "next/navigation";
 import {
   type ReactNode,

--- a/test/e2e/setup.ts
+++ b/test/e2e/setup.ts
@@ -1,0 +1,8 @@
+import { afterEach } from "vitest";
+
+afterEach(async () => {
+  const server = (
+    globalThis as unknown as { testServer?: { reset: () => Promise<void> } }
+  ).testServer;
+  if (server) await server.reset();
+});

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["test/e2e/*.test.ts"],
+    setupFiles: "./test/e2e/setup.ts",
     testTimeout: 30000,
     hookTimeout: 30000,
     maxConcurrency: 1,


### PR DESCRIPTION
## Summary
- add `/api/test/reset` endpoint to clear the DB
- override CASE_STORE_FILE in `startServer` and expose reset helper
- call server reset after each e2e test
- hook setup file into vitest e2e config
- update import order in `CaseChatProvider`

## Testing
- `npm test`
- `npm run e2e:smoke`

------
https://chatgpt.com/codex/tasks/task_e_685bed32698c832bbb059c012f5a2666