### PR TITLE
Fix FOUC with persisted language cookie

### DIFF
--- a/src/app/components/LanguageSwitcher.tsx
+++ b/src/app/components/LanguageSwitcher.tsx
@@ -6,7 +6,11 @@ export default function LanguageSwitcher() {
     <select
       className="border rounded p-1 text-sm bg-white dark:bg-gray-800"
       value={i18n.language}
-      onChange={(e) => i18n.changeLanguage(e.target.value)}
+      onChange={(e) => {
+        const lang = e.target.value;
+        document.cookie = `language=${lang}; path=/; max-age=31536000`;
+        i18n.changeLanguage(lang);
+      }}
     >
       <option value="en">EN</option>
       <option value="es">ES</option>

--- a/src/app/i18n-provider.tsx
+++ b/src/app/i18n-provider.tsx
@@ -1,22 +1,27 @@
 "use client";
 import { useEffect } from "react";
-import { I18nextProvider, initReactI18next } from "react-i18next";
-import i18n from "../i18n";
-
-if (!i18n.isInitialized) {
-  void i18n.use(initReactI18next).init();
-}
+import { I18nextProvider } from "react-i18next";
+import i18n, { initI18n } from "../i18n";
 
 export default function I18nProvider({
   children,
-}: { children: React.ReactNode }) {
+  lang,
+}: { children: React.ReactNode; lang: string }) {
+  if (!i18n.isInitialized) {
+    void initI18n(lang);
+  } else if (i18n.language !== lang) {
+    void initI18n(lang);
+  }
+
   useEffect(() => {
     if (typeof window === "undefined") return;
     document.documentElement.lang = i18n.language;
     localStorage.setItem("language", i18n.language);
+    document.cookie = `language=${i18n.language}; path=/; max-age=31536000`;
     const handler = (lng: string) => {
       document.documentElement.lang = lng;
       localStorage.setItem("language", lng);
+      document.cookie = `language=${lng}; path=/; max-age=31536000`;
     };
     i18n.on("languageChanged", handler);
     return () => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { authOptions } from "@/lib/authOptions";
 import type { Metadata } from "next";
 import { getServerSession } from "next-auth";
+import { cookies } from "next/headers";
 import AuthProvider from "./auth-provider";
 import NavBar from "./components/NavBar";
 import NotificationProvider from "./components/NotificationProvider";
@@ -21,11 +22,12 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const session = await getServerSession(authOptions);
+  const storedLang = cookies().get("language")?.value ?? "en";
   return (
-    <html lang="en">
+    <html lang={storedLang}>
       <body className="antialiased">
         <QueryProvider>
-          <I18nProvider>
+          <I18nProvider lang={storedLang}>
             <NotificationProvider>
               <AuthProvider session={session}>
                 <NavBar />

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,23 +1,28 @@
 import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
 import enCommon from "../public/locales/en/common.json";
 import esCommon from "../public/locales/es/common.json";
 import frCommon from "../public/locales/fr/common.json";
 
 const instance = i18n.createInstance();
 
-const storedLang =
-  typeof window !== "undefined" ? localStorage.getItem("language") : null;
-
-void instance.init({
-  resources: {
-    en: { common: enCommon },
-    es: { common: esCommon },
-    fr: { common: frCommon },
-  },
-  lng: storedLang ?? "en",
-  fallbackLng: "en",
-  defaultNS: "common",
-  interpolation: { escapeValue: false },
-});
+export async function initI18n(lang: string) {
+  if (!instance.isInitialized) {
+    await instance.use(initReactI18next).init({
+      resources: {
+        en: { common: enCommon },
+        es: { common: esCommon },
+        fr: { common: frCommon },
+      },
+      lng: lang,
+      fallbackLng: "en",
+      defaultNS: "common",
+      interpolation: { escapeValue: false },
+    });
+  } else if (instance.language !== lang) {
+    await instance.changeLanguage(lang);
+  }
+  return instance;
+}
 
 export default instance;


### PR DESCRIPTION
## Summary
- persist language selection in a cookie
- read language cookie on the server to set html `lang` and initialize i18next
- initialize i18n with selected language

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685fedf34bbc832bb20d88c5e41eb046