### PR TITLE
Fix mobile chat overlay

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -43,7 +43,7 @@ function CaseChatInner({ caseId }: { caseId: string }) {
       {open ? (
         <div
           className={`bg-white dark:bg-gray-900 shadow-lg rounded flex flex-col ${
-            expanded ? "w-full h-full" : "w-screen h-screen sm:w-80 sm:h-96"
+            expanded ? "w-full h-full" : "w-screen h-[100dvh] sm:w-80 sm:h-96"
           }`}
         >
           <ChatHeader />

--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -689,6 +689,17 @@ export function CaseChatProvider({
   }, [open, saveCurrentSession]);
 
   useEffect(() => {
+    const cls = "case-chat-open";
+    const body = document.body;
+    if (open) {
+      body.classList.add(cls);
+    } else {
+      body.classList.remove(cls);
+    }
+    return () => body.classList.remove(cls);
+  }, [open]);
+
+  useEffect(() => {
     const state: ChatState = {
       open,
       expanded,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,6 +23,12 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+body.case-chat-open {
+  overflow: hidden;
+  touch-action: none;
+  overscroll-behavior: contain;
+}
+
 /* Hide mermaid diagrams until the library finishes styling them */
 .mermaid:not([data-processed]) {
   visibility: hidden;


### PR DESCRIPTION
## Summary
- make case chat overlay use dynamic viewport height on small screens
- prevent page scrolling and zoom while chat is open

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685d3b458ddc832b8c88e715218294ad