### PR TITLE
Add French localization

### DIFF
--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -1,0 +1,9 @@
+{
+  "title": "Photo à Citation",
+  "landingDescription": "Prenez rapidement en photo les pistes cyclables ou trottoirs obstrués et laissez l'application gérer la paperasse.",
+  "signIn": "Connectez-vous pour commencer",
+  "casesLastWeek": "cas créés la semaine dernière",
+  "authorityNotifications": "notifications envoyées aux autorités",
+  "avgTimeToNotify": "temps moyen pour notifier les autorités",
+  "casesWithNotification": "cas avec notification aux autorités"
+}

--- a/src/app/components/LanguageSwitcher.tsx
+++ b/src/app/components/LanguageSwitcher.tsx
@@ -10,6 +10,7 @@ export default function LanguageSwitcher() {
     >
       <option value="en">EN</option>
       <option value="es">ES</option>
+      <option value="fr">FR</option>
     </select>
   );
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,6 +1,7 @@
 import i18n from "i18next";
 import enCommon from "../public/locales/en/common.json";
 import esCommon from "../public/locales/es/common.json";
+import frCommon from "../public/locales/fr/common.json";
 
 const instance = i18n.createInstance();
 
@@ -8,6 +9,7 @@ void instance.init({
   resources: {
     en: { common: enCommon },
     es: { common: esCommon },
+    fr: { common: frCommon },
   },
   lng: "en",
   fallbackLng: "en",


### PR DESCRIPTION
## Summary
- add French translations for logged out landing page strings
- register new language in i18n setup
- offer FR in the language switcher

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685fe1cf156c832b9548646bebe8d2d9