### PR TITLE
fix: disable image optimization for dynamic images

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -233,6 +233,7 @@ export default function ClientCasesPage({
                         alt="case thumbnail"
                         width={80}
                         height={60}
+                        unoptimized
                       />
                     ) : null;
                   })()}

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -48,6 +48,7 @@ function ClientCasePage({
             alt="preview"
             className="max-w-full"
             fill
+            unoptimized
             sizes="100vw"
           />
         ) : null}

--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -172,6 +172,7 @@ export default function ClientThreadPage({
                 src={viewImage}
                 alt="scan full size"
                 fill
+                unoptimized
                 className="object-contain"
               />
             </div>

--- a/src/app/components/MapPreview.tsx
+++ b/src/app/components/MapPreview.tsx
@@ -39,6 +39,7 @@ export default function MapPreview({
         src={url}
         alt={`Map preview at ${lat}, ${lon}`}
         fill
+        unoptimized
         className="object-cover"
         sizes="100vw"
       />

--- a/src/app/components/ZoomableImage.tsx
+++ b/src/app/components/ZoomableImage.tsx
@@ -158,6 +158,7 @@ export default function ZoomableImage({ src, alt }: Props) {
         src={src}
         alt={alt}
         fill
+        unoptimized
         ref={imgRef}
         onLoadingComplete={(img) =>
           setNaturalSize({ width: img.naturalWidth, height: img.naturalHeight })


### PR DESCRIPTION
## Summary
- disable Next.js image optimization for runtime-generated images

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke` *(fails: Test timed out)*
- `docker build -t test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efd193178832ba578601374294f9d