### PR TITLE
Make upload directory configurable

### DIFF
--- a/src/app/api/cases/[id]/thread-images/route.ts
+++ b/src/app/api/cases/[id]/thread-images/route.ts
@@ -1,11 +1,14 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+
+import { NextResponse } from "next/server";
+
 import { withCaseAuthorization } from "@/lib/authz";
 import { addCaseThreadImage, getCase } from "@/lib/caseStore";
+import { config } from "@/lib/config";
 import { ocrPaperwork } from "@/lib/openai";
 import { generateThumbnailsInBackground } from "@/lib/thumbnails";
-import { NextResponse } from "next/server";
 
 export const POST = withCaseAuthorization(
   { obj: "cases", act: "update" },
@@ -29,7 +32,7 @@ export const POST = withCaseAuthorization(
     const bytes = await file.arrayBuffer();
     const buffer = Buffer.from(bytes);
     const ext = path.extname(file.name || "jpg") || ".jpg";
-    const uploadDir = path.join(process.cwd(), "uploads");
+    const uploadDir = config.UPLOAD_DIR;
     fs.mkdirSync(uploadDir, { recursive: true });
     const filename = `${crypto.randomUUID()}${ext}`;
     fs.writeFileSync(path.join(uploadDir, filename), buffer);

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,6 +1,10 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
 import { getAnonymousSessionId } from "@/lib/anonymousSession";
 import { getSessionDetails, withAuthorization } from "@/lib/authz";
 import {
@@ -15,10 +19,9 @@ import {
   setCaseSessionId,
   updateCase,
 } from "@/lib/caseStore";
+import { config } from "@/lib/config";
 import { extractGps, extractTimestamp } from "@/lib/exif";
 import { generateThumbnailsInBackground } from "@/lib/thumbnails";
-import { cookies } from "next/headers";
-import { NextResponse } from "next/server";
 
 export const POST = withAuthorization(
   { obj: "upload" },
@@ -56,7 +59,7 @@ export const POST = withAuthorization(
 
     const gps = extractGps(buffer);
     const takenAt = extractTimestamp(buffer);
-    const uploadDir = path.join(process.cwd(), "uploads");
+    const uploadDir = config.UPLOAD_DIR;
     fs.mkdirSync(uploadDir, { recursive: true });
     const ext = path.extname(file.name || "jpg") || ".jpg";
     const filename = `${crypto.randomUUID()}${ext}`;

--- a/src/app/uploads/[...path]/route.ts
+++ b/src/app/uploads/[...path]/route.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+
 import { NextResponse } from "next/server";
+
+import { config } from "@/lib/config";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -10,7 +13,7 @@ export async function GET(
   { params }: { params: Promise<{ path: string[] }> },
 ): Promise<Response> {
   const { path: segments } = await params;
-  const uploads = path.join(process.cwd(), "uploads");
+  const uploads = config.UPLOAD_DIR;
   const full = path.join(uploads, ...segments);
   if (!full.startsWith(uploads)) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import dotenv from "dotenv";
 import { z } from "zod";
 
@@ -51,6 +52,7 @@ const envSchema = z
     IMAP_PASS: z.string().optional(),
     IMAP_TLS: z.coerce.boolean().default(true),
     INBOX_STATE_FILE: z.string().optional(),
+    UPLOAD_DIR: z.string().default("uploads"),
     NEXT_PUBLIC_BROWSER_DEBUG: z.coerce.boolean().default(false),
     NEXT_PUBLIC_BASE_PATH: z.string().default(""),
   })
@@ -69,3 +71,4 @@ export const config: Config = {
   NEXT_PUBLIC_BROWSER_DEBUG: process.env.NEXT_PUBLIC_BROWSER_DEBUG === "true",
   NEXT_PUBLIC_BASE_PATH: process.env.NEXT_PUBLIC_BASE_PATH || "",
 };
+config.UPLOAD_DIR = path.resolve(config.UPLOAD_DIR);

--- a/src/lib/contactMethods.ts
+++ b/src/lib/contactMethods.ts
@@ -8,7 +8,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import twilio from "twilio";
-import { getConfig } from "./config";
+import { config, getConfig } from "./config";
 
 import {
   type MailingAddress,
@@ -134,7 +134,7 @@ export async function sendSnailMail(options: {
     y -= fontSize * 1.2;
   }
   for (const att of options.attachments) {
-    const abs = path.join(process.cwd(), att.replace(/^\/+/, ""));
+    const abs = path.join(config.UPLOAD_DIR, att.replace(/^\/uploads\//, ""));
     if (!fs.existsSync(abs)) continue;
     const bytes = fs.readFileSync(abs);
     const ext = path.extname(abs).toLowerCase();

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -65,7 +65,7 @@ export async function sendEmail({
     text: body,
     attachments: attachments.map((p) => ({
       filename: path.basename(p),
-      path: path.join(process.cwd(), "public", p.replace(/^\//, "")),
+      path: path.join(config.UPLOAD_DIR, p.replace(/^\/uploads\//, "")),
     })),
   });
   log("email sent", to);

--- a/src/lib/inboxScanner.ts
+++ b/src/lib/inboxScanner.ts
@@ -49,7 +49,7 @@ export async function scanInbox(): Promise<void> {
         a.contentType.startsWith("image/"),
       );
       if (images.length > 0) {
-        const uploadDir = path.join(process.cwd(), "uploads");
+        const uploadDir = config.UPLOAD_DIR;
         fs.mkdirSync(uploadDir, { recursive: true });
         const casePhotos: string[] = [];
         const photoTimes: Record<string, string | null> = {};

--- a/src/lib/thumbnails.ts
+++ b/src/lib/thumbnails.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import sharp from "sharp";
+import { config } from "./config";
 import { runJob } from "./jobScheduler";
 
 export const THUMB_SIZES = [64, 128, 256, 512];
@@ -10,7 +11,7 @@ export async function generateThumbnails(
   filename: string,
 ): Promise<void> {
   const base = path.basename(filename);
-  const uploadDir = path.join(process.cwd(), "uploads", "thumbs");
+  const uploadDir = path.join(config.UPLOAD_DIR, "thumbs");
   try {
     await sharp(buffer).metadata();
   } catch (err) {

--- a/test/uploadRoute.test.ts
+++ b/test/uploadRoute.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { Worker } from "node:worker_threads";
+import { config } from "@/lib/config";
 import {
   type MockInstance,
   afterEach,
@@ -58,7 +59,7 @@ beforeEach(async () => {
   caseStore = await import("@/lib/caseStore");
   caseAnalysis = await import("@/lib/caseAnalysis");
   cancelSpy = vi.spyOn(caseAnalysis, "cancelCaseAnalysis");
-  fs.mkdirSync(path.join(process.cwd(), "uploads"), {
+  fs.mkdirSync(config.UPLOAD_DIR, {
     recursive: true,
   });
   mod = await import("@/app/api/upload/route");
@@ -67,7 +68,7 @@ beforeEach(async () => {
 afterEach(() => {
   fs.rmSync(dataDir, { recursive: true, force: true });
   fs.rmSync(tmpDir, { recursive: true, force: true });
-  fs.rmSync(path.join(process.cwd(), "uploads"), {
+  fs.rmSync(config.UPLOAD_DIR, {
     recursive: true,
     force: true,
   });


### PR DESCRIPTION
## Summary
- configure `UPLOAD_DIR` with a default of `uploads`
- reference `config.UPLOAD_DIR` in upload handlers and tests
- adjust snail mail handling and email attachments

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685fe3d4595c832b8dd660c7a3898599