### PR TITLE
Fix trackpad overlay issues

### DIFF
--- a/src/app/components/ZoomableImage.tsx
+++ b/src/app/components/ZoomableImage.tsx
@@ -55,8 +55,10 @@ export default function ZoomableImage({ src, alt }: Props) {
   const pointers = useRef(new Map<number, { x: number; y: number }>());
   const lastDistance = useRef<number | null>(null);
   const lastCenter = useRef<{ x: number; y: number } | null>(null);
+  const lastWheelCenter = useRef<{ x: number; y: number } | null>(null);
 
   function handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {
+    if ((e.target as HTMLElement).closest("button")) return;
     e.currentTarget.setPointerCapture(e.pointerId);
     pointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
   }
@@ -120,17 +122,36 @@ export default function ZoomableImage({ src, alt }: Props) {
       e.preventDefault();
       const rect = containerRef.current?.getBoundingClientRect();
       if (!rect) return;
-      const cursorX = e.clientX - rect.left;
-      const cursorY = e.clientY - rect.top;
-      const zoom = Math.exp(-e.deltaY / 200);
-      setTransform((t) => {
-        const scale = Math.min(5, Math.max(1, t.scale * zoom));
-        const originX = (cursorX - t.x) / t.scale;
-        const originY = (cursorY - t.y) / t.scale;
-        const x = t.x - (scale - t.scale) * originX;
-        const y = t.y - (scale - t.scale) * originY;
-        return constrainPan(rect, naturalSize, { scale, x, y });
-      });
+
+      if (e.ctrlKey) {
+        const center = {
+          x: e.clientX - rect.left,
+          y: e.clientY - rect.top,
+        };
+        const prev = lastWheelCenter.current;
+        lastWheelCenter.current = center;
+        const dx = prev ? center.x - prev.x : 0;
+        const dy = prev ? center.y - prev.y : 0;
+        const zoom = Math.exp(-e.deltaY / 200);
+
+        setTransform((t) => {
+          const scale = Math.min(5, Math.max(1, t.scale * zoom));
+          const originX = (center.x - t.x) / t.scale;
+          const originY = (center.y - t.y) / t.scale;
+          const x = t.x - (scale - t.scale) * originX + dx;
+          const y = t.y - (scale - t.scale) * originY + dy;
+          return constrainPan(rect, naturalSize, { scale, x, y });
+        });
+      } else {
+        lastWheelCenter.current = null;
+        setTransform((t) =>
+          constrainPan(rect, naturalSize, {
+            scale: t.scale,
+            x: t.x - e.deltaX,
+            y: t.y - e.deltaY,
+          }),
+        );
+      }
     },
     [naturalSize],
   );
@@ -171,6 +192,15 @@ export default function ZoomableImage({ src, alt }: Props) {
           transformOrigin: "0 0",
         }}
       />
+      {(transform.scale !== 1 || transform.x !== 0 || transform.y !== 0) && (
+        <button
+          className="absolute top-2 right-2 bg-black/60 text-white text-xs px-2 py-1 rounded"
+          type="button"
+          onClick={() => setTransform({ scale: 1, x: 0, y: 0 })}
+        >
+          Reset zoom
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- handle pointer capture so reset button remains clickable
- allow panning while pinch-zooming on trackpads
- add zoom overlay when not at default scale and position

## Testing
- `npm test`
- `npm run e2e:smoke` *(failed: command hung due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685fe559644c832b820145aee633892c