### PR TITLE
Fix remote fetch for empty git output

### DIFF
--- a/scripts/generateWebsiteImages.ts
+++ b/scripts/generateWebsiteImages.ts
@@ -80,6 +80,7 @@ function fetchRemote(dir: string, file: string): Buffer | null {
       const data = execSync(`git show origin/gh-pages:${p}`, {
         encoding: "buffer",
       });
+      if (!data?.length) throw new Error();
       return Buffer.from(data);
     } catch {
       // ignore


### PR DESCRIPTION
## Summary
- handle empty git output in `generateWebsiteImages.ts`

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685bf070db5c832b80cd8409a95c7b85