### PR TITLE
fix: protect private case pages

### DIFF
--- a/src/app/cases/[id]/compose/page.tsx
+++ b/src/app/cases/[id]/compose/page.tsx
@@ -1,5 +1,6 @@
 import ComposeWrapper from "@/app/cases/[id]/ComposeWrapper";
-import { getCase } from "@/lib/caseStore";
+import { getAuthorizedCase } from "@/lib/caseAccess";
+import { notFound } from "next/navigation";
 
 export const dynamic = "force-dynamic";
 
@@ -9,6 +10,7 @@ export default async function ComposePage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const c = getCase(id);
-  return <ComposeWrapper caseData={c ?? null} caseId={id} />;
+  const c = await getAuthorizedCase(id);
+  if (!c) notFound();
+  return <ComposeWrapper caseData={c} caseId={id} />;
 }

--- a/src/app/cases/[id]/draft/page.tsx
+++ b/src/app/cases/[id]/draft/page.tsx
@@ -1,8 +1,9 @@
 import { authOptions } from "@/lib/authOptions";
+import { getAuthorizedCase } from "@/lib/caseAccess";
 import { draftEmail } from "@/lib/caseReport";
-import { getCase } from "@/lib/caseStore";
 import { reportModules } from "@/lib/reportModules";
 import { getServerSession } from "next-auth/next";
+import { notFound } from "next/navigation";
 import DraftEditor from "./DraftEditor";
 
 export const dynamic = "force-dynamic";
@@ -11,8 +12,8 @@ export default async function DraftPage({
   params,
 }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const c = getCase(id);
-  if (!c) return <div className="p-8">Case not found</div>;
+  const c = await getAuthorizedCase(id);
+  if (!c) notFound();
   const reportModule = reportModules["oak-park"];
   const session = await getServerSession(authOptions);
   const sender = session?.user

--- a/src/app/cases/[id]/followup/page.tsx
+++ b/src/app/cases/[id]/followup/page.tsx
@@ -1,5 +1,6 @@
 import FollowUpWrapper from "@/app/cases/[id]/FollowUpWrapper";
-import { getCase } from "@/lib/caseStore";
+import { getAuthorizedCase } from "@/lib/caseAccess";
+import { notFound } from "next/navigation";
 
 export const dynamic = "force-dynamic";
 
@@ -9,6 +10,7 @@ export default async function FollowUpPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const c = getCase(id);
-  return <FollowUpWrapper caseData={c ?? null} caseId={id} />;
+  const c = await getAuthorizedCase(id);
+  if (!c) notFound();
+  return <FollowUpWrapper caseData={c} caseId={id} />;
 }

--- a/src/app/cases/[id]/notify-owner/page.tsx
+++ b/src/app/cases/[id]/notify-owner/page.tsx
@@ -1,5 +1,6 @@
 import NotifyOwnerWrapper from "@/app/cases/[id]/NotifyOwnerWrapper";
-import { getCase } from "@/lib/caseStore";
+import { getAuthorizedCase } from "@/lib/caseAccess";
+import { notFound } from "next/navigation";
 
 export const dynamic = "force-dynamic";
 
@@ -9,6 +10,7 @@ export default async function NotifyOwnerPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const c = getCase(id);
-  return <NotifyOwnerWrapper caseData={c ?? null} caseId={id} />;
+  const c = await getAuthorizedCase(id);
+  if (!c) notFound();
+  return <NotifyOwnerWrapper caseData={c} caseId={id} />;
 }

--- a/src/app/cases/[id]/ownership/page.tsx
+++ b/src/app/cases/[id]/ownership/page.tsx
@@ -1,5 +1,6 @@
-import { getCase } from "@/lib/caseStore";
+import { getAuthorizedCase } from "@/lib/caseAccess";
 import { ownershipModules } from "@/lib/ownershipModules";
+import { notFound } from "next/navigation";
 import OwnershipEditor from "./OwnershipEditor";
 
 export const dynamic = "force-dynamic";
@@ -8,8 +9,8 @@ export default async function OwnershipPage({
   params,
 }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const c = getCase(id);
-  if (!c) return <div className="p-8">Case not found</div>;
+  const c = await getAuthorizedCase(id);
+  if (!c) notFound();
   const state = c.analysis?.vehicle?.licensePlateState?.toLowerCase();
   const mod = state ? ownershipModules[state] : undefined;
   if (!mod) {

--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -1,4 +1,5 @@
-import { getCase } from "@/lib/caseStore";
+import { getAuthorizedCase } from "@/lib/caseAccess";
+import { notFound } from "next/navigation";
 import ClientCasePage from "./ClientCasePage";
 
 export const dynamic = "force-dynamic";
@@ -8,6 +9,7 @@ export default async function CasePage({
   params,
 }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const c = getCase(id);
-  return <ClientCasePage caseId={id} initialCase={c ?? null} />;
+  const c = await getAuthorizedCase(id);
+  if (!c) notFound();
+  return <ClientCasePage caseId={id} initialCase={c} />;
 }

--- a/src/app/cases/[id]/thread/[sent]/page.tsx
+++ b/src/app/cases/[id]/thread/[sent]/page.tsx
@@ -1,5 +1,6 @@
 import ThreadWrapper from "@/app/cases/[id]/ThreadWrapper";
-import { getCase } from "@/lib/caseStore";
+import { getAuthorizedCase } from "@/lib/caseAccess";
+import { notFound } from "next/navigation";
 
 export const dynamic = "force-dynamic";
 
@@ -9,12 +10,13 @@ export default async function ThreadPage({
   params: Promise<{ id: string; sent: string }>;
 }) {
   const { id, sent } = await params;
-  const c = getCase(id);
+  const c = await getAuthorizedCase(id);
+  if (!c) notFound();
   return (
     <ThreadWrapper
       caseId={id}
       startId={decodeURIComponent(sent)}
-      caseData={c ?? null}
+      caseData={c}
     />
   );
 }

--- a/src/lib/caseAccess.ts
+++ b/src/lib/caseAccess.ts
@@ -1,0 +1,29 @@
+import { getServerSession } from "next-auth/next";
+import { cookies } from "next/headers";
+import { authOptions } from "./authOptions";
+import { authorize } from "./authz";
+import { isCaseMember } from "./caseMembers";
+import { getCase } from "./caseStore";
+
+export async function getAuthorizedCase(id: string) {
+  const c = getCase(id);
+  if (!c) return null;
+  const session = await getServerSession(authOptions);
+  const cookieStore = await cookies();
+  const anonId =
+    cookieStore.get("anon_session_id")?.value ??
+    cookieStore.get("anonSession")?.value;
+  const role = session?.user?.role ?? "anonymous";
+  const userId = session?.user?.id;
+  const sessionMatch = anonId && c.sessionId && c.sessionId === anonId;
+  const authRole = sessionMatch ? "user" : role;
+  if (!(await authorize(authRole, "cases", "read"))) {
+    return null;
+  }
+  if (!c.public && role !== "admin" && role !== "superadmin") {
+    if (!(sessionMatch || (userId && isCaseMember(id, userId)))) {
+      return null;
+    }
+  }
+  return c;
+}


### PR DESCRIPTION
## Summary
- prevent unauthorized access to case pages
- share authorization logic in a helper

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860421907a0832bb43a34e80e8f41c6