### PR TITLE
Improve Case Chat mobile layout

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -32,12 +32,18 @@ function CaseChatInner({ caseId }: { caseId: string }) {
   const { open, expanded, handleOpen } = useCaseChat();
   return (
     <div
-      className={`${expanded ? "relative h-full" : "fixed bottom-4 right-4 z-40"} text-sm`}
+      className={`${
+        expanded
+          ? "relative h-full"
+          : open
+            ? "fixed inset-0 sm:bottom-4 sm:right-4 sm:inset-auto z-40"
+            : "fixed bottom-4 right-4 z-40"
+      } text-sm`}
     >
       {open ? (
         <div
           className={`bg-white dark:bg-gray-900 shadow-lg rounded flex flex-col ${
-            expanded ? "w-full h-full" : "w-80 h-96"
+            expanded ? "w-full h-full" : "w-screen h-screen sm:w-80 sm:h-96"
           }`}
         >
           <ChatHeader />


### PR DESCRIPTION
## Summary
- make Case Chat occupy the full screen on small devices

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685cb5a75888832b85c54f9e3f29581b