### PR TITLE
Fix reset zoom button click

### DIFF
--- a/src/app/components/ZoomableImage.tsx
+++ b/src/app/components/ZoomableImage.tsx
@@ -57,7 +57,9 @@ export default function ZoomableImage({ src, alt }: Props) {
   const lastCenter = useRef<{ x: number; y: number } | null>(null);
 
   function handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {
-    e.currentTarget.setPointerCapture(e.pointerId);
+    if (e.currentTarget === e.target) {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    }
     pointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
   }
 


### PR DESCRIPTION
## Summary
- ensure pointer capture is only used when clicking on the image container

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686031129d98832b971937ccf4f30f9a