### PR TITLE
Fix mobile case chat viewport

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -43,8 +43,8 @@ function CaseChatInner({ caseId }: { caseId: string }) {
       {open ? (
         <div
           className={`bg-white dark:bg-gray-900 shadow-lg rounded flex flex-col ${
-            expanded ? "w-full h-full" : "w-screen h-screen sm:w-80 sm:h-96"
-          }`}
+            expanded ? "w-full h-full" : "w-screen h-[100dvh] sm:w-80 sm:h-96"
+          } touch-none`}
         >
           <ChatHeader />
           <ChatMessages caseId={caseId} />

--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -676,6 +676,33 @@ export function CaseChatProvider({
   }, [open]);
 
   useEffect(() => {
+    if (!open) return;
+    if (
+      !(
+        typeof matchMedia !== "undefined" &&
+        matchMedia("(max-width: 640px)").matches
+      )
+    )
+      return;
+    const html = document.documentElement;
+    const body = document.body;
+    const prevOverflow = html.style.overflow;
+    const prevTouch = body.style.touchAction;
+    const prevBehaviorHtml = html.style.overscrollBehaviorY;
+    const prevBehaviorBody = body.style.overscrollBehaviorY;
+    html.style.overflow = "hidden";
+    html.style.overscrollBehaviorY = "contain";
+    body.style.touchAction = "none";
+    body.style.overscrollBehaviorY = "contain";
+    return () => {
+      html.style.overflow = prevOverflow;
+      html.style.overscrollBehaviorY = prevBehaviorHtml;
+      body.style.touchAction = prevTouch;
+      body.style.overscrollBehaviorY = prevBehaviorBody;
+    };
+  }, [open]);
+
+  useEffect(() => {
     const handler = () => saveCurrentSession();
     window.addEventListener("beforeunload", handler);
     return () => {


### PR DESCRIPTION
## Summary
- avoid Safari toolbar offset by using `100dvh`
- disable scrolling and pinch-zoom when chat is open on small screens

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke` *(fails: Next.js server hangs)*

------
https://chatgpt.com/codex/tasks/task_e_685d3b458ddc832b8c88e715218294ad