### PR TITLE
Fix remote fetch for empty git output

### DIFF
--- a/scripts/generateWebsiteImages.ts
+++ b/scripts/generateWebsiteImages.ts
@@ -80,6 +80,7 @@ function fetchRemote(dir: string, file: string): Buffer | null {
       const data = execSync(`git show origin/gh-pages:${p}`, {
         encoding: "buffer",
       });
+      if (!data || data.length === 0) throw new Error();
       return Buffer.from(data);
     } catch {
       // ignore
@@ -163,5 +164,12 @@ if (require.main === module) {
     for (const spec of specs) {
       await generate(websiteDir, spec);
     }
-  })();
+  })()
+    .then(() => {
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
 }


### PR DESCRIPTION
## Summary
- handle empty git output in `generateWebsiteImages.ts`
- exit script after image generation completes

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685bf070db5c832b80cd8409a95c7b85