### PR TITLE
Add basic localization support

### DIFF
--- a/src/lib/__tests__/analyzeViolation.test.ts
+++ b/src/lib/__tests__/analyzeViolation.test.ts
@@ -11,7 +11,7 @@ afterEach(() => {
 
 describe("analyzeViolation", () => {
   it("rejects when no images are provided", async () => {
-    await expect(analyzeViolation([])).rejects.toMatchObject({
+    await expect(analyzeViolation([], "en")).rejects.toMatchObject({
       kind: "images",
     });
   });
@@ -21,7 +21,7 @@ describe("analyzeViolation", () => {
       choices: [{ message: { content: "{" }, finish_reason: "length" }],
     } as unknown as ChatCompletion);
 
-    await expect(analyzeViolation(imgs)).rejects.toMatchObject({
+    await expect(analyzeViolation(imgs, "en")).rejects.toMatchObject({
       kind: "truncated",
     });
   });
@@ -32,7 +32,7 @@ describe("analyzeViolation", () => {
       choices: [{ message: { content: "oops" }, finish_reason: "stop" }],
     } as unknown as ChatCompletion);
 
-    await expect(analyzeViolation(imgs)).rejects.toMatchObject({
+    await expect(analyzeViolation(imgs, "en")).rejects.toMatchObject({
       kind: "parse",
     });
   });
@@ -43,7 +43,7 @@ describe("analyzeViolation", () => {
       choices: [{ message: { content: "{}" }, finish_reason: "stop" }],
     } as unknown as ChatCompletion);
 
-    await expect(analyzeViolation(imgs)).rejects.toMatchObject({
+    await expect(analyzeViolation(imgs, "en")).rejects.toMatchObject({
       kind: "schema",
     });
   });

--- a/src/lib/__tests__/caseReport.test.ts
+++ b/src/lib/__tests__/caseReport.test.ts
@@ -47,8 +47,13 @@ describe("draftEmail", () => {
       baseCase,
       reportModules["oak-park"],
       sender,
+      "en",
     );
-    expect(result).toEqual({ subject: "s", body: "b" });
+    expect(result).toEqual({
+      subject: { en: "s" },
+      body: { en: "b" },
+      language: "en",
+    });
   });
 
   it("retries when response is invalid", async () => {
@@ -69,8 +74,13 @@ describe("draftEmail", () => {
       baseCase,
       reportModules["oak-park"],
       sender,
+      "en",
     );
-    expect(result).toEqual({ subject: "s2", body: "b2" });
+    expect(result).toEqual({
+      subject: { en: "s2" },
+      body: { en: "b2" },
+      language: "en",
+    });
   });
 
   it("returns empty draft after repeated failures", async () => {
@@ -83,8 +93,9 @@ describe("draftEmail", () => {
       baseCase,
       reportModules["oak-park"],
       sender,
+      "en",
     );
-    expect(result).toEqual({ subject: "", body: "" });
+    expect(result).toEqual({ subject: {}, body: {}, language: "en" });
   });
 });
 
@@ -99,8 +110,12 @@ describe("draftOwnerNotification", () => {
 
     const result = await draftOwnerNotification(baseCase, [
       "Oak Park Police Department",
-    ]);
-    expect(result).toEqual({ subject: "s", body: "b" });
+    ], "en");
+    expect(result).toEqual({
+      subject: { en: "s" },
+      body: { en: "b" },
+      language: "en",
+    });
   });
 
   it("retries when response is invalid", async () => {
@@ -119,8 +134,12 @@ describe("draftOwnerNotification", () => {
 
     const result = await draftOwnerNotification(baseCase, [
       "Oak Park Police Department",
-    ]);
-    expect(result).toEqual({ subject: "s2", body: "b2" });
+    ], "en");
+    expect(result).toEqual({
+      subject: { en: "s2" },
+      body: { en: "b2" },
+      language: "en",
+    });
   });
 
   it("returns empty draft after repeated failures", async () => {
@@ -131,7 +150,7 @@ describe("draftOwnerNotification", () => {
 
     const result = await draftOwnerNotification(baseCase, [
       "Oak Park Police Department",
-    ]);
-    expect(result).toEqual({ subject: "", body: "" });
+    ], "en");
+    expect(result).toEqual({ subject: {}, body: {}, language: "en" });
   });
 });

--- a/src/lib/__tests__/openai.test.ts
+++ b/src/lib/__tests__/openai.test.ts
@@ -18,10 +18,14 @@ describe("openai client", () => {
       .mockResolvedValueOnce({
         choices: [{ message: { content: '{"callsToAction":["pay now"]}' } }],
       } as unknown as ChatCompletion);
-    const result = await ocrPaperwork({ url: "data:image/png;base64,foo" });
+    const result = await ocrPaperwork(
+      { url: "data:image/png;base64,foo" },
+      "en",
+    );
     expect(result).toEqual({
-      text: "hello",
+      text: { en: "hello" },
       info: { vehicle: {}, callsToAction: ["pay now"] },
+      language: "en",
     });
   });
 });

