### PR TITLE
Migrate settings page to react-query hooks

### DIFF
--- a/src/app/hooks/useAddCredits.ts
+++ b/src/app/hooks/useAddCredits.ts
@@ -1,0 +1,20 @@
+"use client";
+import { apiFetch } from "@/apiClient";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { creditBalanceQueryKey } from "./useCreditBalance";
+
+export default function useAddCredits() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    async mutationFn(usd: number) {
+      await apiFetch("/api/credits/add", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ usd }),
+      });
+    },
+    onSuccess() {
+      queryClient.invalidateQueries({ queryKey: creditBalanceQueryKey });
+    },
+  });
+}

--- a/src/app/hooks/useCreditBalance.ts
+++ b/src/app/hooks/useCreditBalance.ts
@@ -1,0 +1,11 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+
+export const creditBalanceQueryKey = ["/api/credits/balance"] as const;
+
+export default function useCreditBalance(enabled = true) {
+  return useQuery<{ balance: number }>({
+    queryKey: creditBalanceQueryKey,
+    enabled,
+  });
+}

--- a/src/app/settings/SettingsPage.stories.tsx
+++ b/src/app/settings/SettingsPage.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import QueryProvider from "../query-provider";
 import SettingsPage from "./page";
 
 const meta: Meta<typeof SettingsPage> = {
@@ -10,22 +11,27 @@ export default meta;
 type Story = StoryObj<typeof SettingsPage>;
 
 function mockFetch() {
-  const statuses = [
-    { id: "carfax", enabled: true, failureCount: 0 },
-    { id: "dmv", enabled: false, failureCount: 2 },
-  ];
   (global as Record<string, unknown>).fetch = async (
     url: string,
     options?: RequestInit,
   ) => {
-    if (options && options.method === "PUT") return new Response(null);
-    return new Response(JSON.stringify(statuses));
+    if (url.endsWith("/api/credits/balance")) {
+      return new Response(JSON.stringify({ balance: 3 }));
+    }
+    if (url.endsWith("/api/credits/add") && options?.method === "POST") {
+      return new Response(null);
+    }
+    return new Response(null);
   };
 }
 
 export const Default: Story = {
   render: () => {
     mockFetch();
-    return <SettingsPage />;
+    return (
+      <QueryProvider>
+        <SettingsPage />
+      </QueryProvider>
+    );
   },
 };

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,31 +1,15 @@
 "use client";
-import { apiFetch } from "@/apiClient";
 import { useSession } from "@/app/useSession";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
+import useAddCredits from "../hooks/useAddCredits";
+import useCreditBalance from "../hooks/useCreditBalance";
 
 export default function UserSettingsPage() {
   const { data: session } = useSession();
   const [tab, setTab] = useState<"profile" | "credits">("profile");
   const [usd, setUsd] = useState("0");
-  const { data: balanceData } = useQuery({
-    queryKey: ["/api/credits/balance"],
-    enabled: tab === "credits",
-  });
-  const queryClient = useQueryClient();
-  const addCreditsMutation = useMutation({
-    async mutationFn() {
-      await apiFetch("/api/credits/add", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ usd: Number(usd) }),
-      });
-    },
-    onSuccess() {
-      setUsd("0");
-      queryClient.invalidateQueries({ queryKey: ["/api/credits/balance"] });
-    },
-  });
+  const { data: balanceData } = useCreditBalance(tab === "credits");
+  const addCreditsMutation = useAddCredits();
   const balance = balanceData?.balance ?? 0;
 
   if (!session) {
@@ -77,7 +61,13 @@ export default function UserSettingsPage() {
             />
             <button
               type="button"
-              onClick={() => addCreditsMutation.mutate()}
+              onClick={() =>
+                addCreditsMutation.mutate(Number(usd), {
+                  onSuccess() {
+                    setUsd("0");
+                  },
+                })
+              }
               className="bg-blue-600 text-white px-2 py-1 rounded"
             >
               Add


### PR DESCRIPTION
## Summary
- extract credit balance and add credits hooks
- refactor settings page to use these hooks
- update storybook setup for query hooks

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685c53fc51f0832b99cf3a38a5cda3dc