### PR TITLE
fix sign-in link text

### DIFF
--- a/src/app/signin/__tests__/SignInPage.test.tsx
+++ b/src/app/signin/__tests__/SignInPage.test.tsx
@@ -34,7 +34,9 @@ describe("SignInPage", () => {
   it("links to marketing website", () => {
     mockGet.mockReturnValueOnce(null);
     render(<SignInPage />);
-    const link = screen.getByRole("link", { name: /back to website/i });
+    const link = screen.getByRole("link", {
+      name: /learn more about photo to citation/i,
+    });
     expect(link).toHaveAttribute(
       "href",
       "https://antialias.github.io/photo-to-citation/website/",

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -54,7 +54,7 @@ export default function SignInPage() {
         </button>
       </form>
       <a href={MARKETING_URL} className="underline mt-2">
-        Back to Website
+        Learn more about Photo to Citation
       </a>
     </>
   );


### PR DESCRIPTION
## Summary
- update the sign-in page text for the marketing site link
- adjust tests to match new text

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685de29ed3a4832b935909741c1c3d60