### PR TITLE
feat: add nav translations

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2,8 +2,23 @@
   "title": "Photo To Citation",
   "landingDescription": "Snap a quick photo of blocked bike lanes or sidewalks and let the app handle the paperwork.",
   "signIn": "Sign in to get started",
-  "casesLastWeek": "cases created in the last week",
-  "authorityNotifications": "notifications sent to authorities",
+  "casesLastWeek": "{{count}} case created in the last week",
+  "casesLastWeek_plural": "{{count}} cases created in the last week",
+  "authorityNotifications": "{{count}} notification sent to authorities",
+  "authorityNotifications_plural": "{{count}} notifications sent to authorities",
   "avgTimeToNotify": "average time to notify authorities",
-  "casesWithNotification": "cases with authority notification"
+  "casesWithNotification": "cases with authority notification",
+  "nav": {
+    "newCaseFromImage": "New Case from Image",
+    "pointAndShoot": "Point & Shoot",
+    "cases": "Cases",
+    "mapView": "Map View",
+    "triage": "Triage",
+    "admin": "Admin",
+    "systemStatus": "System Status",
+    "userSettings": "User Settings",
+    "profile": "Profile",
+    "signOut": "Sign Out",
+    "signIn": "Sign In"
+  }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -2,8 +2,23 @@
   "title": "Foto a Multa",
   "landingDescription": "Toma una foto rápida de carriles bici o aceras bloqueadas y deja que la aplicación se encargue del papeleo.",
   "signIn": "Inicia sesión para comenzar",
-  "casesLastWeek": "casos creados en la última semana",
-  "authorityNotifications": "notificaciones enviadas a las autoridades",
+  "casesLastWeek": "{{count}} caso creado en la última semana",
+  "casesLastWeek_plural": "{{count}} casos creados en la última semana",
+  "authorityNotifications": "{{count}} notificación enviada a las autoridades",
+  "authorityNotifications_plural": "{{count}} notificaciones enviadas a las autoridades",
   "avgTimeToNotify": "tiempo promedio para notificar a las autoridades",
-  "casesWithNotification": "casos con notificación a la autoridad"
+  "casesWithNotification": "casos con notificación a la autoridad",
+  "nav": {
+    "newCaseFromImage": "Nuevo caso desde imagen",
+    "pointAndShoot": "Apunta y dispara",
+    "cases": "Casos",
+    "mapView": "Ver mapa",
+    "triage": "Triaje",
+    "admin": "Admin",
+    "systemStatus": "Estado del sistema",
+    "userSettings": "Configuración",
+    "profile": "Perfil",
+    "signOut": "Cerrar sesión",
+    "signIn": "Iniciar sesión"
+  }
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -2,8 +2,23 @@
   "title": "Photo à Citation",
   "landingDescription": "Prenez rapidement en photo les pistes cyclables ou trottoirs obstrués et laissez l'application gérer la paperasse.",
   "signIn": "Connectez-vous pour commencer",
-  "casesLastWeek": "cas créés la semaine dernière",
-  "authorityNotifications": "notifications envoyées aux autorités",
+  "casesLastWeek": "{{count}} cas créé la semaine dernière",
+  "casesLastWeek_plural": "{{count}} cas créés la semaine dernière",
+  "authorityNotifications": "{{count}} notification envoyée aux autorités",
+  "authorityNotifications_plural": "{{count}} notifications envoyées aux autorités",
   "avgTimeToNotify": "temps moyen pour notifier les autorités",
-  "casesWithNotification": "cas avec notification aux autorités"
+  "casesWithNotification": "cas avec notification aux autorités",
+  "nav": {
+    "newCaseFromImage": "Nouveau cas à partir d'une image",
+    "pointAndShoot": "Pointer & photographier",
+    "cases": "Cas",
+    "mapView": "Vue carte",
+    "triage": "Triage",
+    "admin": "Admin",
+    "systemStatus": "État du système",
+    "userSettings": "Paramètres",
+    "profile": "Profil",
+    "signOut": "Se déconnecter",
+    "signIn": "Se connecter"
+  }
 }

