### PR TITLE
Fix type errors

### DIFF
--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -2,7 +2,7 @@ import queryClient from "@/app/queryClient";
 import type { useSession as useSessionFn } from "@/app/useSession";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/app/useSession", () => ({
   useSession: vi.fn(

--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -2,6 +2,7 @@
 import type { CaseChatReply } from "@/lib/caseChat";
 import {
   CaseChatProvider,
+  type ChatResponse,
   type Message,
   useCaseChat,
 } from "./CaseChatProvider";
@@ -13,7 +14,9 @@ export default function CaseChat(props: {
   caseId: string;
   onChat?: (
     messages: Message[],
-  ) => Promise<CaseChatReply | { reply: string; system?: string } | string>;
+  ) => Promise<
+    CaseChatReply | { reply: string; system?: string } | ChatResponse | string
+  >;
   expanded?: boolean;
   onExpandChange?: (value: boolean) => void;
 }) {

--- a/src/app/cases/[id]/CaseContext.tsx
+++ b/src/app/cases/[id]/CaseContext.tsx
@@ -26,7 +26,7 @@ interface CaseContextValue {
   members: CaseMember[];
   selectedPhoto: string | null;
   setSelectedPhoto: React.Dispatch<React.SetStateAction<string | null>>;
-  fileInputRef: React.RefObject<HTMLInputElement> | null;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
   refreshCase: () => Promise<void>;
   updateVehicle: (plateNum: string, plateState: string) => Promise<void>;
   inviteMember: (userId: string) => Promise<void>;
@@ -48,7 +48,7 @@ export function CaseProvider({
   caseId: string;
 }) {
   const queryClient = useQueryClient();
-  const { data: caseData } = useCase(caseId, initialCase);
+  const { data: caseData = null } = useCase(caseId, initialCase);
   const { data: members = [] } = useCaseMembers(caseId);
   const [selectedPhoto, setSelectedPhoto] = useState<string | null>(
     initialCase ? getRepresentativePhoto(initialCase) : null,

--- a/src/app/cases/[id]/components/AnalysisStatus.tsx
+++ b/src/app/cases/[id]/components/AnalysisStatus.tsx
@@ -8,6 +8,7 @@ export default function AnalysisStatus({
   readOnly = false,
 }: { readOnly?: boolean }) {
   const { caseData } = useCaseContext();
+  if (!caseData) return null;
   const {
     updatePlateNumber,
     updatePlateState,

--- a/src/app/cases/[id]/components/CaseDetails.tsx
+++ b/src/app/cases/[id]/components/CaseDetails.tsx
@@ -17,6 +17,7 @@ export default function CaseDetails({
   readOnly = false,
 }: { readOnly?: boolean }) {
   const { caseData, members } = useCaseContext();
+  if (!caseData) return null;
   const {
     updateVin,
     clearVin,

--- a/src/app/cases/[id]/components/CaseExtraInfo.tsx
+++ b/src/app/cases/[id]/components/CaseExtraInfo.tsx
@@ -7,6 +7,7 @@ import { baseName, buildThreads } from "../utils";
 
 export default function CaseExtraInfo({ caseId }: { caseId: string }) {
   const { caseData, selectedPhoto, setSelectedPhoto } = useCaseContext();
+  if (!caseData) return null;
   const analysisImages = caseData.analysis?.images ?? {};
   const paperworkScans = (caseData.threadImages ?? []).map((img) => ({
     url: img.url,

--- a/src/app/cases/[id]/components/CaseHeader.tsx
+++ b/src/app/cases/[id]/components/CaseHeader.tsx
@@ -13,6 +13,7 @@ export default function CaseHeader({
   readOnly = false,
 }: { caseId: string; readOnly?: boolean }) {
   const { caseData } = useCaseContext();
+  if (!caseData) return null;
   const { copied, copyPublicUrl, reanalyzingPhoto } = useCaseActions();
   const { progress, isPhotoReanalysis } = useCaseProgress(reanalyzingPhoto);
   const { data: session } = useSession();

--- a/src/app/cases/[id]/components/PhotoGallery.tsx
+++ b/src/app/cases/[id]/components/PhotoGallery.tsx
@@ -26,7 +26,7 @@ export default function PhotoGallery({
   selectedPhoto: string | null;
   setSelectedPhoto: (photo: string) => void;
   handleUpload: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
-  fileInputRef: React.RefObject<HTMLInputElement> | null;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
   hasCamera: boolean;
   removePhoto: (photo: string) => Promise<void>;
   readOnly: boolean;

--- a/src/app/cases/[id]/components/PhotoSection.tsx
+++ b/src/app/cases/[id]/components/PhotoSection.tsx
@@ -13,6 +13,7 @@ export default function PhotoSection({
 }: { caseId: string; readOnly?: boolean }) {
   const { caseData, selectedPhoto, setSelectedPhoto, fileInputRef } =
     useCaseContext();
+  if (!caseData) return null;
   const {
     handleUpload,
     removePhoto,

--- a/src/app/cases/[id]/draft/DraftPreview.tsx
+++ b/src/app/cases/[id]/draft/DraftPreview.tsx
@@ -31,12 +31,11 @@ export default function DraftPreview({
 
   function openCompose() {
     const url = `/cases/${caseId}/compose`;
-    router.push(url).then(() => {
-      if (typeof history !== "undefined") {
-        const st = history.state ?? {};
-        history.replaceState({ ...st, draftData: data }, "", url);
-      }
-    });
+    router.push(url);
+    if (typeof history !== "undefined") {
+      const st = history.state ?? {};
+      history.replaceState({ ...st, draftData: data }, "", url);
+    }
   }
 
   async function send() {

--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -14,11 +14,5 @@ export default async function CasePage({
   const session = await getServerSession(authOptions);
   const isAdmin =
     session?.user?.role === "admin" || session?.user?.role === "superadmin";
-  return (
-    <ClientCasePage
-      caseId={id}
-      initialCase={c ?? null}
-      initialIsAdmin={isAdmin}
-    />
-  );
+  return <ClientCasePage caseId={id} initialCase={c ?? null} />;
 }

--- a/src/app/cases/[id]/useCaseActions.ts
+++ b/src/app/cases/[id]/useCaseActions.ts
@@ -231,15 +231,16 @@ export default function useCaseActions() {
   const updateVin = (value: string) => updateVinMutation.mutateAsync(value);
   const clearVin = () => clearVinMutation.mutateAsync();
   const updateNote = (value: string) => updateNoteMutation.mutateAsync(value);
-  const updatePhotoNote = (photo: string, value: string) =>
-    updatePhotoNoteMutation.mutateAsync({ photo, value });
+  const updatePhotoNote = (photo: string, value: string): Promise<void> =>
+    updatePhotoNoteMutation.mutateAsync({ photo, value }).then(() => {});
   const togglePublic = () => togglePublicMutation.mutate();
   const toggleClosed = () => toggleClosedMutation.mutate();
   const toggleArchived = () => toggleArchivedMutation.mutate();
   const reanalyzePhoto = (
     photo: string,
     detailsEl?: HTMLDetailsElement | null,
-  ) => reanalyzePhotoMutation.mutate({ photo, detailsEl });
+  ): Promise<void> =>
+    reanalyzePhotoMutation.mutateAsync({ photo, detailsEl }).then(() => {});
   const retryAnalysis = () => retryAnalysisMutation.mutate();
   const removePhoto = (photo: string) => removePhotoMutation.mutateAsync(photo);
 

--- a/src/app/cases/__tests__/caseChatScrollButton.test.tsx
+++ b/src/app/cases/__tests__/caseChatScrollButton.test.tsx
@@ -1,6 +1,6 @@
 import CaseChat from "@/app/cases/[id]/CaseChat";
 import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),

--- a/src/app/components/AddImageMenu.tsx
+++ b/src/app/components/AddImageMenu.tsx
@@ -11,7 +11,7 @@ export default function AddImageMenu({
 }: {
   caseId: string;
   hasCamera: boolean;
-  fileInputRef: RefObject<HTMLInputElement>;
+  fileInputRef: RefObject<HTMLInputElement | null>;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }) {
   const [open, setOpen] = useState(false);

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -7,8 +7,12 @@ import { useSession } from "../useSession";
 export default function ProfilePage() {
   const { data: session } = useSession();
   const queryClient = useQueryClient();
-  const { data } = useQuery({
+  const { data } = useQuery<{ name?: string; image?: string }>({
     queryKey: ["/api/profile"],
+    queryFn: async () => {
+      const res = await apiFetch("/api/profile");
+      return (await res.json()) as { name?: string; image?: string };
+    },
     enabled: !!session,
   });
   const [name, setName] = useState("");

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -8,8 +8,12 @@ export default function UserSettingsPage() {
   const { data: session } = useSession();
   const [tab, setTab] = useState<"profile" | "credits">("profile");
   const [usd, setUsd] = useState("0");
-  const { data: balanceData } = useQuery({
+  const { data: balanceData } = useQuery<{ balance: number }>({
     queryKey: ["/api/credits/balance"],
+    queryFn: async () => {
+      const res = await apiFetch("/api/credits/balance");
+      return (await res.json()) as { balance: number };
+    },
     enabled: tab === "credits",
   });
   const queryClient = useQueryClient();

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -64,7 +64,8 @@ export default function Tooltip({
       {cloneElement(children, {
         ref: refs.setReference,
         ...getReferenceProps(),
-      })}
+        /* biome-ignore lint/suspicious/noExplicitAny: ref typing from cloneElement */
+      } as any)}
       {open && (
         <FloatingPortal>
           <div

--- a/src/lib/llmUtils.ts
+++ b/src/lib/llmUtils.ts
@@ -71,7 +71,7 @@ export async function chatWithSchema<T>(
     const total = maxTokens;
     let received = 0;
     if (progress) {
-      for await (const chunk of res as AsyncIterable<ChatCompletionChunk>) {
+      for await (const chunk of res as unknown as AsyncIterable<ChatCompletionChunk>) {
         const delta = chunk.choices[0]?.delta?.content ?? "";
         text += delta;
         finish = chunk.choices[0]?.finish_reason || null;

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -81,7 +81,7 @@ export const paperworkInfoSchema: z.ZodType<PaperworkInfo> = z.object({
     })
     .default({}),
   callsToAction: z.array(z.string()).optional(),
-});
+}) as z.ZodType<PaperworkInfo>;
 
 export interface PaperworkAnalysis {
   text: string;
@@ -141,7 +141,7 @@ export const violationReportSchema: z.ZodType<ViolationReport> = z.object({
       }),
     )
     .default({}),
-});
+}) as z.ZodType<ViolationReport>;
 
 export async function analyzeViolation(
   images: Array<{ url: string; filename: string }>,


### PR DESCRIPTION
## Summary
- export ChatResponse and broaden CaseChat callbacks
- guard components against missing case data
- update hooks to return promises
- fix OpenAI schemas and tooltip typing
- tweak refs and query functions to satisfy strict types

## Testing
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke` *(fails: network issues)*

------
https://chatgpt.com/codex/tasks/task_e_685c893e10ec832b8d01126edfd3541b