### PR TITLE
Add basic localization support

### DIFF
--- a/migrations/0018_localized_maps.sql
+++ b/migrations/0018_localized_maps.sql
@@ -1,0 +1,3 @@
+ALTER TABLE case_photo_analysis ADD COLUMN highlights_map TEXT;
+ALTER TABLE case_photo_analysis ADD COLUMN context_map TEXT;
+ALTER TABLE case_photo_analysis ADD COLUMN paperwork_text_map TEXT;

--- a/src/lib/__tests__/caseReport.test.ts
+++ b/src/lib/__tests__/caseReport.test.ts
@@ -17,9 +17,10 @@ const baseCase: Case = {
   intersection: null,
   analysis: {
     violationType: "test",
-    details: "details",
+    details: { en: "details" },
     vehicle: {},
     images: { "foo.jpg": { representationScore: 1, violation: true } },
+    language: "en",
   },
   analysisOverrides: null,
   analysisStatus: "complete",
@@ -39,7 +40,15 @@ describe("draftEmail", () => {
     const { client } = getLlm("draft_email");
     vi.spyOn(client.chat.completions, "create").mockResolvedValueOnce({
       choices: [
-        { message: { content: JSON.stringify({ subject: "s", body: "b" }) } },
+        {
+          message: {
+            content: JSON.stringify({
+              subject: { en: "s" },
+              body: { en: "b" },
+              language: "en",
+            }),
+          },
+        },
       ],
     } as unknown as ChatCompletion);
 
@@ -48,7 +57,11 @@ describe("draftEmail", () => {
       reportModules["oak-park"],
       sender,
     );
-    expect(result).toEqual({ subject: "s", body: "b" });
+    expect(result).toEqual({
+      subject: { en: "s" },
+      body: { en: "b" },
+      language: "en",
+    });
   });
 
   it("retries when response is invalid", async () => {
@@ -60,7 +73,13 @@ describe("draftEmail", () => {
       .mockResolvedValueOnce({
         choices: [
           {
-            message: { content: JSON.stringify({ subject: "s2", body: "b2" }) },
+            message: {
+              content: JSON.stringify({
+                subject: { en: "s2" },
+                body: { en: "b2" },
+                language: "en",
+              }),
+            },
           },
         ],
       } as unknown as ChatCompletion);
@@ -70,7 +89,11 @@ describe("draftEmail", () => {
       reportModules["oak-park"],
       sender,
     );
-    expect(result).toEqual({ subject: "s2", body: "b2" });
+    expect(result).toEqual({
+      subject: { en: "s2" },
+      body: { en: "b2" },
+      language: "en",
+    });
   });
 
   it("returns empty draft after repeated failures", async () => {
@@ -84,7 +107,11 @@ describe("draftEmail", () => {
       reportModules["oak-park"],
       sender,
     );
-    expect(result).toEqual({ subject: "", body: "" });
+    expect(result).toEqual({
+      subject: { en: "" },
+      body: { en: "" },
+      language: "en",
+    });
   });
 });
 
@@ -93,14 +120,26 @@ describe("draftOwnerNotification", () => {
     const { client } = getLlm("draft_email");
     vi.spyOn(client.chat.completions, "create").mockResolvedValueOnce({
       choices: [
-        { message: { content: JSON.stringify({ subject: "s", body: "b" }) } },
+        {
+          message: {
+            content: JSON.stringify({
+              subject: { en: "s" },
+              body: { en: "b" },
+              language: "en",
+            }),
+          },
+        },
       ],
     } as unknown as ChatCompletion);
 
     const result = await draftOwnerNotification(baseCase, [
       "Oak Park Police Department",
     ]);
-    expect(result).toEqual({ subject: "s", body: "b" });
+    expect(result).toEqual({
+      subject: { en: "s" },
+      body: { en: "b" },
+      language: "en",
+    });
   });
 
   it("retries when response is invalid", async () => {
@@ -112,7 +151,13 @@ describe("draftOwnerNotification", () => {
       .mockResolvedValueOnce({
         choices: [
           {
-            message: { content: JSON.stringify({ subject: "s2", body: "b2" }) },
+            message: {
+              content: JSON.stringify({
+                subject: { en: "s2" },
+                body: { en: "b2" },
+                language: "en",
+              }),
+            },
           },
         ],
       } as unknown as ChatCompletion);
@@ -120,7 +165,11 @@ describe("draftOwnerNotification", () => {
     const result = await draftOwnerNotification(baseCase, [
       "Oak Park Police Department",
     ]);
-    expect(result).toEqual({ subject: "s2", body: "b2" });
+    expect(result).toEqual({
+      subject: { en: "s2" },
+      body: { en: "b2" },
+      language: "en",
+    });
   });
 
   it("returns empty draft after repeated failures", async () => {
@@ -132,6 +181,10 @@ describe("draftOwnerNotification", () => {
     const result = await draftOwnerNotification(baseCase, [
       "Oak Park Police Department",
     ]);
-    expect(result).toEqual({ subject: "", body: "" });
+    expect(result).toEqual({
+      subject: { en: "" },
+      body: { en: "" },
+      language: "en",
+    });
   });
 });

--- a/src/lib/__tests__/localization.test.ts
+++ b/src/lib/__tests__/localization.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getLocalizedText, setLocalizedText } from "../localization";
+
+describe("localization helpers", () => {
+  it("falls back to default language", () => {
+    const t = { en: "hi" };
+    expect(getLocalizedText(t, "es", "en")).toBe("hi");
+  });
+
+  it("updates localized text", () => {
+    const t = setLocalizedText({ en: "hi" }, "es", "hola");
+    expect(t.es).toBe("hola");
+  });
+});

--- a/src/lib/__tests__/openai.test.ts
+++ b/src/lib/__tests__/openai.test.ts
@@ -13,15 +13,22 @@ describe("openai client", () => {
     const { client } = getLlm("ocr_paperwork");
     vi.spyOn(client.chat.completions, "create")
       .mockResolvedValueOnce({
-        choices: [{ message: { content: "hello" } }],
+        choices: [
+          {
+            message: {
+              content: "hello",
+            },
+          },
+        ],
       } as unknown as ChatCompletion)
       .mockResolvedValueOnce({
         choices: [{ message: { content: '{"callsToAction":["pay now"]}' } }],
       } as unknown as ChatCompletion);
     const result = await ocrPaperwork({ url: "data:image/png;base64,foo" });
     expect(result).toEqual({
-      text: "hello",
+      text: { en: "hello" },
       info: { vehicle: {}, callsToAction: ["pay now"] },
+      language: "en",
     });
   });
 });

--- a/src/lib/caseChat.ts
+++ b/src/lib/caseChat.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { LocalizedText } from "./localization";
 import "./zod-setup";
 
 export type CaseChatAction =
@@ -7,13 +8,14 @@ export type CaseChatAction =
   | { photo: string; note: string };
 
 export interface CaseChatReply {
-  response: string;
+  response: LocalizedText;
   actions: CaseChatAction[];
   noop: boolean;
+  language: string;
 }
 
 export const caseChatReplySchema = z.object({
-  response: z.string(),
+  response: z.record(z.string()),
   actions: z.array(
     z.union([
       z.object({ id: z.string() }),
@@ -22,4 +24,5 @@ export const caseChatReplySchema = z.object({
     ]),
   ),
   noop: z.boolean(),
+  language: z.string(),
 });

--- a/src/lib/caseReport.ts
+++ b/src/lib/caseReport.ts
@@ -3,6 +3,7 @@ import type { ChatCompletionMessageParam } from "openai/resources/chat/completio
 import { z } from "zod";
 import type { Case, SentEmail } from "./caseStore";
 import { getLlm } from "./llm";
+import type { LocalizedText } from "./localization";
 import { log } from "./logger";
 import type { ReportModule } from "./reportModules";
 import { getViolationCode } from "./violationCodes";
@@ -23,16 +24,22 @@ function logBadResponse(
 }
 
 export const emailDraftSchema = z.object({
-  subject: z.string(),
-  body: z.string(),
+  subject: z.record(z.string()),
+  body: z.record(z.string()),
+  language: z.string(),
 });
 
-export type EmailDraft = z.infer<typeof emailDraftSchema>;
+export interface EmailDraft {
+  subject: LocalizedText;
+  body: LocalizedText;
+  language: string;
+}
 
 export async function draftEmail(
   caseData: Case,
   mod: ReportModule,
   sender?: { name?: string | null; email?: string | null },
+  lang = "en",
 ): Promise<EmailDraft> {
   const analysis = caseData.analysis;
   const vehicle = analysis?.vehicle ?? {};
@@ -87,7 +94,7 @@ Mention that photos are attached. Respond with JSON matching this schema: ${JSON
   const baseMessages: ChatCompletionMessageParam[] = [
     {
       role: "system",
-      content: "You create email drafts for municipal authorities.",
+      content: `You create email drafts for municipal authorities. Reply in ${lang}.`,
     },
     { role: "user", content: prompt } as ChatCompletionMessageParam,
   ];
@@ -104,10 +111,16 @@ Mention that photos are attached. Respond with JSON matching this schema: ${JSON
     const text = res.choices[0]?.message?.content ?? "{}";
     try {
       const parsed = JSON.parse(text);
-      return emailDraftSchema.parse(parsed);
+      const draft = emailDraftSchema.parse(parsed);
+      return { ...draft, language: lang };
     } catch (err) {
       logBadResponse(attempt, text, err);
-      if (attempt === 2) return { subject: "", body: "" };
+      if (attempt === 2)
+        return {
+          subject: { [lang]: "" },
+          body: { [lang]: "" },
+          language: lang,
+        };
       messages.push({ role: "assistant", content: text });
       messages.push({
         role: "user",
@@ -115,7 +128,7 @@ Mention that photos are attached. Respond with JSON matching this schema: ${JSON
       });
     }
   }
-  return { subject: "", body: "" };
+  return { subject: { [lang]: "" }, body: { [lang]: "" }, language: lang };
 }
 
 export async function draftFollowUp(
@@ -123,6 +136,7 @@ export async function draftFollowUp(
   recipient: string,
   historyEmails: SentEmail[] = caseData.sentEmails ?? [],
   sender?: { name?: string | null; email?: string | null },
+  lang = "en",
 ): Promise<EmailDraft> {
   log(
     `draftFollowUp recipient=${recipient} history=${historyEmails
@@ -167,7 +181,7 @@ Ask about the current citation status and mention that photos are attached again
   const baseMessages: ChatCompletionMessageParam[] = [
     {
       role: "system",
-      content: "You create email drafts for municipal authorities.",
+      content: `You create email drafts for municipal authorities. Reply in ${lang}.`,
     },
     ...history,
     { role: "user", content: prompt } as ChatCompletionMessageParam,
@@ -187,10 +201,16 @@ Ask about the current citation status and mention that photos are attached again
     const text = res.choices[0]?.message?.content ?? "{}";
     try {
       const parsed = JSON.parse(text);
-      return emailDraftSchema.parse(parsed);
+      const draft = emailDraftSchema.parse(parsed);
+      return { ...draft, language: lang };
     } catch (err) {
       logBadResponse(attempt, text, err);
-      if (attempt === 2) return { subject: "", body: "" };
+      if (attempt === 2)
+        return {
+          subject: { [lang]: "" },
+          body: { [lang]: "" },
+          language: lang,
+        };
       messages.push({ role: "assistant", content: text });
       messages.push({
         role: "user",
@@ -198,11 +218,12 @@ Ask about the current citation status and mention that photos are attached again
       });
     }
   }
-  return { subject: "", body: "" };
+  return { subject: { [lang]: "" }, body: { [lang]: "" }, language: lang };
 }
 export async function draftOwnerNotification(
   caseData: Case,
   authorities: string[],
+  lang = "en",
 ): Promise<EmailDraft> {
   const analysis = caseData.analysis;
   const vehicle = analysis?.vehicle ?? {};
@@ -244,8 +265,7 @@ export async function draftOwnerNotification(
   const baseMessages: ChatCompletionMessageParam[] = [
     {
       role: "system",
-      content:
-        "You create anonymous notification emails for vehicle owners about violations.",
+      content: `You create anonymous notification emails for vehicle owners about violations. Reply in ${lang}.`,
     },
     { role: "user", content: prompt } as ChatCompletionMessageParam,
   ];
@@ -261,10 +281,16 @@ export async function draftOwnerNotification(
     const text = res.choices[0]?.message?.content ?? "{}";
     try {
       const parsed = JSON.parse(text);
-      return emailDraftSchema.parse(parsed);
+      const draft = emailDraftSchema.parse(parsed);
+      return { ...draft, language: lang };
     } catch (err) {
       logBadResponse(attempt, text, err);
-      if (attempt === 2) return { subject: "", body: "" };
+      if (attempt === 2)
+        return {
+          subject: { [lang]: "" },
+          body: { [lang]: "" },
+          language: lang,
+        };
       messages.push({ role: "assistant", content: text });
       messages.push({
         role: "user",
@@ -272,5 +298,5 @@ export async function draftOwnerNotification(
       });
     }
   }
-  return { subject: "", body: "" };
+  return { subject: { [lang]: "" }, body: { [lang]: "" }, language: lang };
 }

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -126,10 +126,19 @@ function rowToCase(row: {
     for (const a of analysisRows) {
       images[path.basename(a.url)] = {
         representationScore: a.representationScore,
-        ...(a.highlights !== null && { highlights: a.highlights }),
+        ...(a.highlightsMap !== null
+          ? { highlights: JSON.parse(a.highlightsMap) }
+          : a.highlights !== null
+            ? { highlights: { en: a.highlights } }
+            : {}),
+        ...(a.contextMap !== null && { context: JSON.parse(a.contextMap) }),
         ...(a.violation !== null && { violation: Boolean(a.violation) }),
         ...(a.paperwork !== null && { paperwork: Boolean(a.paperwork) }),
-        ...(a.paperworkText !== null && { paperworkText: a.paperworkText }),
+        ...(a.paperworkTextMap !== null
+          ? { paperworkText: JSON.parse(a.paperworkTextMap) }
+          : a.paperworkText !== null
+            ? { paperworkText: { en: a.paperworkText } }
+            : {}),
         ...(a.paperworkInfo !== null && {
           paperworkInfo: JSON.parse(a.paperworkInfo),
         }),
@@ -197,7 +206,12 @@ function saveCase(c: Case) {
           caseId: c.id,
           url,
           representationScore: info.representationScore,
-          highlights: info.highlights ?? null,
+          highlights:
+            typeof info.highlights === "string" ? info.highlights : null,
+          highlightsMap:
+            typeof info.highlights === "object" && info.highlights
+              ? JSON.stringify(info.highlights)
+              : null,
           violation:
             info.violation === undefined || info.violation === null
               ? null
@@ -210,7 +224,16 @@ function saveCase(c: Case) {
               : info.paperwork
                 ? 1
                 : 0,
-          paperworkText: info.paperworkText ?? null,
+          paperworkText:
+            typeof info.paperworkText === "string" ? info.paperworkText : null,
+          contextMap:
+            info.context && typeof info.context === "object"
+              ? JSON.stringify(info.context)
+              : null,
+          paperworkTextMap:
+            typeof info.paperworkText === "object" && info.paperworkText
+              ? JSON.stringify(info.paperworkText)
+              : null,
           paperworkInfo: info.paperworkInfo
             ? JSON.stringify(info.paperworkInfo)
             : null,

--- a/src/lib/localization.ts
+++ b/src/lib/localization.ts
@@ -1,0 +1,20 @@
+export interface LocalizedText {
+  [lang: string]: string;
+}
+
+export function getLocalizedText(
+  text: LocalizedText | undefined,
+  lang: string,
+  defaultLang = "en",
+): string {
+  if (!text) return "";
+  return text[lang] ?? text[defaultLang] ?? "";
+}
+
+export function setLocalizedText(
+  text: LocalizedText | undefined,
+  lang: string,
+  value: string,
+): LocalizedText {
+  return { ...(text ?? {}), [lang]: value };
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -34,9 +34,12 @@ export const casePhotoAnalysis = sqliteTable(
     url: text("url").notNull(),
     representationScore: real("representation_score").notNull(),
     highlights: text("highlights"),
+    highlightsMap: text("highlights_map"),
     violation: integer("violation"),
     paperwork: integer("paperwork"),
     paperworkText: text("paperwork_text"),
+    contextMap: text("context_map"),
+    paperworkTextMap: text("paperwork_text_map"),
     paperworkInfo: text("paperwork_info"),
   },
   (t) => ({


### PR DESCRIPTION
## Summary
- introduce `LocalizedText` helpers
- update OpenAI result types to include localization maps
- add language-aware email drafting
- extend database schema for localized maps
- add unit tests for localization

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_685ffb422214832b84f6c61710e7dc2c