### PR TITLE
Add i18n to nav and case summary

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -5,5 +5,32 @@
   "casesLastWeek": "cases created in the last week",
   "authorityNotifications": "notifications sent to authorities",
   "avgTimeToNotify": "average time to notify authorities",
-  "casesWithNotification": "cases with authority notification"
+  "casesWithNotification": "cases with authority notification",
+  "nav": {
+    "newCaseFromImage": "New Case from Image",
+    "pointShoot": "Point & Shoot",
+    "cases": "Cases",
+    "mapView": "Map View",
+    "triage": "Triage",
+    "admin": "Admin",
+    "systemStatus": "System Status",
+    "userSettings": "User Settings",
+    "profile": "Profile",
+    "signOut": "Sign Out",
+    "signIn": "Sign In"
+  },
+  "claim": {
+    "signInMessage": "Sign in to claim this case or it will be lost when the session ends.",
+    "signIn": "Sign In",
+    "dismissAria": "Dismiss"
+  },
+  "caseSummary": {
+    "title": "Case Summary",
+    "casesSelected": "{{count}} case selected",
+    "casesSelected_plural": "{{count}} cases selected"
+  },
+  "casesPage": {
+    "heading": "Cases",
+    "selectPrompt": "Select a case to view details."
+  }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -5,5 +5,32 @@
   "casesLastWeek": "casos creados en la última semana",
   "authorityNotifications": "notificaciones enviadas a las autoridades",
   "avgTimeToNotify": "tiempo promedio para notificar a las autoridades",
-  "casesWithNotification": "casos con notificación a la autoridad"
+  "casesWithNotification": "casos con notificación a la autoridad",
+  "nav": {
+    "newCaseFromImage": "Nuevo caso desde imagen",
+    "pointShoot": "Apuntar y disparar",
+    "cases": "Casos",
+    "mapView": "Vista del mapa",
+    "triage": "Evaluación",
+    "admin": "Admin",
+    "systemStatus": "Estado del sistema",
+    "userSettings": "Configuración",
+    "profile": "Perfil",
+    "signOut": "Cerrar sesión",
+    "signIn": "Iniciar sesión"
+  },
+  "claim": {
+    "signInMessage": "Inicia sesión para reclamar este caso o se perderá al finalizar la sesión.",
+    "signIn": "Iniciar sesión",
+    "dismissAria": "Descartar"
+  },
+  "caseSummary": {
+    "title": "Resumen de caso",
+    "casesSelected": "{{count}} caso seleccionado",
+    "casesSelected_plural": "{{count}} casos seleccionados"
+  },
+  "casesPage": {
+    "heading": "Casos",
+    "selectPrompt": "Selecciona un caso para ver detalles."
+  }
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -5,5 +5,32 @@
   "casesLastWeek": "cas créés la semaine dernière",
   "authorityNotifications": "notifications envoyées aux autorités",
   "avgTimeToNotify": "temps moyen pour notifier les autorités",
-  "casesWithNotification": "cas avec notification aux autorités"
+  "casesWithNotification": "cas avec notification aux autorités",
+  "nav": {
+    "newCaseFromImage": "Nouveau cas à partir d'une image",
+    "pointShoot": "Pointer et capturer",
+    "cases": "Cas",
+    "mapView": "Vue carte",
+    "triage": "Triage",
+    "admin": "Admin",
+    "systemStatus": "État du système",
+    "userSettings": "Paramètres",
+    "profile": "Profil",
+    "signOut": "Déconnexion",
+    "signIn": "Connexion"
+  },
+  "claim": {
+    "signInMessage": "Connectez-vous pour réclamer ce cas ou il sera perdu à la fin de la session.",
+    "signIn": "Connexion",
+    "dismissAria": "Fermer"
+  },
+  "caseSummary": {
+    "title": "Résumé du cas",
+    "casesSelected": "{{count}} cas sélectionné",
+    "casesSelected_plural": "{{count}} cas sélectionnés"
+  },
+  "casesPage": {
+    "heading": "Cas",
+    "selectPrompt": "Sélectionnez un cas pour voir les détails."
+  }
 }

