### PR TITLE
Add dockerignore for smaller builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Ignore node modules and build output
+node_modules
+.next
+
+# Ignore tests and sample data
+coverage
+data
+test
+
+# Documentation and marketing site
+website
+docs
+
+# Development files
+terraform
+.storybook
+.github
+
+# Misc
+*.log
+.DS_Store
+.env*
+


### PR DESCRIPTION
## Summary
- add `.dockerignore` to reduce Docker build context

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`
- `docker build` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d29aca6bc832baab33265d56449e6