### PR TITLE
Fix language switcher

### DIFF
--- a/src/app/LoggedOutLanding.tsx
+++ b/src/app/LoggedOutLanding.tsx
@@ -1,50 +1,7 @@
 import { getLandingStats } from "@/lib/stats";
-import i18n from "../i18n";
+import LoggedOutLandingClient from "./LoggedOutLandingClient";
 
-function formatCount(n: number): string {
-  if (n < 10) return n.toString();
-  const digits = Math.floor(Math.log10(n));
-  const base = 10 ** digits;
-  return `>${Math.floor(n / base) * base}`;
-}
-
-export default async function LoggedOutLanding() {
+export default function LoggedOutLanding() {
   const stats = getLandingStats();
-  return (
-    <main className="p-8 flex flex-col items-center text-center gap-6">
-      <h1 className="text-3xl font-bold">{i18n.t("title")}</h1>
-      <p className="text-lg max-w-xl">{i18n.t("landingDescription")}</p>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
-        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
-          <div className="text-2xl font-semibold">
-            {formatCount(stats.casesLastWeek)}
-          </div>
-          <div className="text-sm">{i18n.t("casesLastWeek")}</div>
-        </div>
-        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
-          <div className="text-2xl font-semibold">
-            {formatCount(stats.authorityNotifications)}
-          </div>
-          <div className="text-sm">{i18n.t("authorityNotifications")}</div>
-        </div>
-        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
-          <div className="text-2xl font-semibold">
-            {`<${Math.ceil(stats.avgDaysToNotification)} days`}
-          </div>
-          <div className="text-sm">{i18n.t("avgTimeToNotify")}</div>
-        </div>
-        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
-          <div className="text-2xl font-semibold">
-            {`>${Math.floor(stats.notificationSuccessRate * 100)}%`}
-          </div>
-          <div className="text-sm">{i18n.t("casesWithNotification")}</div>
-        </div>
-      </div>
-      <p className="mt-4">
-        <a href="/signin" className="text-blue-600 underline">
-          {i18n.t("signIn")}
-        </a>
-      </p>
-    </main>
-  );
+  return <LoggedOutLandingClient stats={stats} />;
 }

--- a/src/app/LoggedOutLandingClient.tsx
+++ b/src/app/LoggedOutLandingClient.tsx
@@ -1,0 +1,61 @@
+"use client";
+import { useTranslation } from "react-i18next";
+
+export interface LandingStats {
+  casesLastWeek: number;
+  authorityNotifications: number;
+  avgDaysToNotification: number;
+  notificationSuccessRate: number;
+}
+
+function formatCount(n: number): string {
+  if (n < 10) return n.toString();
+  const digits = Math.floor(Math.log10(n));
+  const base = 10 ** digits;
+  return `>${Math.floor(n / base) * base}`;
+}
+
+export default function LoggedOutLandingClient({
+  stats,
+}: {
+  stats: LandingStats;
+}) {
+  const { t } = useTranslation();
+  return (
+    <main className="p-8 flex flex-col items-center text-center gap-6">
+      <h1 className="text-3xl font-bold">{t("title")}</h1>
+      <p className="text-lg max-w-xl">{t("landingDescription")}</p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
+        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
+          <div className="text-2xl font-semibold">
+            {formatCount(stats.casesLastWeek)}
+          </div>
+          <div className="text-sm">{t("casesLastWeek")}</div>
+        </div>
+        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
+          <div className="text-2xl font-semibold">
+            {formatCount(stats.authorityNotifications)}
+          </div>
+          <div className="text-sm">{t("authorityNotifications")}</div>
+        </div>
+        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
+          <div className="text-2xl font-semibold">
+            {`<${Math.ceil(stats.avgDaysToNotification)} days`}
+          </div>
+          <div className="text-sm">{t("avgTimeToNotify")}</div>
+        </div>
+        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
+          <div className="text-2xl font-semibold">
+            {`>${Math.floor(stats.notificationSuccessRate * 100)}%`}
+          </div>
+          <div className="text-sm">{t("casesWithNotification")}</div>
+        </div>
+      </div>
+      <p className="mt-4">
+        <a href="/signin" className="text-blue-600 underline">
+          {t("signIn")}
+        </a>
+      </p>
+    </main>
+  );
+}

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -6,8 +6,8 @@ import * as Popover from "@radix-ui/react-popover";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { FaBars } from "react-icons/fa";
-import i18n from "../../i18n";
 import LanguageSwitcher from "./LanguageSwitcher";
 
 export default function NavBar() {
@@ -15,6 +15,7 @@ export default function NavBar() {
   const uploadCase = useNewCaseFromFiles();
   const inputRef = useRef<HTMLInputElement>(null);
   const { data: session } = useSession();
+  const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
   if (pathname.startsWith("/point")) {
     return (
@@ -136,7 +137,7 @@ export default function NavBar() {
         href="/"
         className="text-lg font-semibold hover:text-gray-600 dark:hover:text-gray-300"
       >
-        {i18n.t("title")}
+        {t("title")}
       </Link>
       <input
         type="file"


### PR DESCRIPTION
## Summary
- update NavBar to re-render translations on language change
- convert LoggedOutLanding into a server wrapper with a new client component for translation

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685f5942ebd8832ba4029b8999853ddf