### PR TITLE
Add chat widget components

### DIFF
--- a/src/app/cases/[id]/camera/TakePhotoWidget.tsx
+++ b/src/app/cases/[id]/camera/TakePhotoWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 import useAddFilesToCase from "@/app/useAddFilesToCase";
 import { useEffect, useRef, useState } from "react";
+import { ChatWidget, WidgetActions } from "../widgets";
 
 export default function TakePhotoWidget({
   caseId,
@@ -71,13 +72,13 @@ export default function TakePhotoWidget({
   }
 
   return (
-    <div className="bg-blue-600 text-white px-2 py-1 rounded mx-1 text-xs space-y-1 w-48">
+    <ChatWidget className="w-48">
       <video ref={videoRef} className="w-full h-32 bg-black rounded">
         <track kind="captions" label="" />
       </video>
       <canvas ref={canvasRef} className="hidden" />
       {error && <div className="text-red-200 text-center">{error}</div>}
-      <div className="flex gap-1 justify-center">
+      <WidgetActions centered>
         <button
           type="button"
           onClick={takePicture}
@@ -93,7 +94,7 @@ export default function TakePhotoWidget({
         >
           Close
         </button>
-      </div>
-    </div>
+      </WidgetActions>
+    </ChatWidget>
   );
 }

--- a/src/app/cases/[id]/draft/DraftPreview.tsx
+++ b/src/app/cases/[id]/draft/DraftPreview.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useNotify } from "../../../components/NotificationProvider";
+import { ChatWidget, WidgetActions } from "../widgets";
 
 interface DraftData {
   email: EmailDraft;
@@ -82,7 +83,7 @@ export default function DraftPreview({
           ))}
         </div>
       )}
-      <div className="flex gap-1 flex-wrap">
+      <WidgetActions wrap>
         <button
           type="button"
           onClick={send}
@@ -104,12 +105,12 @@ export default function DraftPreview({
         >
           Full Editor
         </Link>
-      </div>
+      </WidgetActions>
     </div>
   );
 
   return (
-    <div className="bg-blue-600 text-white px-2 py-1 rounded mx-1 text-xs space-y-1">
+    <ChatWidget>
       <Tooltip label={tooltipContent} interactive>
         <button
           type="button"
@@ -119,7 +120,7 @@ export default function DraftPreview({
           <strong>{data.email.subject}</strong> {previewBody}
         </button>
       </Tooltip>
-      <div className="flex gap-1">
+      <WidgetActions>
         <button
           type="button"
           onClick={send}
@@ -135,7 +136,7 @@ export default function DraftPreview({
         >
           Close
         </button>
-      </div>
-    </div>
+      </WidgetActions>
+    </ChatWidget>
   );
 }

--- a/src/app/cases/[id]/widgets/ChatWidget.tsx
+++ b/src/app/cases/[id]/widgets/ChatWidget.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+export default function ChatWidget({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`bg-blue-600 text-white px-2 py-1 rounded mx-1 text-xs space-y-1 ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/app/cases/[id]/widgets/WidgetActions.tsx
+++ b/src/app/cases/[id]/widgets/WidgetActions.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+export default function WidgetActions({
+  children,
+  centered = false,
+  wrap = false,
+}: {
+  children: ReactNode;
+  centered?: boolean;
+  wrap?: boolean;
+}) {
+  const classes = ["flex", "gap-1"];
+  if (centered) classes.push("justify-center");
+  if (wrap) classes.push("flex-wrap");
+  return <div className={classes.join(" ")}>{children}</div>;
+}

--- a/src/app/cases/[id]/widgets/index.ts
+++ b/src/app/cases/[id]/widgets/index.ts
@@ -1,0 +1,2 @@
+export { default as ChatWidget } from "./ChatWidget";
+export { default as WidgetActions } from "./WidgetActions";


### PR DESCRIPTION
## Summary
- factor camera and draft preview into chat widgets
- standardize widget actions layout

## Testing
- `npm run lint`
- `npm test` *(fails: Could not locate the bindings file for better-sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_685dc12c6bd0832bb46b8612e55d1f86