### PR TITLE
Add Docker layer caching

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,4 +22,6 @@ jobs:
           context: .
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/photo-to-citation:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 

--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ with prebuilt Node.js binaries.
 When commits land on `main`, the `docker-build.yml` workflow pushes the image to
 GitHub Container Registry as `ghcr.io/<OWNER>/photo-to-citation:latest`. Point
 Watchtower at this tag so your Synology NAS automatically pulls updates and redeploys.
+The workflow caches build layers with GitHub Actions so subsequent runs reuse these layers and finish faster.
 The `docker-build-photo-citation.yml` workflow publishes a second image tagged
 `photo-citation` for NAS deployments requiring `NEXT_PUBLIC_BASE_PATH=/photo-citation`.
 


### PR DESCRIPTION
## Summary
- enable layer caching in docker-build workflow
- note in README that builds are cached on GitHub Actions

## Testing
- `npm run format`
- `npm run lint`
- `npm test -- --bail 1`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685d76447054832b8662e5875e90abf4