### PR TITLE
Fix runtime uploads path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ storybook-static
 storybook-screenshots
 coverage
 *.tsbuildinfo
-public/uploads
+/uploads
 
 .terraform/
 terraform.tfstate*

--- a/src/app/api/cases/[id]/thread-images/route.ts
+++ b/src/app/api/cases/[id]/thread-images/route.ts
@@ -29,7 +29,7 @@ export const POST = withCaseAuthorization(
     const bytes = await file.arrayBuffer();
     const buffer = Buffer.from(bytes);
     const ext = path.extname(file.name || "jpg") || ".jpg";
-    const uploadDir = path.join(process.cwd(), "public", "uploads");
+    const uploadDir = path.join(process.cwd(), "uploads");
     fs.mkdirSync(uploadDir, { recursive: true });
     const filename = `${crypto.randomUUID()}${ext}`;
     fs.writeFileSync(path.join(uploadDir, filename), buffer);

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -56,7 +56,7 @@ export const POST = withAuthorization(
 
     const gps = extractGps(buffer);
     const takenAt = extractTimestamp(buffer);
-    const uploadDir = path.join(process.cwd(), "public", "uploads");
+    const uploadDir = path.join(process.cwd(), "uploads");
     fs.mkdirSync(uploadDir, { recursive: true });
     const ext = path.extname(file.name || "jpg") || ".jpg";
     const filename = `${crypto.randomUUID()}${ext}`;

--- a/src/app/uploads/[...path]/route.ts
+++ b/src/app/uploads/[...path]/route.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const { path: segments } = await params;
+  const uploads = path.join(process.cwd(), "uploads");
+  const full = path.join(uploads, ...segments);
+  if (!full.startsWith(uploads)) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  try {
+    const data = await fs.readFile(full);
+    const ext = path.extname(full).toLowerCase();
+    const contentType =
+      ext === ".png"
+        ? "image/png"
+        : ext === ".webp"
+          ? "image/webp"
+          : ext === ".jpg" || ext === ".jpeg"
+            ? "image/jpeg"
+            : "application/octet-stream";
+    return new NextResponse(data, {
+      headers: { "Content-Type": contentType },
+    });
+  } catch {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+}

--- a/src/lib/contactMethods.ts
+++ b/src/lib/contactMethods.ts
@@ -134,7 +134,7 @@ export async function sendSnailMail(options: {
     y -= fontSize * 1.2;
   }
   for (const att of options.attachments) {
-    const abs = path.join(process.cwd(), "public", att.replace(/^\/+/, ""));
+    const abs = path.join(process.cwd(), att.replace(/^\/+/, ""));
     if (!fs.existsSync(abs)) continue;
     const bytes = fs.readFileSync(abs);
     const ext = path.extname(abs).toLowerCase();

--- a/src/lib/inboxScanner.ts
+++ b/src/lib/inboxScanner.ts
@@ -49,7 +49,7 @@ export async function scanInbox(): Promise<void> {
         a.contentType.startsWith("image/"),
       );
       if (images.length > 0) {
-        const uploadDir = path.join(process.cwd(), "public", "uploads");
+        const uploadDir = path.join(process.cwd(), "uploads");
         fs.mkdirSync(uploadDir, { recursive: true });
         const casePhotos: string[] = [];
         const photoTimes: Record<string, string | null> = {};

--- a/src/lib/thumbnails.ts
+++ b/src/lib/thumbnails.ts
@@ -10,7 +10,7 @@ export async function generateThumbnails(
   filename: string,
 ): Promise<void> {
   const base = path.basename(filename);
-  const uploadDir = path.join(process.cwd(), "public", "uploads", "thumbs");
+  const uploadDir = path.join(process.cwd(), "uploads", "thumbs");
   try {
     await sharp(buffer).metadata();
   } catch (err) {

--- a/test/snailMailAttachments.test.ts
+++ b/test/snailMailAttachments.test.ts
@@ -66,18 +66,18 @@ beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "snail-"));
   root = fs.mkdtempSync(path.join(os.tmpdir(), "snailroot-"));
   cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(root);
-  fs.mkdirSync(path.join(root, "public", "uploads"), { recursive: true });
+  fs.mkdirSync(path.join(root, "uploads"), { recursive: true });
   const img = Buffer.from(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAEklEQVR42mP8/5+hHgAHggJ/P5V6XQAAAABJRU5ErkJggg==",
     "base64",
   );
-  fs.writeFileSync(path.join(root, "public", "uploads", "img.png"), img);
+  fs.writeFileSync(path.join(root, "uploads", "img.png"), img);
   process.env.RETURN_ADDRESS = "Me\n1 A St\nTown, ST 12345";
   process.env.SNAIL_MAIL_PROVIDER = "mock";
 });
 
 afterEach(() => {
-  fs.rmSync(path.join(root, "public", "uploads"), {
+  fs.rmSync(path.join(root, "uploads"), {
     recursive: true,
     force: true,
   });

--- a/test/uploadRoute.test.ts
+++ b/test/uploadRoute.test.ts
@@ -58,7 +58,7 @@ beforeEach(async () => {
   caseStore = await import("@/lib/caseStore");
   caseAnalysis = await import("@/lib/caseAnalysis");
   cancelSpy = vi.spyOn(caseAnalysis, "cancelCaseAnalysis");
-  fs.mkdirSync(path.join(process.cwd(), "public", "uploads"), {
+  fs.mkdirSync(path.join(process.cwd(), "uploads"), {
     recursive: true,
   });
   mod = await import("@/app/api/upload/route");
@@ -67,7 +67,7 @@ beforeEach(async () => {
 afterEach(() => {
   fs.rmSync(dataDir, { recursive: true, force: true });
   fs.rmSync(tmpDir, { recursive: true, force: true });
-  fs.rmSync(path.join(process.cwd(), "public", "uploads"), {
+  fs.rmSync(path.join(process.cwd(), "uploads"), {
     recursive: true,
     force: true,
   });


### PR DESCRIPTION
## Summary
- serve uploaded files via dynamic API route
- store upload files outside `public` directory
- adjust thumbnail generation and inbox scanner
- update tests and gitignore for new uploads path

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685f25432cd8832b988e26156bbed52c