### PR TITLE
Fix flappy caseStore test by using unique IDs

### DIFF
--- a/src/app/useNewCaseFromFiles.ts
+++ b/src/app/useNewCaseFromFiles.ts
@@ -14,7 +14,7 @@ export default function useNewCaseFromFiles() {
   });
   return async (files: FileList | null) => {
     if (!files || files.length === 0) return;
-    const id = Date.now().toString();
+    const id = crypto.randomUUID();
     const preview = URL.createObjectURL(files[0]);
     sessionStorage.setItem(`preview-${id}`, preview);
     const results = await Promise.all(

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import path from "node:path";
 import { eq, sql } from "drizzle-orm";
 import { caseEvents } from "./caseEvents";
@@ -283,7 +284,7 @@ export function createCase(
   sessionId?: string | null,
 ): Case {
   const newCase: Case = {
-    id: id ?? Date.now().toString(),
+    id: id ?? crypto.randomUUID(),
     photos: [photo],
     photoTimes: { [photo]: takenAt ?? null },
     photoGps: { [photo]: gps },


### PR DESCRIPTION
## Summary
- generate unique IDs with crypto.randomUUID
- use random UUID for new case creation in client hook

## Testing
- `npm run lint`
- `npm test --silent`
- `npm run e2e:smoke --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e94f3a910832b87c30c169ee2d7de