### PR TITLE
Implement locale detection and fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Open [http://localhost:3000](http://localhost:3000) to view the app.
 
 The UI language comes from the `language` cookie. When it doesn't exist, the
 server reads the `Accept-Language` header to pick the first supported locale
-(`en`, `es`, or `fr`) and sets the cookie for future requests. On the client,
-`I18nProvider` also checks `navigator.languages` if the cookie is missing.
+(`en`, `es`, or `fr`). The client persists this value by setting the cookie on
+the first render, and `I18nProvider` falls back to `navigator.languages` if the
+cookie is still missing.
 
 For local HTTPS, run:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ npm run format
 
 Open [http://localhost:3000](http://localhost:3000) to view the app.
 
+The UI language comes from the `language` cookie. When it doesn't exist, the
+server reads the `Accept-Language` header to pick the first supported locale
+(`en`, `es`, or `fr`) and sets the cookie for future requests. On the client,
+`I18nProvider` also checks `navigator.languages` if the cookie is missing.
+
 For local HTTPS, run:
 
 ```bash

--- a/src/app/i18n-provider.tsx
+++ b/src/app/i18n-provider.tsx
@@ -15,6 +15,17 @@ export default function I18nProvider({
 
   useEffect(() => {
     if (typeof window === "undefined") return;
+    // Fallback to the browser's preferred languages if no cookie is set
+    if (!document.cookie.includes("language=")) {
+      const supported = ["en", "es", "fr"];
+      for (const l of navigator.languages ?? []) {
+        const code = l.toLowerCase().split("-")[0];
+        if (supported.includes(code)) {
+          void i18n.changeLanguage(code);
+          break;
+        }
+      }
+    }
     document.documentElement.lang = i18n.language;
     localStorage.setItem("language", i18n.language);
     document.cookie = `language=${i18n.language}; path=/; max-age=31536000`;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,11 +22,12 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const session = await getServerSession(authOptions);
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
   // Prefer the language cookie but fall back to Accept-Language
   let storedLang = cookieStore.get("language")?.value;
   if (!storedLang) {
-    const accept = headers().get("accept-language") ?? "";
+    const headerList = await headers();
+    const accept = headerList.get("accept-language") ?? "";
     // Parse the first supported locale from the Accept-Language header
     const supported = ["en", "es", "fr"];
     for (const part of accept.split(",")) {
@@ -37,7 +38,6 @@ export default async function RootLayout({
       }
     }
     storedLang = storedLang ?? "en";
-    // The client persists this value in a cookie on first render
   }
   return (
     <html lang={storedLang}>


### PR DESCRIPTION
## Summary
- parse `Accept-Language` when the language cookie is missing
- set navigator-based fallback in `I18nProvider`
- explain language detection in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`

------
https://chatgpt.com/codex/tasks/task_e_685ff5b588f8832bb92e124e38f67bc9