### PR TITLE
Fix hero image zoom shifting

### DIFF
--- a/website/_includes/layout.njk
+++ b/website/_includes/layout.njk
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{{ title }}</title>
     <link rel="stylesheet" href="{{ '/style.css' | url }}" />
   </head>


### PR DESCRIPTION
## Summary
- add viewport meta tag to site layout to prevent hero image shifting on mobile zoom

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686023ac99f0832ba716c5af745674ff