--- a/src/app/cases/[id]/components/ClaimBanner.tsx
+++ b/src/app/cases/[id]/components/ClaimBanner.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { signIn } from "@/app/useSession";
 import { withBasePath } from "@/basePath";
+import { useTranslation } from "react-i18next";
 
 export default function ClaimBanner({
   show,
@@ -11,14 +12,13 @@ export default function ClaimBanner({
   onDismiss: () => void;
   className?: string;
 }) {
+  const { t } = useTranslation();
   if (!show) return null;
   return (
     <div
       className={`bg-yellow-100 border border-yellow-300 text-yellow-800 p-2 flex items-center justify-between ${className ?? ""}`}
     >
-      <span>
-        Sign in to claim this case or it will be lost when the session ends.
-      </span>
+      <span>{t("claim.signInMessage")}</span>
       <div className="flex items-center gap-2">
         <button
           type="button"
@@ -27,12 +27,12 @@ export default function ClaimBanner({
           }
           className="underline"
         >
-          Sign In
+          {t("claim.signIn")}
         </button>
         <button
           type="button"
           onClick={onDismiss}
-          aria-label="Dismiss"
+          aria-label={t("claim.dismissAria")}
           className="text-xl leading-none"
         >
           ×

--- a/src/app/cases/__tests__/claimBanner.test.tsx
+++ b/src/app/cases/__tests__/claimBanner.test.tsx
@@ -1,16 +1,23 @@
 import ClaimBanner from "@/app/cases/[id]/components/ClaimBanner";
+import I18nProvider from "@/app/i18n-provider";
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 describe("ClaimBanner", () => {
   it("renders when show is true", () => {
-    const { getByText } = render(<ClaimBanner show onDismiss={() => {}} />);
+    const { getByText } = render(
+      <I18nProvider lang="en">
+        <ClaimBanner show onDismiss={() => {}} />
+      </I18nProvider>,
+    );
     expect(getByText(/claim this case/i)).toBeTruthy();
   });
 
   it("renders nothing when show is false", () => {
     const { container } = render(
-      <ClaimBanner show={false} onDismiss={() => {}} />,
+      <I18nProvider lang="en">
+        <ClaimBanner show={false} onDismiss={() => {}} />
+      </I18nProvider>,
     );
     expect(container.firstChild).toBeNull();
   });

--- a/src/app/components/CaseSummary.tsx
+++ b/src/app/components/CaseSummary.tsx
@@ -6,10 +6,12 @@ import {
   getCaseVin,
   hasViolation,
 } from "@/lib/caseUtils";
+import { useTranslation } from "react-i18next";
 import MultiCaseToolbar from "./MultiCaseToolbar";
 
 export default function CaseSummary({ cases }: { cases: Case[] }) {
   if (cases.length === 0) return null;
+  const { t } = useTranslation();
   const first = cases[0];
   function allEqual<T>(getter: (c: Case) => T): T | undefined {
     const value = getter(first);
@@ -37,9 +39,9 @@ export default function CaseSummary({ cases }: { cases: Case[] }) {
         hasOwner={hasOwnerAll}
       />
       <div className="p-8 flex flex-col gap-2">
-        <h1 className="text-xl font-semibold">Case Summary</h1>
+        <h1 className="text-xl font-semibold">{t("caseSummary.title")}</h1>
         <p className="text-sm text-gray-500 dark:text-gray-400">
-          {cases.length} cases selected.
+          {t("caseSummary.casesSelected", { count: cases.length })}
         </p>
         {violation ? <p>Violation: {violation}</p> : null}
         {plateNum || plateState ? (

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -21,7 +21,7 @@ export default function NavBar() {
     return (
       <nav className="p-2 flex justify-end bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
         <Link href="/cases" className="text-sm underline">
-          Cases
+          {t("nav.cases")}
         </Link>
       </nav>
     );
@@ -36,28 +36,28 @@ export default function NavBar() {
           inputRef.current?.click();
         }}
       >
-        New Case from Image
+        {t("nav.newCaseFromImage")}
       </button>
       <Link
         href="/point"
         className="hover:text-gray-600 dark:hover:text-gray-300"
         onClick={() => setMenuOpen(false)}
       >
-        Point &amp; Shoot
+        {t("nav.pointShoot")}
       </Link>
       <Link
         href="/cases"
         className="hover:text-gray-600 dark:hover:text-gray-300"
         onClick={() => setMenuOpen(false)}
       >
-        Cases
+        {t("nav.cases")}
       </Link>
       <Link
         href="/map"
         className="hover:text-gray-600 dark:hover:text-gray-300"
         onClick={() => setMenuOpen(false)}
       >
-        Map View
+        {t("nav.mapView")}
       </Link>
       {session ? (
         <Link
@@ -65,7 +65,7 @@ export default function NavBar() {
           className="hover:text-gray-600 dark:hover:text-gray-300"
           onClick={() => setMenuOpen(false)}
         >
-          Triage
+          {t("nav.triage")}
         </Link>
       ) : null}
       {session?.user?.role === "admin" ||
@@ -75,7 +75,7 @@ export default function NavBar() {
           className="hover:text-gray-600 dark:hover:text-gray-300"
           onClick={() => setMenuOpen(false)}
         >
-          Admin
+          {t("nav.admin")}
         </Link>
       ) : null}
       {session?.user?.role === "superadmin" ? (
@@ -84,7 +84,7 @@ export default function NavBar() {
           className="hover:text-gray-600 dark:hover:text-gray-300"
           onClick={() => setMenuOpen(false)}
         >
-          System Status
+          {t("nav.systemStatus")}
         </Link>
       ) : null}
       {session ? (
@@ -94,14 +94,14 @@ export default function NavBar() {
             className="hover:text-gray-600 dark:hover:text-gray-300"
             onClick={() => setMenuOpen(false)}
           >
-            User Settings
+            {t("nav.userSettings")}
           </Link>
           <Link
             href="/profile"
             className="hover:text-gray-600 dark:hover:text-gray-300"
             onClick={() => setMenuOpen(false)}
           >
-            Profile
+            {t("nav.profile")}
           </Link>
         </>
       ) : null}
@@ -114,7 +114,7 @@ export default function NavBar() {
           }}
           className="hover:text-gray-600 dark:hover:text-gray-300"
         >
-          Sign Out
+          {t("nav.signOut")}
         </button>
       ) : (
         <button
@@ -125,7 +125,7 @@ export default function NavBar() {
           }}
           className="hover:text-gray-600 dark:hover:text-gray-300"
         >
-          Sign In
+          {t("nav.signIn")}
         </button>
       )}
     </>

--- a/src/app/components/__tests__/NavBar.test.tsx
+++ b/src/app/components/__tests__/NavBar.test.tsx
@@ -1,3 +1,4 @@
+import I18nProvider from "@/app/i18n-provider";
 import QueryProvider from "@/app/query-provider";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -23,7 +24,9 @@ describe("NavBar", () => {
     mockedUsePathname.mockReturnValue("/cases");
     render(
       <QueryProvider>
-        <NavBar />
+        <I18nProvider lang="en">
+          <NavBar />
+        </I18nProvider>
       </QueryProvider>,
     );
     expect(screen.getByText("Point & Shoot")).toBeInTheDocument();
@@ -34,7 +37,9 @@ describe("NavBar", () => {
     mockedUsePathname.mockReturnValue("/point");
     render(
       <QueryProvider>
-        <NavBar />
+        <I18nProvider lang="en">
+          <NavBar />
+        </I18nProvider>
       </QueryProvider>,
     );
     expect(screen.queryByText("Point & Shoot")).toBeNull();


### PR DESCRIPTION
## Summary
- add new localization keys for nav, claim banner, and case summary
- translate nav bar, claim banner, and case summary components
- wrap tests with I18nProvider for translated components

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ff1ad1070832bb667b8e50a26fa7a