### PR TITLE
Improve Docker build caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Install dependencies only, no dev dependencies after build
 FROM node:20-bookworm AS deps
 WORKDIR /app
-COPY package.json ./
+COPY package.json package-lock.json ./
 RUN npm install
 
 # Build the application


### PR DESCRIPTION
## Summary
- copy `package-lock.json` when installing dependencies in Docker

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685d76d578d0832b9ca0cc894f8c79a5