### PR TITLE
Add icon-only back buttons

### DIFF
--- a/src/app/cases/[id]/components/CaseHeader.tsx
+++ b/src/app/cases/[id]/components/CaseHeader.tsx
@@ -3,7 +3,7 @@ import CaseToolbar from "@/app/components/CaseToolbar";
 import { useSession } from "@/app/useSession";
 import { getCaseOwnerContact, hasViolation } from "@/lib/caseUtils";
 import Link from "next/link";
-import { FaShare } from "react-icons/fa";
+import { FaArrowLeft, FaShare } from "react-icons/fa";
 import { useCaseContext } from "../CaseContext";
 import useCaseActions from "../useCaseActions";
 import useCaseProgress from "../useCaseProgress";
@@ -25,8 +25,12 @@ export default function CaseHeader({
   return (
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-2">
-        <Link href="/cases" className="text-blue-500 underline md:hidden">
-          Back to Cases
+        <Link
+          href="/cases"
+          aria-label="Back to Cases"
+          className="md:hidden text-xl p-2 text-blue-500 hover:text-blue-700"
+        >
+          <FaArrowLeft />
         </Link>
         <h1 className="text-xl font-semibold">Case {caseData.id}</h1>
         {caseData.public ? (

--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
+import { FaArrowLeft } from "react-icons/fa";
 import { useNotify } from "../../../components/NotificationProvider";
 import useCase, { caseQueryKey } from "../../../hooks/useCase";
 
@@ -97,8 +98,12 @@ export default function ClientThreadPage({
     <div className="p-8 flex flex-col gap-4">
       <div className="sticky top-0 bg-white dark:bg-gray-900 z-10 flex justify-between items-center border-b pb-2">
         <div className="flex items-center gap-2">
-          <Link href={`/cases/${caseId}`} className="text-blue-500 underline">
-            Back to Case
+          <Link
+            href={`/cases/${caseId}`}
+            aria-label="Back to Case"
+            className="text-xl p-2 text-blue-500 hover:text-blue-700"
+          >
+            <FaArrowLeft />
           </Link>
           <h1 className="text-xl font-semibold">Thread</h1>
         </div>


### PR DESCRIPTION
## Summary
- change `Back to Cases` link to arrow icon-only button
- style thread page back link similarly

## Testing
- `npm test`
- `npm run e2e:smoke` *(fails: MODULE_NOT_FOUND 'next/dist/telemetry/flush-and-exit.js')*

------
https://chatgpt.com/codex/tasks/task_e_685de002679c832baf749ad43bbfea49