### PR TITLE
Fix mobile chat layout

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -1,5 +1,7 @@
 "use client";
 import type { CaseChatReply } from "@/lib/caseChat";
+import useBodyScrollLock from "../../useBodyScrollLock";
+import useViewportHeight from "../../useViewportHeight";
 import {
   CaseChatProvider,
   type ChatResponse,
@@ -30,6 +32,8 @@ export default function CaseChat(props: {
 
 function CaseChatInner({ caseId }: { caseId: string }) {
   const { open, expanded, handleOpen } = useCaseChat();
+  useBodyScrollLock(open);
+  useViewportHeight(open);
   return (
     <div
       className={`${
@@ -43,8 +47,11 @@ function CaseChatInner({ caseId }: { caseId: string }) {
       {open ? (
         <div
           className={`bg-white dark:bg-gray-900 shadow-lg rounded flex flex-col ${
-            expanded ? "w-full h-full" : "w-screen h-screen sm:w-80 sm:h-96"
+            expanded ? "w-full h-full" : "w-screen sm:w-80"
           }`}
+          style={
+            expanded ? undefined : { height: "calc(var(--vh, 1vh) * 100)" }
+          }
         >
           <ChatHeader />
           <ChatMessages caseId={caseId} />

--- a/src/app/cases/[id]/ChatInput.tsx
+++ b/src/app/cases/[id]/ChatInput.tsx
@@ -5,7 +5,12 @@ export default function ChatInput() {
   const { input, setInput, send, loading, showJump, scrollToBottom, inputRef } =
     useCaseChat();
   return (
-    <div className="border-t p-2 flex flex-col gap-2">
+    <div
+      className="border-t p-2 flex flex-col gap-2"
+      style={{
+        paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 0.5rem)",
+      }}
+    >
       {showJump ? (
         <button
           type="button"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,7 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --vh: 1vh;
 }
 
 @theme inline {

--- a/src/app/useBodyScrollLock.ts
+++ b/src/app/useBodyScrollLock.ts
@@ -1,0 +1,21 @@
+"use client";
+import { useEffect } from "react";
+
+export default function useBodyScrollLock(active: boolean) {
+  useEffect(() => {
+    if (!active) return;
+    if (window.innerWidth >= 640) return;
+    const { style } = document.body;
+    const overflow = style.overflow;
+    const touch = style.touchAction;
+    const overscroll = style.overscrollBehavior;
+    style.overflow = "hidden";
+    style.touchAction = "none";
+    style.overscrollBehavior = "contain";
+    return () => {
+      style.overflow = overflow;
+      style.touchAction = touch;
+      style.overscrollBehavior = overscroll;
+    };
+  }, [active]);
+}

--- a/src/app/useViewportHeight.ts
+++ b/src/app/useViewportHeight.ts
@@ -1,0 +1,19 @@
+"use client";
+import { useEffect } from "react";
+
+export default function useViewportHeight(active: boolean) {
+  useEffect(() => {
+    if (!active) return;
+    function set() {
+      document.documentElement.style.setProperty(
+        "--vh",
+        `${window.innerHeight * 0.01}px`,
+      );
+    }
+    set();
+    window.addEventListener("resize", set);
+    return () => {
+      window.removeEventListener("resize", set);
+    };
+  }, [active]);
+}


### PR DESCRIPTION
## Summary
- lock body scrolling while mobile chat is open
- adjust chat container height using dynamic viewport units
- pad chat input with safe-area inset for iOS Safari

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685d3b458ddc832b8c88e715218294ad