### PR TITLE
Improve mobile chat behavior

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -36,14 +36,14 @@ function CaseChatInner({ caseId }: { caseId: string }) {
         expanded
           ? "relative h-full"
           : open
-            ? "fixed inset-0 sm:bottom-4 sm:right-4 sm:inset-auto z-40"
+            ? "fixed inset-0 sm:bottom-4 sm:right-4 sm:inset-auto z-40 touch-pan-y overscroll-none"
             : "fixed bottom-4 right-4 z-40"
       } text-sm`}
     >
       {open ? (
         <div
           className={`bg-white dark:bg-gray-900 shadow-lg rounded flex flex-col ${
-            expanded ? "w-full h-full" : "w-screen h-screen sm:w-80 sm:h-96"
+            expanded ? "w-full h-full" : "w-screen h-[100dvh] sm:w-80 sm:h-96"
           }`}
         >
           <ChatHeader />

--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -145,6 +145,16 @@ export function CaseChatProvider({
   const notify = useNotify();
   const [chatError, setChatError] = useState<string | null>(null);
 
+  useEffect(() => {
+    if (open) {
+      const prev = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+      return () => {
+        document.body.style.overflow = prev;
+      };
+    }
+  }, [open]);
+
   const storageKey = `case-chat-${caseId}`;
   const stateKey = `case-chat-state-${caseId}`;
 

--- a/src/app/cases/[id]/ChatInput.tsx
+++ b/src/app/cases/[id]/ChatInput.tsx
@@ -5,7 +5,7 @@ export default function ChatInput() {
   const { input, setInput, send, loading, showJump, scrollToBottom, inputRef } =
     useCaseChat();
   return (
-    <div className="border-t p-2 flex flex-col gap-2">
+    <div className="border-t p-2 flex flex-col gap-2 pb-[env(safe-area-inset-bottom)]">
       {showJump ? (
         <button
           type="button"


### PR DESCRIPTION
## Summary
- block body scrolling while chat is open
- add safe area padding to chat input
- prevent zoom/pan and use dvh for mobile chat

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685d3b458ddc832b8c88e715218294ad