### PR TITLE
chore: expand node memory for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm test -- --bail 1
+        env:
+          NODE_OPTIONS: '--max-old-space-size=6144'
 
   e2e:
     runs-on: ubuntu-latest
@@ -42,6 +44,8 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run e2e -- --bail 1
+        env:
+          NODE_OPTIONS: '--max-old-space-size=6144'
 
   storybook:
     runs-on: ubuntu-latest
@@ -61,6 +65,7 @@ jobs:
       - run: npm run build-storybook
         env:
           STORYBOOK_DISABLE_TELEMETRY: "1"
+          NODE_OPTIONS: '--max-old-space-size=6144'
       - name: Deploy Storybook to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -30,6 +30,7 @@ jobs:
         env:
           PATH_PREFIX: /photo-to-citation/website/
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          NODE_OPTIONS: '--max-old-space-size=6144'
       - name: Deploy Website to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     globals: true,
     setupFiles: "./vitest.setup.ts",
     exclude: [...configDefaults.exclude, "test/e2e/**"],
+    maxThreads: 2,
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],


### PR DESCRIPTION
## Summary
- limit Vitest worker threads to cut memory usage
- set NODE_OPTIONS to increase available heap in GitHub Actions

## Testing
- `npm run lint`
- `NODE_OPTIONS='--max-old-space-size=6144' npm test`
- `npm run e2e:smoke` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685d35df22a0832b9b0872dc8e7bd88f