### PR TITLE
Fix JSDOM imports for build

### DIFF
--- a/.storybook/routerDecorator.tsx
+++ b/.storybook/routerDecorator.tsx
@@ -1,5 +1,5 @@
 "use client";
-import type { Decorator } from "@storybook/react";
+import type { Decorator, StoryFn } from "@storybook/react";
 import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import {
   PathParamsContext,
@@ -16,7 +16,7 @@ const router = {
   prefetch: () => Promise.resolve(),
 };
 
-export const withRouter: Decorator = (Story) => (
+export const withRouter: Decorator = (Story: StoryFn) => (
   <AppRouterContext.Provider value={router}>
     <PathnameContext.Provider value="/">
       <SearchParamsContext.Provider value={new URLSearchParams()}>

--- a/scripts/generateWebsiteImages.ts
+++ b/scripts/generateWebsiteImages.ts
@@ -3,7 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 
 import dotenv from "dotenv";
-import { JSDOM } from "jsdom";
+import jsdom from "jsdom";
+const { JSDOM } = jsdom;
 import OpenAI from "openai";
 import type { ImageGenerateParams } from "openai/resources/images";
 import sharp from "sharp";

--- a/src/lib/vinLookup.ts
+++ b/src/lib/vinLookup.ts
@@ -1,4 +1,5 @@
-import { JSDOM } from "jsdom";
+import jsdom from "jsdom";
+const { JSDOM } = jsdom;
 import type { Case } from "./caseStore";
 import { updateCase } from "./caseStore";
 import { runJob } from "./jobScheduler";


### PR DESCRIPTION
## Summary
- fix Storybook router decorator type for `Story`
- update jsdom imports in `generateWebsiteImages` and `vinLookup`

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685eda25dc8c832bae83e74b5bc33fe7