### PR TITLE
Overlay hint over camera

### DIFF
--- a/docs/feature-outline.md
+++ b/docs/feature-outline.md
@@ -113,9 +113,9 @@ before being stored in the case record.
 The mobile `/point` page performs a quick pass using a lightweight WASM model
 running in a Web Worker. Each captured frame is evaluated locally so the user
 gets instant feedback on the likely violation type or detected license plate
-numbers. These hints appear below the camera view while the image uploads in
-the background. The final server‑side OpenAI workflow refines the results once
-the photo reaches the server.
+numbers. These hints appear centered over the camera view with a translucent
+background while the image uploads in the background. The final server‑side
+OpenAI workflow refines the results once the photo reaches the server.
 
 ### 4.3 Handling Errors
 

--- a/src/app/__tests__/point.test.tsx
+++ b/src/app/__tests__/point.test.tsx
@@ -20,4 +20,9 @@ describe("Point and Shoot page", () => {
     render(<PointAndShootPage />);
     expect(screen.getByText("Cases")).toBeInTheDocument();
   });
+
+  it("shows default hint when nothing detected", () => {
+    render(<PointAndShootPage />);
+    expect(screen.getByText("Nothing has been detected")).toBeInTheDocument();
+  });
 });

--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -158,6 +158,14 @@ export default function PointAndShootPage() {
           Uploading photo...
         </div>
       ) : null}
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
+        <div
+          className="bg-black/40 text-white px-2 py-1 rounded text-xl"
+          data-testid="hint"
+        >
+          {analysisHint ?? "Nothing has been detected"}
+        </div>
+      </div>
       <div className="absolute inset-0 flex flex-col items-center justify-end gap-2 p-4 pointer-events-none">
         <input
           ref={inputRef}
@@ -183,23 +191,6 @@ export default function PointAndShootPage() {
         >
           Take Picture
         </button>
-        {!analysisHint && (
-          <div
-            className="pointer-events-none text-white text-sm text-center"
-            data-testid="instructions"
-          >
-            Point your camera at the vehicle. We&apos;ll guess the plate or
-            violation below.
-          </div>
-        )}
-        {analysisHint && (
-          <div
-            className="pointer-events-none text-white text-sm"
-            data-testid="hint"
-          >
-            {analysisHint}
-          </div>
-        )}
         <Link
           href={caseId ? `/cases/${caseId}` : "/cases"}
           className="pointer-events-auto text-xs text-white underline mt-2"


### PR DESCRIPTION
## Summary
- center the point-and-shoot analysis hint over the camera view
- update docs to explain the new overlay
- test for default hint text when no detection

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npx vitest run -c vitest.e2e.config.ts --testNamePattern "@smoke"` *(fails: E2E tests didn't finish due to environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_685df0afb318832b9455cc68c883316f