### PR TITLE
Fix createContext error by marking component as client

### DIFF
--- a/src/app/components/CaseSummary.tsx
+++ b/src/app/components/CaseSummary.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { Case } from "@/lib/caseStore";
 import {
   getCaseOwnerContact,


### PR DESCRIPTION
## Summary
- fix `createContext` error by turning `CaseSummary` into a client component

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68604430bd2c832bbac264c0bee9042a