### PR TITLE
Fix jsdom import

### DIFF
--- a/scripts/generateWebsiteImages.ts
+++ b/scripts/generateWebsiteImages.ts
@@ -3,7 +3,9 @@ import fs from "node:fs";
 import path from "node:path";
 
 import dotenv from "dotenv";
-import { JSDOM } from "jsdom";
+import jsdom from "jsdom";
+
+const { JSDOM } = jsdom;
 import OpenAI from "openai";
 import type { ImageGenerateParams } from "openai/resources/images";
 import sharp from "sharp";


### PR DESCRIPTION
## Summary
- import jsdom in website image generation script using a default import

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685eda25dc8c832bae83e74b5bc33fe7