### PR TITLE
Fix case thumbnails in list

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -228,7 +228,7 @@ export default function ClientCasesPage({
                     const photo = getRepresentativePhoto(c);
                     return photo ? (
                       <img
-                        src={photo}
+                        src={`/uploads/${photo}`}
                         alt="case thumbnail"
                         width={80}
                         height={60}


### PR DESCRIPTION
## Summary
- fix case list to prefix filenames with `/uploads/` so thumbnails display

## Testing
- `npm test`
- `npm run e2e:smoke`

------
https://chatgpt.com/codex/tasks/task_e_68603278ecec832ba9abc461daac2151