### PR TITLE
fix: persist language selection

### DIFF
--- a/src/app/i18n-provider.tsx
+++ b/src/app/i18n-provider.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useEffect } from "react";
 import { I18nextProvider, initReactI18next } from "react-i18next";
 import i18n from "../i18n";
 
@@ -9,5 +10,18 @@ if (!i18n.isInitialized) {
 export default function I18nProvider({
   children,
 }: { children: React.ReactNode }) {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    document.documentElement.lang = i18n.language;
+    localStorage.setItem("language", i18n.language);
+    const handler = (lng: string) => {
+      document.documentElement.lang = lng;
+      localStorage.setItem("language", lng);
+    };
+    i18n.on("languageChanged", handler);
+    return () => {
+      i18n.off("languageChanged", handler);
+    };
+  }, []);
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -4,12 +4,15 @@ import esCommon from "../public/locales/es/common.json";
 
 const instance = i18n.createInstance();
 
+const storedLang =
+  typeof window !== "undefined" ? localStorage.getItem("language") : null;
+
 void instance.init({
   resources: {
     en: { common: enCommon },
     es: { common: esCommon },
   },
-  lng: "en",
+  lng: storedLang ?? "en",
   fallbackLng: "en",
   defaultNS: "common",
   interpolation: { escapeValue: false },


### PR DESCRIPTION
## Summary
- remember selected language in localStorage
- sync `<html>` lang and localStorage with language changes

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685fe1af1110832b9115bed07b69cda9