### PR TITLE
Fix React Hook order in upload flows

### DIFF
--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -24,7 +24,9 @@ export default function PointAndShootPage() {
   const [uploading, setUploading] = useState(false);
   const params = useSearchParams();
   const caseId = params.get("case") || null;
-  const uploadCase = caseId ? useAddFilesToCase(caseId) : useNewCaseFromFiles();
+  const addFilesToCase = useAddFilesToCase(caseId ?? "");
+  const newCase = useNewCaseFromFiles();
+  const uploadCase = caseId ? addFilesToCase : newCase;
 
   useEffect(() => {
     async function startCamera() {

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -7,7 +7,9 @@ import { useSearchParams } from "next/navigation";
 export default function UploadPage() {
   const params = useSearchParams();
   const caseId = params.get("case");
-  const uploadCase = caseId ? useAddFilesToCase(caseId) : useNewCaseFromFiles();
+  const addFilesToCase = useAddFilesToCase(caseId ?? "");
+  const newCase = useNewCaseFromFiles();
+  const uploadCase = caseId ? addFilesToCase : newCase;
   return (
     <div className="p-8">
       <input


### PR DESCRIPTION
## Summary
- ensure hooks are always called in the same order for upload pages

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685d7b8e6d64832bbaa9bf2aaa73607a