### PR TITLE
Restrict case photo access

### DIFF
--- a/src/app/uploads/[...path]/route.ts
+++ b/src/app/uploads/[...path]/route.ts
@@ -3,20 +3,49 @@ import path from "node:path";
 
 import { NextResponse } from "next/server";
 
+import { getAnonymousSessionId } from "@/lib/anonymousSession";
+import { authorize, loadAuthContext } from "@/lib/authz";
+import { isCaseMember } from "@/lib/caseMembers";
+import { getCaseForUpload } from "@/lib/caseStore";
+
 import { config } from "@/lib/config";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(
-  _req: Request,
-  { params }: { params: Promise<{ path: string[] }> },
+  req: Request,
+  {
+    params,
+    session,
+  }: {
+    params: Promise<{ path: string[] }>;
+    session?: { user?: { id?: string; role?: string } };
+  },
 ): Promise<Response> {
   const { path: segments } = await params;
   const uploads = config.UPLOAD_DIR;
   const full = path.join(uploads, ...segments);
   if (!full.startsWith(uploads)) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const filename = segments[segments.length - 1];
+  const caseData = getCaseForUpload(filename);
+  if (caseData) {
+    const { role, userId } = await loadAuthContext({ session });
+    const anonId = getAnonymousSessionId(req);
+    const sessionMatch =
+      anonId && caseData.sessionId && caseData.sessionId === anonId;
+    const authRole = sessionMatch ? "user" : role;
+    const authCtx = sessionMatch ? undefined : { caseId: caseData.id, userId };
+    if (!(await authorize(authRole, "cases", "read", authCtx))) {
+      return new Response(null, { status: 403 });
+    }
+    if (!caseData.public && role !== "admin" && role !== "superadmin") {
+      if (!(sessionMatch || (userId && isCaseMember(caseData.id, userId)))) {
+        return new Response(null, { status: 403 });
+      }
+    }
   }
   try {
     const data = await fs.readFile(full);

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -531,6 +531,24 @@ export function claimCasesForSession(
   return claimed;
 }
 
+export function getCaseIdForPhoto(photo: string): string | undefined {
+  const row = orm
+    .select({ caseId: casePhotos.caseId })
+    .from(casePhotos)
+    .where(eq(casePhotos.url, photo))
+    .get() as { caseId: string } | undefined;
+  return row?.caseId;
+}
+
+export function getCaseForUpload(photo: string): Case | undefined {
+  const id = getCaseIdForPhoto(photo);
+  if (id) return getCase(id);
+  const all = getCases();
+  return all.find((c) =>
+    (c.threadImages ?? []).some((img) => img.url === photo),
+  );
+}
+
 export function deleteAnonymousCasesOlderThan(cutoff: Date): number {
   const rows = db
     .prepare("SELECT id, data FROM cases WHERE session_id IS NOT NULL")

--- a/test/uploadsAuth.test.ts
+++ b/test/uploadsAuth.test.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let dataDir: string;
+let uploadDir: string;
+let route: typeof import("@/app/uploads/[...path]/route");
+let store: typeof import("@/lib/caseStore");
+let configMod: typeof import("@/lib/config");
+let orm: typeof import("@/lib/orm").orm;
+let schema: typeof import("@/lib/schema");
+let origUploadDir: string;
+
+beforeEach(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
+  uploadDir = fs.mkdtempSync(path.join(os.tmpdir(), "uploads-"));
+  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
+  vi.resetModules();
+  const db = await import("@/lib/db");
+  await db.migrationsReady;
+  ({ orm } = await import("@/lib/orm"));
+  schema = await import("@/lib/schema");
+  orm
+    .insert(schema.casbinRules)
+    .values({ ptype: "p", v0: "user", v1: "cases", v2: "read" })
+    .run();
+  orm
+    .insert(schema.users)
+    .values([{ id: "u1" }, { id: "u2" }])
+    .run();
+  store = await import("@/lib/caseStore");
+  configMod = await import("@/lib/config");
+  origUploadDir = configMod.config.UPLOAD_DIR;
+  configMod.config.UPLOAD_DIR = uploadDir;
+  fs.mkdirSync(uploadDir, { recursive: true });
+  route = await import("@/app/uploads/[...path]/route");
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.rmSync(uploadDir, { recursive: true, force: true });
+  vi.resetModules();
+  process.env.CASE_STORE_FILE = undefined;
+  if (configMod) configMod.config.UPLOAD_DIR = origUploadDir;
+});
+
+describe("uploads route authorization", () => {
+  it("rejects access by non-member", async () => {
+    const c = store.createCase("a.jpg", null, undefined, null, "u1");
+    fs.writeFileSync(path.join(uploadDir, "a.jpg"), "a");
+    const res = await route.GET(new Request("http://test"), {
+      params: Promise.resolve({ path: ["a.jpg"] }),
+      session: { user: { id: "u2", role: "user" } },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("allows access via anonymous session", async () => {
+    const c = store.createCase("b.jpg");
+    store.setCaseSessionId(c.id, "sess");
+    fs.writeFileSync(path.join(uploadDir, "b.jpg"), "b");
+    const req = new Request("http://test");
+    req.headers.set("cookie", "anon_session_id=sess");
+    const res = await route.GET(req, {
+      params: Promise.resolve({ path: ["b.jpg"] }),
+    });
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- restrict `/uploads` route to case members
- expose helper to look up case by photo
- test upload route authorization

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686037fdb57c832baf61252537ff2a85