### PR TITLE
Add lang parameter to OpenAI helpers

### DIFF
--- a/src/lib/__tests__/analyzeViolation.test.ts
+++ b/src/lib/__tests__/analyzeViolation.test.ts
@@ -11,7 +11,7 @@ afterEach(() => {
 
 describe("analyzeViolation", () => {
   it("rejects when no images are provided", async () => {
-    await expect(analyzeViolation([])).rejects.toMatchObject({
+    await expect(analyzeViolation([], "en")).rejects.toMatchObject({
       kind: "images",
     });
   });
@@ -21,7 +21,7 @@ describe("analyzeViolation", () => {
       choices: [{ message: { content: "{" }, finish_reason: "length" }],
     } as unknown as ChatCompletion);
 
-    await expect(analyzeViolation(imgs)).rejects.toMatchObject({
+    await expect(analyzeViolation(imgs, "en")).rejects.toMatchObject({
       kind: "truncated",
     });
   });
@@ -32,7 +32,7 @@ describe("analyzeViolation", () => {
       choices: [{ message: { content: "oops" }, finish_reason: "stop" }],
     } as unknown as ChatCompletion);
 
-    await expect(analyzeViolation(imgs)).rejects.toMatchObject({
+    await expect(analyzeViolation(imgs, "en")).rejects.toMatchObject({
       kind: "parse",
     });
   });
@@ -43,7 +43,7 @@ describe("analyzeViolation", () => {
       choices: [{ message: { content: "{}" }, finish_reason: "stop" }],
     } as unknown as ChatCompletion);
 
-    await expect(analyzeViolation(imgs)).rejects.toMatchObject({
+    await expect(analyzeViolation(imgs, "en")).rejects.toMatchObject({
       kind: "schema",
     });
   });
@@ -60,7 +60,7 @@ describe("analyzeViolation", () => {
       choices: [{ message: { content: reply }, finish_reason: "stop" }],
     } as unknown as ChatCompletion);
 
-    await expect(analyzeViolation(imgs)).rejects.toMatchObject({
+    await expect(analyzeViolation(imgs, "en")).rejects.toMatchObject({
       kind: "schema",
     });
   });

--- a/src/lib/__tests__/openai.test.ts
+++ b/src/lib/__tests__/openai.test.ts
@@ -18,7 +18,10 @@ describe("openai client", () => {
       .mockResolvedValueOnce({
         choices: [{ message: { content: '{"callsToAction":["pay now"]}' } }],
       } as unknown as ChatCompletion);
-    const result = await ocrPaperwork({ url: "data:image/png;base64,foo" });
+    const result = await ocrPaperwork(
+      { url: "data:image/png;base64,foo" },
+      "en",
+    );
     expect(result).toEqual({
       text: "hello",
       info: { vehicle: {}, callsToAction: ["pay now"] },

--- a/src/lib/caseAnalysis.ts
+++ b/src/lib/caseAnalysis.ts
@@ -109,7 +109,7 @@ export async function analyzeCase(caseData: Case): Promise<void> {
         steps,
       },
     });
-    const result = await analyzeViolation(images, (p) => {
+    const result = await analyzeViolation(images, "en", (p) => {
       updateCase(caseData.id, {
         analysisProgress: { ...p, step: currentStep, steps },
       });
@@ -129,7 +129,7 @@ export async function analyzeCase(caseData: Case): Promise<void> {
     steps = 1 + paperwork.length;
     let stepIndex = 2;
     for (const [name, url] of paperwork) {
-      const ocr = await ocrPaperwork({ url }, (p) => {
+      const ocr = await ocrPaperwork({ url }, "en", (p) => {
         updateCase(caseData.id, {
           analysisProgress: { ...p, step: stepIndex, steps },
         });
@@ -226,6 +226,7 @@ export async function reanalyzePhoto(
   try {
     const result = await analyzeViolation(
       [{ filename: path.basename(photo), url: dataUrl }],
+      "en",
       (p) => {
         updateCase(caseData.id, {
           analysisProgress: { ...p, step: 1, steps: 1 },
@@ -238,6 +239,7 @@ export async function reanalyzePhoto(
     if (info?.paperwork && !info.paperworkText) {
       const ocr = await ocrPaperwork(
         { url: dataUrl },
+        "en",
         (p) => {
           updateCase(caseData.id, {
             analysisProgress: { ...p, step: 2, steps: 2 },

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -145,6 +145,7 @@ export const violationReportSchema: z.ZodType<ViolationReport> = z.object({
 
 export async function analyzeViolation(
   images: Array<{ url: string; filename: string }>,
+  lang = "en",
   progress?: (info: LlmProgress) => void,
   signal?: AbortSignal,
 ): Promise<ViolationReport> {
@@ -192,8 +193,7 @@ export async function analyzeViolation(
   const baseMessages: ChatCompletionMessageParam[] = [
     {
       role: "system",
-      content:
-        "You identify vehicle violations and reply in JSON strictly following the provided schema. License plate states should be two uppercase letters. Omit the licensePlateNumber and licensePlateState fields if no plate is visible.",
+      content: `You identify vehicle violations and reply in JSON strictly following the provided schema. License plate states should be two uppercase letters. Omit the licensePlateNumber and licensePlateState fields if no plate is visible. Reply in ${lang}.`,
     },
     {
       role: "user",
@@ -296,6 +296,7 @@ export async function analyzeViolation(
 
 export async function extractPaperworkInfo(
   text: string,
+  lang = "en",
 ): Promise<PaperworkInfo> {
   const schema = {
     type: "object",
@@ -317,8 +318,7 @@ export async function extractPaperworkInfo(
   const baseMessages: ChatCompletionMessageParam[] = [
     {
       role: "system",
-      content:
-        "You extract structured vehicle information from text and reply in JSON strictly following the provided schema. A VIN is a 17-character string of digits and capital letters except I, O, and Q.",
+      content: `You extract structured vehicle information from text and reply in JSON strictly following the provided schema. A VIN is a 17-character string of digits and capital letters except I, O, and Q. Reply in ${lang}.`,
     },
     {
       role: "user",
@@ -357,14 +357,14 @@ export async function extractPaperworkInfo(
 
 export async function ocrPaperwork(
   image: { url: string },
+  lang = "en",
   progress?: (info: LlmProgress) => void,
   signal?: AbortSignal,
 ): Promise<PaperworkAnalysis> {
   const baseMessages: ChatCompletionMessageParam[] = [
     {
       role: "system",
-      content:
-        "You transcribe text from public paperwork. Return the text exactly as it appears, with no redactions or omissions.",
+      content: `You transcribe text from public paperwork. Return the text exactly as it appears, with no redactions or omissions. Reply in ${lang}.`,
     },
     {
       role: "user",
@@ -416,7 +416,7 @@ export async function ocrPaperwork(
       text = (res as ChatCompletion).choices[0]?.message?.content ?? "";
     }
     if (text.trim()) {
-      const info = await extractPaperworkInfo(text.trim());
+      const info = await extractPaperworkInfo(text.trim(), lang);
       return { text: text.trim(), info };
     }
     logBadResponse(attempt, text, new Error("Empty OCR result"));


### PR DESCRIPTION
## Summary
- allow passing a language string to `analyzeViolation`, `ocrPaperwork` and `extractPaperworkInfo`
- include language in system prompts
- default to `en` when calling helpers in case analysis and thread image upload
- adjust tests for new signatures

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke` *(fails: run did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_686039875c48832b8d85ae0468924374