### PR TITLE
Fix mobile map header

### DIFF
--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -21,7 +21,7 @@ export default function NavBar() {
     );
   }
   return (
-    <nav className="py-4 px-8 flex items-center justify-between bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+    <nav className="py-4 px-8 flex items-center justify-between bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 sticky top-0 z-10">
       <Link
         href="/"
         className="text-lg font-semibold hover:text-gray-600 dark:hover:text-gray-300"

--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -69,7 +69,7 @@ export default function MapPageClient({ cases }: { cases: MapCase[] }) {
   );
   return (
     <MapContainerAny
-      style={{ height: "calc(100vh - 4rem)", width: "100%" }}
+      style={{ height: "calc(100dvh - 4rem)", width: "100%" }}
       center={[0, 0] as [number, number]}
       zoom={2}
       scrollWheelZoom={true}


### PR DESCRIPTION
## Summary
- keep NavBar fixed on scroll so it doesn't get hidden
- size map using `100dvh` so the header stays visible on mobile

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685dc1b305bc832b892f73f213dc576c