### PR TITLE
Fix hero image center on zoom

### DIFF
--- a/website/style.css
+++ b/website/style.css
@@ -41,9 +41,10 @@ main {
 }
 
 .hero img {
+  display: block;
   max-width: 100%;
   height: auto;
-  margin-bottom: 1rem;
+  margin: 0 auto 1rem;
 }
 
 .hero h1 {


### PR DESCRIPTION
## Summary
- center hero images using display:block and auto margins to prevent jump when zooming on mobile

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686023ac99f0832ba716c5af745674ff