### PR TITLE
Fix map page import and include jobs in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,6 @@ COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/migrations ./migrations
+COPY --from=builder /app/src ./src
 EXPOSE 3000
 CMD ["npm", "start"]

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,6 +1,9 @@
 import { getCases } from "@/lib/caseStore";
 import { getOfficialCaseGps, getRepresentativePhoto } from "@/lib/caseUtils";
-import MapPageClient from "./MapPageClient";
+import nextDynamic from "next/dynamic";
+const MapPageClient = nextDynamic(() => import("./MapPageClient"), {
+  ssr: false,
+});
 
 export const dynamic = "force-dynamic";
 


### PR DESCRIPTION
## Summary
- dynamically import map client component to avoid server-side `window` usage
- include job sources in Docker runtime image

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke` *(fails: terminated due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_685d4d0408ec832baf29542ad0ab9111