### PR TITLE
Improve npm caching reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
-      - run: npm ci
+      - name: Install dependencies
+        run: |
+          npm ci || (npm cache clean --force && npm ci)
       - run: npm run lint
       - run: npm run typecheck
 
@@ -28,7 +30,9 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
-      - run: npm ci
+      - name: Install dependencies
+        run: |
+          npm ci || (npm cache clean --force && npm ci)
       - run: npm test -- --bail 1
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
@@ -42,7 +46,9 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
-      - run: npm ci
+      - name: Install dependencies
+        run: |
+          npm ci || (npm cache clean --force && npm ci)
       - run: npm run e2e -- --bail 1
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
@@ -61,7 +67,9 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
-      - run: npm ci
+      - name: Install dependencies
+        run: |
+          npm ci || (npm cache clean --force && npm ci)
       - run: npm run build-storybook
         env:
           STORYBOOK_DISABLE_TELEMETRY: "1"

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -25,7 +25,9 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-      - run: npm ci
+      - name: Install dependencies
+        run: |
+          npm ci || (npm cache clean --force && npm ci)
       - run: npm run website
         env:
           PATH_PREFIX: /photo-to-citation/website/


### PR DESCRIPTION
## Summary
- retry `npm ci` after cleaning cache to avoid `ETXTBSY`

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685e9db78ed0832b855b6152141d0ff7