### PR TITLE
Add thread page to smoke tests

### DIFF
--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -8,7 +8,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { useNotify } from "../../../components/NotificationProvider";
-import useCase, { caseQueryKey } from "../../hooks/useCase";
+import useCase, { caseQueryKey } from "../../../hooks/useCase";
 
 function buildThread(c: Case, startId: string): SentEmail[] {
   const list = c.sentEmails ?? [];

--- a/test/e2e/thread.test.ts
+++ b/test/e2e/thread.test.ts
@@ -7,6 +7,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createApi } from "./api";
 import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
 import { createPhoto } from "./photo";
+import { smokeEnv, smokePort } from "./smokeServer";
 import { type TestServer, startServer } from "./startServer";
 
 let server: TestServer;
@@ -40,11 +41,11 @@ beforeAll(async () => {
   });
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   const env = {
+    ...smokeEnv,
     CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
-    NEXTAUTH_SECRET: "secret",
     OPENAI_BASE_URL: stub.url,
   };
-  server = await startServer(3006, env);
+  server = await startServer(smokePort, env);
   api = createApi(server);
   await signIn("user@example.com");
 });
@@ -55,7 +56,7 @@ afterAll(async () => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-describe("thread page", () => {
+describe("thread page @smoke", () => {
   async function createCase(): Promise<string> {
     const file = createPhoto("a");
     const form = new FormData();


### PR DESCRIPTION
## Summary
- fix path to `useCase` hook import
- include thread view page in e2e smoke tests

## Testing
- `npm test`
- `npm run e2e:smoke` *(fails: ENOTFOUND due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685c41c6b384832baaa56f6e0a627cee