### PR TITLE
Fix tooltip ref typing error

### DIFF
--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -59,12 +59,14 @@ export default function Tooltip({
     role,
   ]);
 
+  const referenceProps = getReferenceProps({ ref: refs.setReference });
+
   return (
     <>
-      {cloneElement(children as ReactElement, {
-        ref: refs.setReference,
-        ...getReferenceProps(),
-      })}
+      {cloneElement(
+        children as ReactElement,
+        referenceProps as Record<string, unknown>,
+      )}
       {open && (
         <FloatingPortal>
           <div


### PR DESCRIPTION
## Summary
- fix tooltip cloneElement usage by prebuilding reference props

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d323fa994832bbafc714c0145784e