### PR TITLE
Fix missing workers and map error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,7 @@ COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/migrations ./migrations
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/src/jobs ./src/jobs
 EXPOSE 3000
 CMD ["npm", "start"]

--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -3,9 +3,8 @@ import * as L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import ThumbnailImage from "@/components/thumbnail-image";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import type React from "react";
 import {
   MapContainer,
@@ -37,13 +36,6 @@ const markerSvg = `
   </svg>
 `;
 
-const markerIcon = L.divIcon({
-  html: markerSvg,
-  className: "",
-  iconSize: [25, 41],
-  iconAnchor: [12.5, 41],
-});
-
 export interface MapCase {
   id: string;
   gps: { lat: number; lon: number };
@@ -65,6 +57,16 @@ function FitBounds({ cases }: { cases: MapCase[] }) {
 
 export default function MapPageClient({ cases }: { cases: MapCase[] }) {
   const router = useRouter();
+  const markerIcon = useMemo(
+    () =>
+      L.divIcon({
+        html: markerSvg,
+        className: "",
+        iconSize: [25, 41],
+        iconAnchor: [12.5, 41],
+      }),
+    [],
+  );
   return (
     <MapContainerAny
       style={{ height: "calc(100vh - 4rem)", width: "100%" }}


### PR DESCRIPTION
## Summary
- include `public` assets and `src/jobs` in the runtime Docker image
- lazily create Leaflet markers to avoid `window is not defined`

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`

------
https://chatgpt.com/codex/tasks/task_e_685d4d0408ec832baf29542ad0ab9111