### PR TITLE
Improve analysis failure info

### DIFF
--- a/src/app/cases/[id]/components/AnalysisStatus.tsx
+++ b/src/app/cases/[id]/components/AnalysisStatus.tsx
@@ -29,12 +29,40 @@ export default function AnalysisStatus({
       ? "Analysis failed because the AI response was cut off."
       : caseData.analysisError === "parse"
         ? "Analysis failed due to invalid JSON from the AI."
-        : caseData.analysisError === "images"
-          ? "Analysis failed because no images were provided or some photo files were missing."
-          : "Analysis failed because the AI response did not match the expected format."
+        : caseData.analysisError === "schema"
+          ? "Analysis failed because the AI response did not match the expected schema."
+          : caseData.analysisError === "images"
+            ? "Analysis failed because no images were provided or some photo files were missing."
+            : "Analysis failed because the AI response did not match the expected format."
     : caseData.analysisStatusCode && caseData.analysisStatusCode >= 400
       ? "Analysis failed. Please try again later."
       : "Analysis failed.";
+
+  let failureDetail: string | null = null;
+  switch (caseData.analysisError) {
+    case "truncated":
+      failureDetail =
+        "The AI response ended early, which usually means the output was too long.";
+      break;
+    case "parse":
+      failureDetail = "The AI returned text that could not be parsed as JSON.";
+      break;
+    case "schema":
+      failureDetail = "The AI's JSON did not match the expected schema.";
+      break;
+    case "images":
+      failureDetail = "One or more uploaded photos were missing.";
+      break;
+    default:
+      if (caseData.analysisStatusCode && caseData.analysisStatusCode >= 500) {
+        failureDetail = "The server encountered an error while analyzing.";
+      } else if (
+        caseData.analysisStatusCode &&
+        caseData.analysisStatusCode >= 400
+      ) {
+        failureDetail = "The request to analyze the case was rejected.";
+      }
+  }
 
   if (caseData.analysis) {
     return (
@@ -89,12 +117,10 @@ export default function AnalysisStatus({
         <p className="mt-1">
           Last attempt: {new Date(caseData.updatedAt).toLocaleString()}
         </p>
-        <p className="mt-1">Possible causes:</p>
-        <ul className="list-disc ml-4">
-          <li>Missing photo files</li>
-          <li>Invalid JSON response</li>
-          <li>Server error</li>
-        </ul>
+        {failureDetail ? <p className="mt-1">{failureDetail}</p> : null}
+        {caseData.analysisStatusCode ? (
+          <p className="mt-1">Status code: {caseData.analysisStatusCode}</p>
+        ) : null}
       </details>
     </div>
   );


### PR DESCRIPTION
## Summary
- show the real reason for analysis failure instead of a static list
- surface the server status code if available

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685fee5e6fb8832b965de066a9fa88c0