### PR TITLE
fix: correct useCase hook import

### DIFF
--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -8,7 +8,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { useNotify } from "../../../components/NotificationProvider";
-import useCase, { caseQueryKey } from "../../hooks/useCase";
+import useCase, { caseQueryKey } from "../../../hooks/useCase";
 
 function buildThread(c: Case, startId: string): SentEmail[] {
   const list = c.sentEmails ?? [];


### PR DESCRIPTION
## Summary
- update ClientThreadPage to import `useCase` from the correct path

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c417c41f4832b9135f2b3036e64fd