### PR TITLE
Add Google sign-in and Terraform setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,8 @@ SUPER_ADMIN_EMAIL=
 # NextAuth settings
 NEXTAUTH_SECRET=
 NEXTAUTH_URL=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
 
 # SQLite database locations
 # Default case store is data/cases.sqlite

--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ The sign‑in flow sends a verification email, so set `SMTP_HOST`, `SMTP_PORT`,
 `SMTP_USER`, `SMTP_PASS`, and `SMTP_FROM` in your environment. Without these
 values login emails cannot be delivered.
 
+To enable Google sign‑in, also provide `GOOGLE_CLIENT_ID` and
+`GOOGLE_CLIENT_SECRET`. A Terraform module under `terraform/google-oauth`
+creates these credentials:
+
+```bash
+cd terraform/google-oauth
+terraform init
+terraform apply
+```
+
+Copy the outputs into `.env.local` for the production deployment.
+
 ## Generating Zod Schemas
 
 When interfaces in `src/lib` change, update the runtime schemas and verify the output with:

--- a/src/app/signin/__tests__/SignInPage.test.tsx
+++ b/src/app/signin/__tests__/SignInPage.test.tsx
@@ -1,10 +1,11 @@
 import SignInPage from "@/app/signin/page";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/app/useSession", () => ({
   signIn: vi.fn(),
 }));
+import { signIn } from "@/app/useSession";
 
 const mockGet = vi.fn();
 vi.mock("next/navigation", () => ({
@@ -38,5 +39,13 @@ describe("SignInPage", () => {
       "href",
       "https://antialias.github.io/photo-to-citation/website/",
     );
+  });
+
+  it("allows signing in with Google", () => {
+    mockGet.mockReturnValueOnce(null);
+    render(<SignInPage />);
+    const btn = screen.getByRole("button", { name: /sign in with google/i });
+    fireEvent.click(btn);
+    expect(signIn).toHaveBeenCalledWith("google", { callbackUrl: "/" });
   });
 });

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -45,6 +45,13 @@ export default function SignInPage() {
         <button type="submit" className="bg-blue-500 text-white px-4 py-2">
           Sign In
         </button>
+        <button
+          type="button"
+          onClick={() => signIn("google", { callbackUrl: withBasePath("/") })}
+          className="bg-red-500 text-white px-4 py-2 mt-2"
+        >
+          Sign in with Google
+        </button>
       </form>
       <a href={MARKETING_URL} className="underline mt-2">
         Back to Website

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { NextAuthOptions, Session, User } from "next-auth";
 import type { Adapter } from "next-auth/adapters";
 import EmailProvider from "next-auth/providers/email";
+import GoogleProvider from "next-auth/providers/google";
 import { authAdapter, seedSuperAdmin } from "./auth";
 import { config } from "./config";
 import { sendEmail } from "./email";
@@ -31,6 +32,10 @@ export const authOptions: NextAuthOptions = {
         log("Verification email sent", identifier);
       },
       from: config.SMTP_FROM,
+    }),
+    GoogleProvider({
+      clientId: config.GOOGLE_CLIENT_ID ?? "",
+      clientSecret: config.GOOGLE_CLIENT_SECRET ?? "",
     }),
   ],
   pages: { signIn: "/signin" },

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -29,6 +29,8 @@ const envSchema = z
     SUPER_ADMIN_EMAIL: z.string().optional(),
     NEXTAUTH_SECRET: z.string().optional(),
     NEXTAUTH_URL: z.string().optional(),
+    GOOGLE_CLIENT_ID: z.string().optional(),
+    GOOGLE_CLIENT_SECRET: z.string().optional(),
     CASE_STORE_FILE: z.string().optional(),
     VIN_SOURCE_FILE: z.string().optional(),
     SNAIL_MAIL_FILE: z.string().optional(),

--- a/terraform/google-oauth/README.md
+++ b/terraform/google-oauth/README.md
@@ -1,0 +1,21 @@
+# Google OAuth Client
+
+This directory contains Terraform configuration for creating a Google OAuth client
+used by the production deployment. The resources enable the IAP API, create an
+internal brand, and provision an OAuth client ID and secret.
+
+```
+terraform init
+terraform apply
+```
+
+Pass the required variables on the command line or in a `terraform.tfvars` file:
+
+```hcl
+project          = "your-gcp-project-id"
+support_email    = "you@example.com"
+application_title = "photo-to-citation"
+```
+
+After apply, copy `google_client_id` and `google_client_secret` from the outputs
+into your environment as `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`.

--- a/terraform/google-oauth/main.tf
+++ b/terraform/google-oauth/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.2"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+}
+
+resource "google_project_service" "iap" {
+  project = var.project
+  service = "iap.googleapis.com"
+}
+
+resource "google_iap_brand" "brand" {
+  support_email     = var.support_email
+  application_title = var.application_title
+  project           = var.project
+  depends_on        = [google_project_service.iap]
+}
+
+resource "google_iap_client" "client" {
+  display_name = var.application_title
+  brand        = google_iap_brand.brand.name
+}

--- a/terraform/google-oauth/outputs.tf
+++ b/terraform/google-oauth/outputs.tf
@@ -1,0 +1,8 @@
+output "google_client_id" {
+  value = google_iap_client.client.client_id
+}
+
+output "google_client_secret" {
+  value     = google_iap_client.client.secret
+  sensitive = true
+}

--- a/terraform/google-oauth/variables.tf
+++ b/terraform/google-oauth/variables.tf
@@ -1,0 +1,15 @@
+variable "project" {
+  type        = string
+  description = "GCP project ID"
+}
+
+variable "support_email" {
+  type        = string
+  description = "Email shown on the consent screen"
+}
+
+variable "application_title" {
+  type        = string
+  description = "OAuth app name"
+  default     = "photo-to-citation"
+}


### PR DESCRIPTION
## Summary
- support Google OAuth login with NextAuth
- add Google env vars to validation and .env example
- expose Google sign-in button on sign-in page
- document setup in README and add Terraform module for OAuth client

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke` *(fails: Command killed due to environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_685d371aae40832ba47a0a2b90c16a5c