### PR TITLE
fix uploads access for public cases

### DIFF
--- a/src/app/triage/page.tsx
+++ b/src/app/triage/page.tsx
@@ -12,7 +12,7 @@ import { reportModules } from "@/lib/reportModules";
 import { getServerSession } from "next-auth/next";
 import { cookies, headers } from "next/headers";
 import Link from "next/link";
-import i18n, { initI18n } from "../../i18n";
+import i18n, { initI18n } from "../../i18n.server";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/uploads/[...path]/route.ts
+++ b/src/app/uploads/[...path]/route.ts
@@ -40,7 +40,8 @@ export async function GET(
     const anonId = getAnonymousSessionId(req);
     const sessionMatch = anonId && c.sessionId && c.sessionId === anonId;
     const authRole = sessionMatch ? "user" : role;
-    if (!(await authorize(authRole, "cases", "read"))) {
+    const obj = c.public ? "public_cases" : "cases";
+    if (!(await authorize(authRole, obj, "read"))) {
       return new Response(null, { status: 403 });
     }
     if (!c.public && role !== "admin" && role !== "superadmin") {

--- a/src/i18n.server.ts
+++ b/src/i18n.server.ts
@@ -1,0 +1,27 @@
+import i18n from "i18next";
+import enCommon from "../public/locales/en/common.json";
+import esCommon from "../public/locales/es/common.json";
+import frCommon from "../public/locales/fr/common.json";
+
+const instance = i18n.createInstance();
+
+export async function initI18n(lang: string) {
+  if (!instance.isInitialized) {
+    await instance.init({
+      resources: {
+        en: { common: enCommon },
+        es: { common: esCommon },
+        fr: { common: frCommon },
+      },
+      lng: lang,
+      fallbackLng: "en",
+      defaultNS: "common",
+      interpolation: { escapeValue: false },
+    });
+  } else if (instance.language !== lang) {
+    await instance.changeLanguage(lang);
+  }
+  return instance;
+}
+
+export default instance;

--- a/test/uploadsAccess.test.ts
+++ b/test/uploadsAccess.test.ts
@@ -61,4 +61,12 @@ describe("uploads access", () => {
     });
     expect(res.status).toBe(200);
   });
+
+  it("allows access to public case photo", async () => {
+    store.createCase("a.jpg", null, undefined, null, undefined, true);
+    const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({ path: ["a.jpg"] }),
+    });
+    expect(res.status).toBe(200);
+  });
 });


### PR DESCRIPTION
## Summary
- allow public case photo requests
- avoid `react-i18next` in server components
- test public case photo access

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68603e1fbf08832bb53c3dfe11cfb599