### PR TITLE
Fix 'window is not defined' during map page SSR

### DIFF
--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,6 +1,13 @@
 import { getCases } from "@/lib/caseStore";
 import { getOfficialCaseGps, getRepresentativePhoto } from "@/lib/caseUtils";
-import MapPageClient from "./MapPageClient";
+import nextDynamic from "next/dynamic";
+
+// Leaflet relies on the `window` object which isn't available on the server.
+// Dynamically import the client component to ensure it only loads in the
+// browser.
+const MapPageClient = nextDynamic(() => import("./MapPageClient"), {
+  ssr: false,
+});
 
 export const dynamic = "force-dynamic";
 


### PR DESCRIPTION
## Summary
- dynamically import the map client page so Leaflet isn't loaded on the server

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685e9eb8a154832bbcbe23bf560d230f