### PR TITLE
Fix image path storage

### DIFF
--- a/src/app/api/cases/[id]/thread-images/route.ts
+++ b/src/app/api/cases/[id]/thread-images/route.ts
@@ -48,7 +48,7 @@ export const POST = withCaseAuthorization(
     const updated = addCaseThreadImage(id, {
       id: new Date().toISOString(),
       threadParent: parent ?? null,
-      url: `/uploads/${filename}`,
+      url: filename,
       uploadedAt: new Date().toISOString(),
       ocrText: ocr.text,
       ocrInfo: ocr.info ?? null,

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -68,12 +68,7 @@ export const POST = withAuthorization(
     const existing = clientId ? getCase(clientId) : null;
     if (existing) {
       cancelCaseAnalysis(existing.id);
-      const updated = addCasePhoto(
-        existing.id,
-        `/uploads/${filename}`,
-        takenAt,
-        gps,
-      );
+      const updated = addCasePhoto(existing.id, filename, takenAt, gps);
       if (!updated) {
         return NextResponse.json({ error: "Not found" }, { status: 404 });
       }
@@ -97,7 +92,7 @@ export const POST = withAuthorization(
       return res;
     }
     const newCase = createCase(
-      `/uploads/${filename}`,
+      filename,
       gps,
       clientId || (!userId ? anonId : undefined),
       takenAt,

--- a/src/app/cases/[id]/components/PhotoViewer.tsx
+++ b/src/app/cases/[id]/components/PhotoViewer.tsx
@@ -46,7 +46,7 @@ export default function PhotoViewer({
   return (
     <>
       <div className="relative w-full aspect-[3/2] md:max-w-2xl shrink-0">
-        <ZoomableImage src={selectedPhoto} alt="uploaded" />
+        <ZoomableImage src={`/uploads/${selectedPhoto}`} alt="uploaded" />
         {isPhotoReanalysis && reanalyzingPhoto === selectedPhoto ? (
           <div className="absolute top-0 left-0 right-0">
             <Progress

--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -144,7 +144,7 @@ export default function ClientThreadPage({
               height={100}
               className="cursor-pointer"
               imgClassName="object-contain"
-              onClick={() => setViewImage(img.url)}
+              onClick={() => setViewImage(`/uploads/${img.url}`)}
             />
             <div className="flex flex-col gap-2 flex-1">
               <button

--- a/src/app/cases/__tests__/caseChatPhotoNote.test.tsx
+++ b/src/app/cases/__tests__/caseChatPhotoNote.test.tsx
@@ -7,7 +7,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 const caseData = {
-  photos: ["/uploads/a.jpg"],
+  photos: ["a.jpg"],
   photoNotes: {},
 };
 

--- a/src/lib/caseAnalysis.ts
+++ b/src/lib/caseAnalysis.ts
@@ -7,6 +7,7 @@ import { APIError } from "openai/error";
 
 import { clearQueue, enqueueTask, removeQueuedPhoto } from "./analysisQueue";
 import { type Case, getCase, updateCase } from "./caseStore";
+import { config } from "./config";
 import { runJob } from "./jobScheduler";
 import {
   AnalysisError,
@@ -65,11 +66,7 @@ export async function analyzeCase(caseData: Case): Promise<void> {
     const missing: string[] = [];
     const images = caseData.photos
       .map((p) => {
-        const filePath = path.join(
-          process.cwd(),
-          "public",
-          p.replace(/^\/+/, ""),
-        );
+        const filePath = path.join(config.UPLOAD_DIR, p);
         if (!fs.existsSync(filePath)) {
           missing.push(p);
           return null;
@@ -203,11 +200,7 @@ export async function reanalyzePhoto(
   caseData: Case,
   photo: string,
 ): Promise<void> {
-  const filePath = path.join(
-    process.cwd(),
-    "public",
-    photo.replace(/^\/+/, ""),
-  );
+  const filePath = path.join(config.UPLOAD_DIR, photo);
   if (!fs.existsSync(filePath)) {
     updateCase(caseData.id, {
       analysisStatus: "failed",

--- a/src/lib/contactMethods.ts
+++ b/src/lib/contactMethods.ts
@@ -134,7 +134,7 @@ export async function sendSnailMail(options: {
     y -= fontSize * 1.2;
   }
   for (const att of options.attachments) {
-    const abs = path.join(config.UPLOAD_DIR, att.replace(/^\/uploads\//, ""));
+    const abs = path.join(config.UPLOAD_DIR, att);
     if (!fs.existsSync(abs)) continue;
     const bytes = fs.readFileSync(abs);
     const ext = path.extname(abs).toLowerCase();

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -65,7 +65,7 @@ export async function sendEmail({
     text: body,
     attachments: attachments.map((p) => ({
       filename: path.basename(p),
-      path: path.join(config.UPLOAD_DIR, p.replace(/^\/uploads\//, "")),
+      path: path.join(config.UPLOAD_DIR, p),
     })),
   });
   log("email sent", to);

--- a/src/lib/inboxScanner.ts
+++ b/src/lib/inboxScanner.ts
@@ -63,8 +63,8 @@ export async function scanInbox(): Promise<void> {
           const gps = extractGps(buffer);
           const takenAt = extractTimestamp(buffer);
           gpsList.push(gps);
-          casePhotos.push(`/uploads/${filename}`);
-          photoTimes[`/uploads/${filename}`] = takenAt;
+          casePhotos.push(filename);
+          photoTimes[filename] = takenAt;
         }
         const firstGps = gpsList.find((g) => g) || null;
         const firstPhoto = casePhotos.shift();

--- a/test/snailMailAttachments.test.ts
+++ b/test/snailMailAttachments.test.ts
@@ -102,7 +102,7 @@ describe("sendSnailMail attachments", () => {
       address: "You\n2 B St\nSomewhere, ST 67890",
       subject: "Hello",
       body: "Body",
-      attachments: ["/uploads/img.png"],
+      attachments: ["img.png"],
     });
     expect(mockSend).toHaveBeenCalled();
     expect(createdPdf?.getPageCount()).toBe(2);

--- a/test/uploadRoute.test.ts
+++ b/test/uploadRoute.test.ts
@@ -79,7 +79,7 @@ afterEach(() => {
 
 describe("upload route", () => {
   it("cancels active analysis when uploading additional photo", async () => {
-    const c = caseStore.createCase("/a.jpg");
+    const c = caseStore.createCase("a.jpg");
     caseAnalysis.analyzeCaseInBackground(c);
     expect(runJobMock).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
## Summary
- don't store upload paths
- attach upload paths on the client side when rendering
- load case photos using filenames
- update email, snail mail, and tests for new storage format

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686026e8b13c832bb10d6975effcd6f3