### PR TITLE
Fix React Hooks order

### DIFF
--- a/src/app/cases/[id]/components/PhotoSection.tsx
+++ b/src/app/cases/[id]/components/PhotoSection.tsx
@@ -27,7 +27,6 @@ export default function PhotoSection({
     analysisActive,
     isPhotoReanalysis,
   } = useCaseProgress(reanalyzingPhoto);
-  if (!caseData) return null;
   const [hasCamera, setHasCamera] = useState(false);
   useEffect(() => {
     if (
@@ -38,6 +37,7 @@ export default function PhotoSection({
       setHasCamera(true);
     }
   }, []);
+  if (!caseData) return null;
   const photoNote = selectedPhoto
     ? caseData.photoNotes?.[selectedPhoto] || ""
     : "";


### PR DESCRIPTION
## Summary
- ensure `PhotoSection` calls hooks before returning early to satisfy React's rules of hooks

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685d7b8e6d64832bbaa9bf2aaa73607a