--- a/src/app/LoggedOutLandingClient.tsx
+++ b/src/app/LoggedOutLandingClient.tsx
@@ -30,13 +30,19 @@ export default function LoggedOutLandingClient({
           <div className="text-2xl font-semibold">
             {formatCount(stats.casesLastWeek)}
           </div>
-          <div className="text-sm">{t("casesLastWeek")}</div>
+          <div className="text-sm">
+            {t("casesLastWeek", { count: stats.casesLastWeek })}
+          </div>
         </div>
         <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
           <div className="text-2xl font-semibold">
             {formatCount(stats.authorityNotifications)}
           </div>
-          <div className="text-sm">{t("authorityNotifications")}</div>
+          <div className="text-sm">
+            {t("authorityNotifications", {
+              count: stats.authorityNotifications,
+            })}
+          </div>
         </div>
         <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
           <div className="text-2xl font-semibold">

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -36,28 +36,28 @@ export default function NavBar() {
           inputRef.current?.click();
         }}
       >
-        New Case from Image
+        {t("nav.newCaseFromImage")}
       </button>
       <Link
         href="/point"
         className="hover:text-gray-600 dark:hover:text-gray-300"
         onClick={() => setMenuOpen(false)}
       >
-        Point &amp; Shoot
+        {t("nav.pointAndShoot")}
       </Link>
       <Link
         href="/cases"
         className="hover:text-gray-600 dark:hover:text-gray-300"
         onClick={() => setMenuOpen(false)}
       >
-        Cases
+        {t("nav.cases")}
       </Link>
       <Link
         href="/map"
         className="hover:text-gray-600 dark:hover:text-gray-300"
         onClick={() => setMenuOpen(false)}
       >
-        Map View
+        {t("nav.mapView")}
       </Link>
       {session ? (
         <Link
@@ -65,7 +65,7 @@ export default function NavBar() {
           className="hover:text-gray-600 dark:hover:text-gray-300"
           onClick={() => setMenuOpen(false)}
         >
-          Triage
+          {t("nav.triage")}
         </Link>
       ) : null}
       {session?.user?.role === "admin" ||
@@ -75,7 +75,7 @@ export default function NavBar() {
           className="hover:text-gray-600 dark:hover:text-gray-300"
           onClick={() => setMenuOpen(false)}
         >
-          Admin
+          {t("nav.admin")}
         </Link>
       ) : null}
       {session?.user?.role === "superadmin" ? (
@@ -84,7 +84,7 @@ export default function NavBar() {
           className="hover:text-gray-600 dark:hover:text-gray-300"
           onClick={() => setMenuOpen(false)}
         >
-          System Status
+          {t("nav.systemStatus")}
         </Link>
       ) : null}
       {session ? (
@@ -94,14 +94,14 @@ export default function NavBar() {
             className="hover:text-gray-600 dark:hover:text-gray-300"
             onClick={() => setMenuOpen(false)}
           >
-            User Settings
+            {t("nav.userSettings")}
           </Link>
           <Link
             href="/profile"
             className="hover:text-gray-600 dark:hover:text-gray-300"
             onClick={() => setMenuOpen(false)}
           >
-            Profile
+            {t("nav.profile")}
           </Link>
         </>
       ) : null}
@@ -114,7 +114,7 @@ export default function NavBar() {
           }}
           className="hover:text-gray-600 dark:hover:text-gray-300"
         >
-          Sign Out
+          {t("nav.signOut")}
         </button>
       ) : (
         <button
@@ -125,7 +125,7 @@ export default function NavBar() {
           }}
           className="hover:text-gray-600 dark:hover:text-gray-300"
         >
-          Sign In
+          {t("nav.signIn")}
         </button>
       )}
     </>

--- a/src/app/components/__tests__/NavBar.test.tsx
+++ b/src/app/components/__tests__/NavBar.test.tsx
@@ -1,3 +1,4 @@
+import I18nProvider from "@/app/i18n-provider";
 import QueryProvider from "@/app/query-provider";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -23,7 +24,9 @@ describe("NavBar", () => {
     mockedUsePathname.mockReturnValue("/cases");
     render(
       <QueryProvider>
-        <NavBar />
+        <I18nProvider lang="en">
+          <NavBar />
+        </I18nProvider>
       </QueryProvider>,
     );
     expect(screen.getByText("Point & Shoot")).toBeInTheDocument();
@@ -34,7 +37,9 @@ describe("NavBar", () => {
     mockedUsePathname.mockReturnValue("/point");
     render(
       <QueryProvider>
-        <NavBar />
+        <I18nProvider lang="en">
+          <NavBar />
+        </I18nProvider>
       </QueryProvider>,
     );
     expect(screen.queryByText("Point & Shoot")).toBeNull();


### PR DESCRIPTION
## Summary
- use i18next for navigation items
- add pluralized stats labels
- translate navbar strings in tests

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685ff1ad1070832bb667b8e50a26fa7a