### PR TITLE
fix: stabilize reanalysis test

### DIFF
--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -177,6 +177,12 @@ describe("reanalysis", () => {
       });
       expect(rean.status).toBe(200);
 
+      await poll(
+        () => api(`/api/cases/${caseId}/analysis-active`),
+        async (r) => (await r.json()).active === true,
+        10,
+      );
+
       const single = await api(
         `/api/cases/${caseId}/reanalyze-photo?photo=${encodeURIComponent(photo)}`,
         { method: "POST" },


### PR DESCRIPTION
## Summary
- wait for analysis to start before reanalyzing a single photo

## Testing
- `npm test`
- `npm run e2e:smoke`

------
https://chatgpt.com/codex/tasks/task_e_6860380b0584832b9f95e76f6756d4ba