### PR TITLE
Fix migrations in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,6 @@ ENV PORT=3000
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/migrations ./migrations
 EXPOSE 3000
 CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- copy migrations directory into runtime Docker image so migrations run

## Testing
- `npm test`
- `npm run e2e:smoke` *(fails: command stuck/blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685c7c13c138832bae0efef784390dd8