### PR TITLE
Compile worker jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ARG NEXT_PUBLIC_BASE_PATH=""
 ENV NEXT_PUBLIC_BASE_PATH=$NEXT_PUBLIC_BASE_PATH
-RUN npm run build && npm prune --production
+RUN npm run build && npm run build:jobs && npm prune --production
 
 # Runtime image
 FROM node:20-bookworm AS runner
@@ -27,7 +27,7 @@ COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/tsconfig.generated.json ./tsconfig.generated.json
 COPY --from=builder /app/migrations ./migrations
 COPY --from=builder /app/public ./public
-COPY --from=builder /app/src/jobs ./src/jobs
+COPY --from=builder /app/dist/jobs ./dist/jobs
 COPY --from=builder /app/src/lib ./src/lib
 EXPOSE 3000
 CMD ["npm", "start"]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build:jobs": "tsc -p tsconfig.jobs.json",
+    "build": "npm run build:jobs && next build",
     "start": "next start",
     "lint": "biome check .",
     "format": "biome format . --write",
@@ -72,8 +73,6 @@
     "react-leaflet": "^5.0.0",
     "react-mermaid2": "^0.1.4",
     "sharp": "^0.34.2",
-    "ts-node": "^10.9.2",
-    "tsconfig-paths": "^4.2.0",
     "twilio": "^4.23.0",
     "umzug": "^3.8.2",
     "zod": "^3.23.8",
@@ -110,6 +109,8 @@
     "storycap": "^3.1.0",
     "tailwindcss": "^4",
     "ts-to-zod": "^3.15.0",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^3.2.3"

--- a/src/lib/jobScheduler.ts
+++ b/src/lib/jobScheduler.ts
@@ -71,11 +71,15 @@ export function runJob(
   jobData: unknown,
   opts?: { caseId?: string },
 ): Worker {
-  const jobPath = path.join(process.cwd(), "src", "jobs", `${name}.ts`);
-  const wrapper = path.join(process.cwd(), "src", "jobs", "workerWrapper.js");
-  const worker = new Worker(wrapper, {
-    workerData: { path: jobPath, jobData },
-  });
+  const isProd = process.env.NODE_ENV === "production";
+  const jobPath = isProd
+    ? path.join(process.cwd(), "dist", "jobs", `${name}.js`)
+    : path.join(process.cwd(), "src", "jobs", `${name}.ts`);
+  const worker = isProd
+    ? new Worker(jobPath, { workerData: { jobData } })
+    : new Worker(path.join(process.cwd(), "src", "jobs", "workerWrapper.js"), {
+        workerData: { path: jobPath, jobData },
+      });
   activeJobs.set(worker.threadId, {
     type: name,
     worker,

--- a/tsconfig.jobs.json
+++ b/tsconfig.jobs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/jobs",
+    "module": "CommonJS",
+    "noEmit": false,
+    "rootDir": "src/jobs"
+  },
+  "include": ["src/jobs/*.ts"]
+}


### PR DESCRIPTION
## Summary
- compile `src/jobs` to CommonJS in `dist/jobs`
- move worker TS helper deps to devDependencies
- build jobs in Dockerfile and copy compiled output
- load compiled workers in production via jobScheduler

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685ea90e786c832ba87be3fcead80ce8