--- a/src/lib/caseAnalysis.ts
+++ b/src/lib/caseAnalysis.ts
@@ -112,7 +112,7 @@ export async function analyzeCase(caseData: Case): Promise<void> {
         steps,
       },
     });
-    const result = await analyzeViolation(images, (p) => {
+    const result = await analyzeViolation(images, "en", (p) => {
       updateCase(caseData.id, {
         analysisProgress: { ...p, step: currentStep, steps },
       });
@@ -132,7 +132,7 @@ export async function analyzeCase(caseData: Case): Promise<void> {
     steps = 1 + paperwork.length;
     let stepIndex = 2;
     for (const [name, url] of paperwork) {
-      const ocr = await ocrPaperwork({ url }, (p) => {
+      const ocr = await ocrPaperwork({ url }, "en", (p) => {
         updateCase(caseData.id, {
           analysisProgress: { ...p, step: stepIndex, steps },
         });
@@ -233,6 +233,7 @@ export async function reanalyzePhoto(
   try {
     const result = await analyzeViolation(
       [{ filename: path.basename(photo), url: dataUrl }],
+      "en",
       (p) => {
         updateCase(caseData.id, {
           analysisProgress: { ...p, step: 1, steps: 1 },
@@ -245,6 +246,7 @@ export async function reanalyzePhoto(
     if (info?.paperwork && !info.paperworkText) {
       const ocr = await ocrPaperwork(
         { url: dataUrl },
+        "en",
         (p) => {
           updateCase(caseData.id, {
             analysisProgress: { ...p, step: 2, steps: 2 },

--- a/src/lib/caseChat.ts
+++ b/src/lib/caseChat.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { LocalizedText } from "./localization";
 import "./zod-setup";
 
 export type CaseChatAction =
@@ -7,7 +8,8 @@ export type CaseChatAction =
   | { photo: string; note: string };
 
 export interface CaseChatReply {
-  response: string;
+  response: LocalizedText;
+  language: string;
   actions: CaseChatAction[];
   noop: boolean;
 }
@@ -22,4 +24,5 @@ export const caseChatReplySchema = z.object({
     ]),
   ),
   noop: z.boolean(),
+  language: z.string(),
 });

--- a/src/lib/localization.ts
+++ b/src/lib/localization.ts
@@ -1,0 +1,17 @@
+export type LocalizedText = Record<string, string>;
+
+export function getLocalizedText(
+  map: LocalizedText,
+  lang: string,
+  fallback = "en",
+): string | undefined {
+  return map[lang] ?? map[fallback];
+}
+
+export function setLocalizedText(
+  map: LocalizedText,
+  lang: string,
+  text: string,
+): LocalizedText {
+  return { ...map, [lang]: text };
+}


### PR DESCRIPTION
## Summary
- add LocalizedText helpers
- localize OpenAI, CaseChat, and CaseReport types
- update LLM calls to handle language argument
- adjust analyzeViolation and OCR workflows
- update unit tests for new localized structures

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685ffb422214832b84f6c61710e7dc2c