### PR TITLE
Fix isCaseAnalysisActive pending check

### DIFF
--- a/src/lib/caseAnalysis.ts
+++ b/src/lib/caseAnalysis.ts
@@ -27,7 +27,9 @@ export function isPhotoAnalysisActive(id: string, photo: string): boolean {
 }
 
 export function isCaseAnalysisActive(id: string): boolean {
-  return activeWorkers.has(id);
+  if (activeWorkers.has(id)) return true;
+  const c = getCase(id);
+  return c?.analysisStatus === "pending";
 }
 
 export function cancelCaseAnalysis(id: string): boolean {


### PR DESCRIPTION
## Summary
- mark case analysis active when status is pending

## Testing
- `npm test`
- `npm run e2e:smoke` *(fails: log truncated, may require rerun)*

------
https://chatgpt.com/codex/tasks/task_e_6860380b0584832b9f95e76f6756d4ba