### PR TITLE
Fix trackpad overlay issues

### DIFF
--- a/src/app/components/ZoomableImage.tsx
+++ b/src/app/components/ZoomableImage.tsx
@@ -57,6 +57,7 @@ export default function ZoomableImage({ src, alt }: Props) {
   const lastCenter = useRef<{ x: number; y: number } | null>(null);
 
   function handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {
+    if ((e.target as HTMLElement).closest("button")) return;
     e.currentTarget.setPointerCapture(e.pointerId);
     pointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
   }
@@ -120,17 +121,27 @@ export default function ZoomableImage({ src, alt }: Props) {
       e.preventDefault();
       const rect = containerRef.current?.getBoundingClientRect();
       if (!rect) return;
-      const cursorX = e.clientX - rect.left;
-      const cursorY = e.clientY - rect.top;
-      const zoom = Math.exp(-e.deltaY / 200);
-      setTransform((t) => {
-        const scale = Math.min(5, Math.max(1, t.scale * zoom));
-        const originX = (cursorX - t.x) / t.scale;
-        const originY = (cursorY - t.y) / t.scale;
-        const x = t.x - (scale - t.scale) * originX;
-        const y = t.y - (scale - t.scale) * originY;
-        return constrainPan(rect, naturalSize, { scale, x, y });
-      });
+      if (e.ctrlKey) {
+        const cursorX = e.clientX - rect.left;
+        const cursorY = e.clientY - rect.top;
+        const zoom = Math.exp(-e.deltaY / 200);
+        setTransform((t) => {
+          const scale = Math.min(5, Math.max(1, t.scale * zoom));
+          const originX = (cursorX - t.x) / t.scale;
+          const originY = (cursorY - t.y) / t.scale;
+          const x = t.x - (scale - t.scale) * originX - e.deltaX;
+          const y = t.y - (scale - t.scale) * originY - e.deltaY;
+          return constrainPan(rect, naturalSize, { scale, x, y });
+        });
+      } else {
+        setTransform((t) =>
+          constrainPan(rect, naturalSize, {
+            scale: t.scale,
+            x: t.x - e.deltaX,
+            y: t.y - e.deltaY,
+          }),
+        );
+      }
     },
     [naturalSize],
   );
@@ -171,6 +182,15 @@ export default function ZoomableImage({ src, alt }: Props) {
           transformOrigin: "0 0",
         }}
       />
+      {(transform.scale !== 1 || transform.x !== 0 || transform.y !== 0) && (
+        <button
+          className="absolute top-2 right-2 bg-black/60 text-white text-xs px-2 py-1 rounded"
+          type="button"
+          onClick={() => setTransform({ scale: 1, x: 0, y: 0 })}
+        >
+          Reset zoom
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- handle pointer capture so reset button remains clickable
- allow panning while pinch-zooming on trackpads
- add zoom overlay when not at default scale and position

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685fe559644c832b820145aee633892c