### PR TITLE
Fix public case image access

### DIFF
--- a/src/app/uploads/[...path]/route.ts
+++ b/src/app/uploads/[...path]/route.ts
@@ -40,7 +40,10 @@ export async function GET(
     const anonId = getAnonymousSessionId(req);
     const sessionMatch = anonId && c.sessionId && c.sessionId === anonId;
     const authRole = sessionMatch ? "user" : role;
-    if (!(await authorize(authRole, "cases", "read"))) {
+    const canReadCase = await authorize(authRole, "cases", "read");
+    const canReadPublic =
+      c.public && (await authorize(role, "public_cases", "read"));
+    if (!(canReadCase || canReadPublic)) {
       return new Response(null, { status: 403 });
     }
     if (!c.public && role !== "admin" && role !== "superadmin") {

--- a/test/uploadsAccess.test.ts
+++ b/test/uploadsAccess.test.ts
@@ -61,4 +61,12 @@ describe("uploads access", () => {
     });
     expect(res.status).toBe(200);
   });
+
+  it("allows anonymous access to public case photo", async () => {
+    store.createCase("a.jpg", null, undefined, null, undefined, true);
+    const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({ path: ["a.jpg"] }),
+    });
+    expect(res.status).toBe(200);
+  });
 });


### PR DESCRIPTION
## Summary
- permit anonymous users to fetch images from public cases
- test uploads route for anonymous public case access

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke` *(fails: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68603e1fbf08832bb53c3dfe11cfb599