### PR TITLE
Fix missing modules in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,6 @@ COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/migrations ./migrations
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/src/jobs ./src/jobs
+COPY --from=builder /app/src/lib ./src/lib
 EXPOSE 3000
 CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- copy `src/lib` during Docker build so worker threads can load libraries at runtime

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685d992a6964832bb2f033ab38dc7f3f