### PR TITLE
Implement reusable e2e DB

### DIFF
--- a/test/e2e/adminActions.test.ts
+++ b/test/e2e/adminActions.test.ts
@@ -1,6 +1,3 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createApi } from "./api";
 import { createAuthHelpers } from "./authHelpers";
@@ -37,13 +34,10 @@ beforeAll(async () => {
     vehicle: {},
     images: {},
   });
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-admin-"));
-  const case_store_file = path.join(tmpDir, "cases.sqlite");
   server = await startServer(3021, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: case_store_file,
     SUPER_ADMIN_EMAIL: "super@example.com",
     OPENAI_BASE_URL: stub.url,
   });

--- a/test/e2e/analysisQueue.test.ts
+++ b/test/e2e/analysisQueue.test.ts
@@ -45,7 +45,6 @@ function envFiles() {
     ),
   );
   return {
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
     OPENAI_BASE_URL: stub.url,
     NEXTAUTH_SECRET: "secret",
@@ -74,6 +73,9 @@ beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   server = await startServer(3007, envFiles());
   api = createApi(server);
+});
+
+beforeEach(async () => {
   await signIn("user@example.com");
 });
 

--- a/test/e2e/chat.test.ts
+++ b/test/e2e/chat.test.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -10,15 +9,12 @@ import { type TestServer, startServer } from "./startServer";
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 let stub: OpenAIStub;
-let tmpDir: string;
 
 beforeAll(async () => {
   stub = await startOpenAIStub({ response: "hello", actions: [], noop: false });
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-chat-"));
   server = await startServer(3012, {
     NEXTAUTH_SECRET: "secret",
     OPENAI_BASE_URL: stub.url,
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);
 });
@@ -26,7 +22,6 @@ beforeAll(async () => {
 afterAll(async () => {
   await server.close();
   await stub.close();
-  fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
 describe("chat api", () => {

--- a/test/e2e/claimBanner.test.ts
+++ b/test/e2e/claimBanner.test.ts
@@ -1,6 +1,3 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { getByText } from "@testing-library/dom";
 import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -10,12 +7,9 @@ import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
-let dataDir: string;
 
 beforeAll(async () => {
-  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
   server = await startServer(3035, {
-    CASE_STORE_FILE: path.join(dataDir, "cases.sqlite"),
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
   });
@@ -24,7 +18,6 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await server.close();
-  fs.rmSync(dataDir, { recursive: true, force: true });
 });
 
 describe("claim banner", () => {

--- a/test/e2e/email.test.ts
+++ b/test/e2e/email.test.ts
@@ -43,7 +43,6 @@ beforeAll(async () => {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     EMAIL_FILE: path.join(tmpDir, "emails.json"),
     MOCK_EMAIL_TO: "",
     OPENAI_BASE_URL: stub.url,

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -65,7 +65,6 @@ beforeAll(async () => {
   });
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   const env = {
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
     OPENAI_BASE_URL: stub.url,
     NEXTAUTH_SECRET: "secret",
@@ -85,6 +84,10 @@ beforeAll(async () => {
   api = createApi(server);
   await signIn("admin@example.com");
   await signOut();
+  await signIn("user@example.com");
+});
+
+beforeEach(async () => {
   await signIn("user@example.com");
 });
 

--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -7,6 +7,7 @@ import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { createPhoto } from "./photo";
 import { poll } from "./poll";
+import { casesDb } from "./smokeServer";
 import { type TestServer, startServer } from "./startServer";
 
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
@@ -48,7 +49,6 @@ beforeAll(async () => {
   ]);
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   const env = {
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
     OPENAI_BASE_URL: stub.url,
     NEXTAUTH_SECRET: "secret",
@@ -103,8 +103,7 @@ describe("follow up", () => {
 
   it("passes prior emails to openai", async () => {
     const id = await createCase();
-    const caseFile = path.join(tmpDir, "cases.sqlite");
-    const db = new Database(caseFile);
+    const db = new Database(casesDb());
     const row = db.prepare("SELECT data FROM cases WHERE id = ?").get(id) as {
       data: string;
     };

--- a/test/e2e/freshDatabase.test.ts
+++ b/test/e2e/freshDatabase.test.ts
@@ -31,7 +31,6 @@ beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-auth-"));
   server = await startServer(smokePort, {
     ...smokeEnv,
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);
 });

--- a/test/e2e/members.test.ts
+++ b/test/e2e/members.test.ts
@@ -48,12 +48,10 @@ async function createCase(): Promise<string> {
 }
 
 beforeAll(async () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   server = await startServer(3012, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);
 });

--- a/test/e2e/notes.test.ts
+++ b/test/e2e/notes.test.ts
@@ -35,11 +35,9 @@ async function createCase(): Promise<string> {
 }
 
 beforeAll(async () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   server = await startServer(3023, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
   });
   api = createApi(server);
 });

--- a/test/e2e/permissions.test.ts
+++ b/test/e2e/permissions.test.ts
@@ -55,12 +55,10 @@ async function createCase(): Promise<string> {
 
 beforeAll(async () => {
   stub = await startOpenAIStub({ subject: "", body: "" });
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   server = await startServer(3011, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     OPENAI_BASE_URL: stub.url,
   });
   api = createApi(server);

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -56,12 +56,10 @@ beforeAll(async () => {
     vehicle: {},
     images: {},
   });
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   server = await startServer(3021, {
     NEXTAUTH_SECRET: "secret",
     NODE_ENV: "test",
     SMTP_FROM: "test@example.com",
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     OPENAI_BASE_URL: stub.url,
   });
   api = createApi(server);

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -38,10 +38,8 @@ beforeAll(async () => {
     vehicle: {},
     images: {},
   });
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   server = await startServer(smokePort, {
     ...smokeEnv,
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     OPENAI_BASE_URL: stub.url,
   });
   api = createApi(server);

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -50,7 +50,6 @@ async function setup(responses: Array<import("./openaiStub").StubResponse>) {
   stub = await startOpenAIStub(responses);
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   const env = {
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
     OPENAI_BASE_URL: stub.url,
     NEXTAUTH_SECRET: "secret",

--- a/test/e2e/signinEmptyDb.test.ts
+++ b/test/e2e/signinEmptyDb.test.ts
@@ -7,21 +7,17 @@ import { smokeEnv, smokePort } from "./smokeServer";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
-let dataDir: string;
 let api: (path: string, opts?: RequestInit) => Promise<Response>;
 
 beforeAll(async () => {
-  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
   server = await startServer(smokePort, {
     ...smokeEnv,
-    CASE_STORE_FILE: path.join(dataDir, "cases.sqlite"),
   });
   api = createApi(server);
 });
 
 afterAll(async () => {
   await server.close();
-  fs.rmSync(dataDir, { recursive: true, force: true });
 });
 
 describe("sign in with empty db @smoke", () => {

--- a/test/e2e/snailmail.test.ts
+++ b/test/e2e/snailmail.test.ts
@@ -53,7 +53,6 @@ beforeAll(async () => {
   });
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-snail-"));
   const env: NodeJS.ProcessEnv & {
-    CASE_STORE_FILE: string;
     VIN_SOURCE_FILE: string;
     OPENAI_BASE_URL: string;
     SNAIL_MAIL_PROVIDER_FILE: string;
@@ -64,7 +63,6 @@ beforeAll(async () => {
     NODE_ENV: string;
     NEXTAUTH_SECRET: string;
   } = {
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     VIN_SOURCE_FILE: path.join(tmpDir, "vinSources.json"),
     OPENAI_BASE_URL: stub.url,
     SNAIL_MAIL_PROVIDER_FILE: path.join(tmpDir, "providers.json"),
@@ -99,6 +97,10 @@ beforeAll(async () => {
   );
   server = await startServer(3008, env);
   api = createApi(server);
+  await signIn("admin@example.com");
+});
+
+beforeEach(async () => {
   await signIn("admin@example.com");
 });
 

--- a/test/e2e/thread.test.ts
+++ b/test/e2e/thread.test.ts
@@ -40,7 +40,6 @@ beforeAll(async () => {
   });
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   const env = {
-    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
     NEXTAUTH_SECRET: "secret",
     OPENAI_BASE_URL: stub.url,
   };

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    setupFiles: "./vitest.e2e.setup.ts",
     include: ["test/e2e/*.test.ts"],
     testTimeout: 30000,
     hookTimeout: 30000,

--- a/vitest.e2e.setup.ts
+++ b/vitest.e2e.setup.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import Database from "better-sqlite3";
+import { afterAll, afterEach, beforeAll } from "vitest";
+import { runMigrations } from "./src/lib/migrate";
+import { casesDb } from "./test/e2e/smokeServer";
+
+const dbFile = casesDb();
+process.env.CASE_STORE_FILE = dbFile;
+
+let db: Database.Database;
+
+beforeAll(() => {
+  if (fs.existsSync(dbFile)) fs.unlinkSync(dbFile);
+  db = new Database(dbFile);
+  runMigrations(db);
+});
+
+afterEach(() => {
+  const tables = db
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+    )
+    .all() as Array<{ name: string }>;
+  for (const { name } of tables) {
+    if (name === "migrations") continue;
+    db.prepare(`DELETE FROM ${name}`).run();
+  }
+  const stmt = db.prepare(
+    "INSERT INTO casbin_rules (ptype, v0, v1, v2) VALUES (?, ?, ?, ?)",
+  );
+  const rules: Array<[string, string, string, string | null]> = [
+    ["p", "user", "upload", "create"],
+    ["g", "admin", "user", null],
+    ["g", "superadmin", "admin", null],
+    ["p", "anonymous", "public_cases", "read"],
+  ];
+  for (const r of rules) stmt.run(...r);
+});
+
+afterAll(() => {
+  db.close();
+  fs.unlinkSync(dbFile);
+});


### PR DESCRIPTION
## Summary
- add cleanup logic for casbin rules between tests
- sign in before each e2e test needing auth

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint` *(fails: biome not found)*
- `npm test` *(fails: vitest not found)*
- `npm run e2e` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bed32698c832bbb059c012f5a2666