### PR TITLE
Restrict uploaded photo access

### DIFF
--- a/src/app/uploads/[...path]/route.ts
+++ b/src/app/uploads/[...path]/route.ts
@@ -3,20 +3,51 @@ import path from "node:path";
 
 import { NextResponse } from "next/server";
 
+import { getAnonymousSessionId } from "@/lib/anonymousSession";
+import { authorize, loadAuthContext } from "@/lib/authz";
+import { isCaseMember } from "@/lib/caseMembers";
+import { findCaseIdForFile, getCase } from "@/lib/caseStore";
+
 import { config } from "@/lib/config";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(
-  _req: Request,
-  { params }: { params: Promise<{ path: string[] }> },
+  req: Request,
+  {
+    params,
+    session,
+  }: {
+    params: Promise<{ path: string[] }>;
+    session?: { user?: { id?: string; role?: string } };
+  },
 ): Promise<Response> {
   const { path: segments } = await params;
   const uploads = config.UPLOAD_DIR;
   const full = path.join(uploads, ...segments);
   if (!full.startsWith(uploads)) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const filename = segments[segments.length - 1];
+  const caseId = findCaseIdForFile(filename);
+  if (caseId) {
+    const c = getCase(caseId);
+    if (!c) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const { role, userId } = await loadAuthContext({ session });
+    const anonId = getAnonymousSessionId(req);
+    const sessionMatch = anonId && c.sessionId && c.sessionId === anonId;
+    const authRole = sessionMatch ? "user" : role;
+    if (!(await authorize(authRole, "cases", "read"))) {
+      return new Response(null, { status: 403 });
+    }
+    if (!c.public && role !== "admin" && role !== "superadmin") {
+      if (!(sessionMatch || (userId && isCaseMember(caseId, userId)))) {
+        return new Response(null, { status: 403 });
+      }
+    }
   }
   try {
     const data = await fs.readFile(full);

--- a/test/uploadsAccess.test.ts
+++ b/test/uploadsAccess.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let dataDir: string;
+let uploadDir: string;
+let mod: typeof import("@/app/uploads/[...path]/route");
+let store: typeof import("@/lib/caseStore");
+let config: typeof import("@/lib/config").config;
+
+beforeEach(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
+  uploadDir = fs.mkdtempSync(path.join(os.tmpdir(), "uploads-"));
+  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
+  vi.resetModules();
+  const db = await import("@/lib/db");
+  await db.migrationsReady;
+  store = await import("@/lib/caseStore");
+  const { orm } = await import("@/lib/orm");
+  const { users } = await import("@/lib/schema");
+  orm.insert(users).values({ id: "u1" }).run();
+  ({ config } = await import("@/lib/config"));
+  config.UPLOAD_DIR = uploadDir;
+  fs.writeFileSync(path.join(uploadDir, "a.jpg"), "a");
+  mod = await import("@/app/uploads/[...path]/route");
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.rmSync(uploadDir, { recursive: true, force: true });
+  vi.resetModules();
+  process.env.CASE_STORE_FILE = undefined;
+});
+
+describe("uploads access", () => {
+  it("denies private case photo to strangers", async () => {
+    const c = store.createCase("a.jpg", null, undefined, null, "u1");
+    const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({ path: ["a.jpg"] }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("allows access when session matches", async () => {
+    const c = store.createCase("a.jpg");
+    store.setCaseSessionId(c.id, "sess");
+    const req = new Request("http://test");
+    req.headers.set("cookie", "anon_session_id=sess");
+    const res = await mod.GET(req, {
+      params: Promise.resolve({ path: ["a.jpg"] }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("allows member access", async () => {
+    const c = store.createCase("a.jpg", null, undefined, null, "u1");
+    const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({ path: ["a.jpg"] }),
+      session: { user: { id: "u1", role: "user" } },
+    });
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- only serve uploaded photos when the requester is a case member or session owner
- find case for a given filename
- test access controls on uploads

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686037fdb57c832baf61252537ff2a85