### PR TITLE
Replace Next.js Image with standard img

### DIFF
--- a/.storybook/MapPreviewStub.tsx
+++ b/.storybook/MapPreviewStub.tsx
@@ -1,5 +1,3 @@
-import Image from "next/image";
-
 export default function MapPreviewStub({
   width,
   height,
@@ -10,11 +8,12 @@ export default function MapPreviewStub({
       className={className ?? ""}
       style={{ aspectRatio: `${width} / ${height}` }}
     >
-      <Image
+      <img
         src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='150'%3E%3Crect width='100%25' height='100%25' fill='%23ddd'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23666' font-family='sans-serif' font-size='20'%3EMap Preview%3C/text%3E%3C/svg%3E"
         alt="Map preview placeholder"
         width={width}
         height={height}
+        loading="lazy"
       />
     </div>
   );

--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -6,7 +6,6 @@ import useNewCaseFromFiles from "@/app/useNewCaseFromFiles";
 import type { Case } from "@/lib/caseStore";
 import { getOfficialCaseGps, getRepresentativePhoto } from "@/lib/caseUtils";
 import { distanceBetween } from "@/lib/distance";
-import Image from "next/image";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useNotify } from "../components/NotificationProvider";
@@ -228,12 +227,12 @@ export default function ClientCasesPage({
                   {(() => {
                     const photo = getRepresentativePhoto(c);
                     return photo ? (
-                      <Image
+                      <img
                         src={photo}
                         alt="case thumbnail"
                         width={80}
                         height={60}
-                        unoptimized
+                        loading="lazy"
                       />
                     ) : null;
                   })()}

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -7,7 +7,6 @@ import CaseProgressGraph from "@/app/components/CaseProgressGraph";
 import DebugWrapper from "@/app/components/DebugWrapper";
 import { useSession } from "@/app/useSession";
 import type { Case } from "@/lib/caseStore";
-import Image from "next/image";
 import { useEffect, useState } from "react";
 import { CaseProvider, useCaseContext } from "./CaseContext";
 import CaseDetails from "./components/CaseDetails";
@@ -43,13 +42,11 @@ function ClientCasePage({
       <div className="p-8 flex flex-col gap-4">
         <h1 className="text-xl font-semibold">Uploading...</h1>
         {preview ? (
-          <Image
+          <img
             src={preview}
             alt="preview"
             className="max-w-full"
-            fill
-            unoptimized
-            sizes="100vw"
+            loading="lazy"
           />
         ) : null}
         <p className="text-sm text-gray-500 dark:text-gray-400">

--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -4,7 +4,6 @@ import ThumbnailImage from "@/components/thumbnail-image";
 import type { Case, SentEmail, ThreadImage } from "@/lib/caseStore";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import { useQueryClient } from "@tanstack/react-query";
-import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { FaArrowLeft } from "react-icons/fa";
@@ -168,12 +167,11 @@ export default function ClientThreadPage({
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
           <div className="bg-white dark:bg-gray-900 rounded shadow max-w-3xl w-full">
             <div className="relative w-full h-[80vh]">
-              <Image
+              <img
                 src={viewImage}
                 alt="scan full size"
-                fill
-                unoptimized
-                className="object-contain"
+                className="object-contain absolute inset-0 w-full h-full"
+                loading="lazy"
               />
             </div>
             <div className="flex justify-end p-2">

--- a/src/app/components/MapPreview.tsx
+++ b/src/app/components/MapPreview.tsx
@@ -1,5 +1,4 @@
 import { config } from "@/lib/config";
-import Image from "next/image";
 
 export default function MapPreview({
   lat,
@@ -35,13 +34,11 @@ export default function MapPreview({
           <span className="sr-only">View on map</span>
         </a>
       ) : null}
-      <Image
+      <img
         src={url}
         alt={`Map preview at ${lat}, ${lon}`}
-        fill
-        unoptimized
-        className="object-cover"
-        sizes="100vw"
+        className="object-cover absolute inset-0 w-full h-full"
+        loading="lazy"
       />
     </div>
   );

--- a/src/app/components/ZoomableImage.tsx
+++ b/src/app/components/ZoomableImage.tsx
@@ -1,5 +1,4 @@
 "use client";
-import Image from "next/image";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 export interface Transform {
@@ -154,17 +153,19 @@ export default function ZoomableImage({ src, alt }: Props) {
       onPointerUp={handlePointerUp}
       onPointerCancel={handlePointerUp}
     >
-      <Image
+      <img
         src={src}
         alt={alt}
-        fill
-        unoptimized
         ref={imgRef}
-        onLoadingComplete={(img) =>
-          setNaturalSize({ width: img.naturalWidth, height: img.naturalHeight })
+        onLoad={(e) =>
+          setNaturalSize({
+            width: (e.currentTarget as HTMLImageElement).naturalWidth,
+            height: (e.currentTarget as HTMLImageElement).naturalHeight,
+          })
         }
         draggable={false}
-        className="object-contain select-none"
+        className="object-contain select-none absolute inset-0 w-full h-full"
+        loading="lazy"
         style={{
           transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
           transformOrigin: "0 0",

--- a/src/components/thumbnail-image.tsx
+++ b/src/components/thumbnail-image.tsx
@@ -1,8 +1,12 @@
-import Image from "next/image";
-import { useEffect, useState } from "react";
+import { type ImgHTMLAttributes, useEffect, useState } from "react";
 
 export interface ThumbnailImageProps
-  extends React.ComponentPropsWithoutRef<typeof Image> {
+  extends Omit<
+    ImgHTMLAttributes<HTMLImageElement>,
+    "src" | "width" | "height" | "alt"
+  > {
+  src: string;
+  alt: string;
   width: number;
   height: number;
   imgClassName?: string;
@@ -36,15 +40,16 @@ export default function ThumbnailImage({
           <div className="w-6 h-6 border-2 border-gray-500 border-t-transparent rounded-full animate-spin" />
         </div>
       )}
-      <Image
-        unoptimized
+      {/* biome-ignore lint/a11y/useAltText: alt text provided via props */}
+      <img
         src={`${src}${attempt ? `?${attempt}` : ""}`}
-        alt={alt}
+        alt={alt ?? ""}
         width={width}
         height={height}
         onLoad={() => setReady(true)}
         onError={() => setReady(false)}
         className={`object-cover max-w-full max-h-full ${imgClassName ?? ""} ${ready ? "" : "invisible"}`}
+        loading="lazy"
         {...props}
       />
     </div>


### PR DESCRIPTION
## Summary
- remove `next/image` imports
- use standard `<img>` tags across components
- add lazy loading attributes to reduce network usage

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke` *(fails: environment issue)*

------
https://chatgpt.com/codex/tasks/task_e_685f0ec330dc832bad7b49ff3ef2e329