### PR TITLE
Fix reanalysis e2e timing

### DIFF
--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -149,7 +149,7 @@ describe("reanalysis", () => {
       await poll(
         () => Promise.resolve(stub.requests.length),
         (len) => len >= 1,
-        20,
+        40,
       );
       expect(stub.requests.length).toBeGreaterThanOrEqual(1);
     });
@@ -244,7 +244,7 @@ describe("reanalysis", () => {
       await poll(
         () => Promise.resolve(stub.requests.length),
         (len) => len >= 1,
-        20,
+        40,
       );
       expect(stub.requests.length).toBeGreaterThanOrEqual(1);
     });


### PR DESCRIPTION
## Summary
- increase wait time for OpenAI stub requests in reanalyze e2e tests

## Testing
- `npm test`
- `npm run e2e:smoke`
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_e_6860329f32bc832b9def27e4e08c85ed