### PR TITLE
Fix FOUC in language selection

### DIFF
--- a/src/app/i18n-provider.tsx
+++ b/src/app/i18n-provider.tsx
@@ -14,9 +14,11 @@ export default function I18nProvider({
     if (typeof window === "undefined") return;
     document.documentElement.lang = i18n.language;
     localStorage.setItem("language", i18n.language);
+    document.cookie = `language=${i18n.language}; path=/; max-age=31536000; sameSite=lax`;
     const handler = (lng: string) => {
       document.documentElement.lang = lng;
       localStorage.setItem("language", lng);
+      document.cookie = `language=${lng}; path=/; max-age=31536000; sameSite=lax`;
     };
     i18n.on("languageChanged", handler);
     return () => {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -18,6 +18,7 @@ void instance.init({
   fallbackLng: "en",
   defaultNS: "common",
   interpolation: { escapeValue: false },
+  initImmediate: false,
 });
 
 export default instance;


### PR DESCRIPTION
## Summary
- set initImmediate to false for synchronous i18n init
- store selected language in a cookie to keep page language consistent

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685fedf34bbc832bb20d88c5e41eb046