### PR TITLE
feat: add zoom reset button

### DIFF
--- a/src/app/components/ZoomableImage.tsx
+++ b/src/app/components/ZoomableImage.tsx
@@ -171,6 +171,15 @@ export default function ZoomableImage({ src, alt }: Props) {
           transformOrigin: "0 0",
         }}
       />
+      {transform.scale > 1 ? (
+        <button
+          type="button"
+          onClick={() => setTransform({ scale: 1, x: 0, y: 0 })}
+          className="absolute top-1 left-1 z-20 bg-black/60 text-white rounded px-1 text-xs"
+        >
+          Reset zoom
+        </button>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a reset zoom button for hero photos when zoomed in

## Testing
- `npm test`
- `npm run e2e:smoke` *(fails: Hook timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68602791ec78832bb9889edf5260b357