### PR TITLE
Update localized text handling

### DIFF
--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -73,7 +73,7 @@ export const POST = withCaseAuthorization(
 
     const { client, model } = getLlm("draft_email");
     try {
-      const reply = await chatWithSchema(
+      const raw = await chatWithSchema(
         client,
         model,
         messages,
@@ -82,6 +82,15 @@ export const POST = withCaseAuthorization(
           maxTokens: 800,
         },
       );
+      const lang = (raw as { language?: string }).language ?? "en";
+      const reply: import("@/lib/caseChat").CaseChatReply = {
+        response:
+          typeof raw.response === "string"
+            ? { [lang]: raw.response }
+            : raw.response,
+        actions: raw.actions,
+        noop: raw.noop,
+      };
       return NextResponse.json({
         reply,
         system,

--- a/src/app/cases/[id]/CaseChat.stories.tsx
+++ b/src/app/cases/[id]/CaseChat.stories.tsx
@@ -20,7 +20,12 @@ export const WithLiveLlm: Story = {
     async function onChat(
       messages: Array<{ role: "user" | "assistant"; content: string }>,
     ): Promise<CaseChatReply> {
-      if (!apiKey) return { response: "", actions: [], noop: true };
+      if (!apiKey)
+        return {
+          response: { en: "" },
+          actions: [],
+          noop: true,
+        };
       const client = new OpenAI({
         apiKey,
         baseURL: baseUrl || undefined,
@@ -35,7 +40,11 @@ export const WithLiveLlm: Story = {
       try {
         return JSON.parse(text) as CaseChatReply;
       } catch {
-        return { response: text, actions: [], noop: false };
+        return {
+          response: { en: text },
+          actions: [],
+          noop: false,
+        };
       }
     }
 
@@ -81,7 +90,7 @@ export const CaseAction: Story = {
   render: function CaseActionStory() {
     usePhotoStub();
     const reply: CaseChatReply = {
-      response: "Notify the owner?",
+      response: { en: "Notify the owner?" },
       actions: [{ id: "notify-owner" }],
       noop: false,
     };
@@ -93,7 +102,7 @@ export const EditAction: Story = {
   render: function EditActionStory() {
     usePhotoStub();
     const reply: CaseChatReply = {
-      response: "Plate looks like ABC123",
+      response: { en: "Plate looks like ABC123" },
       actions: [{ field: "plate", value: "ABC123" }],
       noop: false,
     };
@@ -105,7 +114,7 @@ export const PhotoNoteAction: Story = {
   render: function PhotoNoteActionStory() {
     usePhotoStub();
     const reply: CaseChatReply = {
-      response: "Add note to photo",
+      response: { en: "Add note to photo" },
       actions: [{ photo: "a.jpg", note: "Clear" }],
       noop: false,
     };
@@ -117,7 +126,7 @@ export const MixedActions: Story = {
   render: function MixedActionsStory() {
     usePhotoStub();
     const reply: CaseChatReply = {
-      response: "Multiple suggestions",
+      response: { en: "Multiple suggestions" },
       actions: [
         { id: "compose" },
         { field: "state", value: "IL" },
@@ -133,7 +142,7 @@ export const ResponseOnly: Story = {
   render: function ResponseOnlyStory() {
     usePhotoStub();
     const reply: CaseChatReply = {
-      response: "Just a regular response",
+      response: { en: "Just a regular response" },
       actions: [],
       noop: false,
     };
@@ -145,7 +154,7 @@ export const Noop: Story = {
   render: function NoopStory() {
     usePhotoStub();
     const reply: CaseChatReply = {
-      response: "",
+      response: { en: "" },
       actions: [],
       noop: true,
     };

--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -17,6 +17,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useTranslation } from "react-i18next";
 import { useNotify } from "../../components/NotificationProvider";
 
 export interface Message {
@@ -134,6 +135,7 @@ export function CaseChatProvider({
   const [unavailableActions, setUnavailableActions] = useState<string[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
+  const { i18n } = useTranslation();
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [showJump, setShowJump] = useState(false);
@@ -276,14 +278,22 @@ export function CaseChatProvider({
         if (typeof result === "string") {
           if (result.startsWith("[action:") && result.endsWith("]")) {
             reply = {
-              response: "",
+              response: { en: "" },
               actions: [{ id: result.slice(8, -1) }],
               noop: false,
             };
           } else if (result === "[noop]") {
-            reply = { response: "", actions: [], noop: true };
+            reply = {
+              response: { en: "" },
+              actions: [],
+              noop: true,
+            };
           } else {
-            reply = { response: result, actions: [], noop: false };
+            reply = {
+              response: { en: result },
+              actions: [],
+              noop: false,
+            };
           }
         } else if ("response" in result) {
           reply = result as CaseChatReply;
@@ -321,7 +331,11 @@ export function CaseChatProvider({
           {
             id: crypto.randomUUID(),
             role: "assistant",
-            content: reply.response,
+            content:
+              reply.response[i18n.language] ??
+              reply.response.en ??
+              Object.values(reply.response)[0] ??
+              "",
             actions: reply.actions,
           },
         ]);
@@ -562,14 +576,22 @@ export function CaseChatProvider({
         if (typeof result === "string") {
           if (result.startsWith("[action:") && result.endsWith("]")) {
             reply = {
-              response: "",
+              response: { en: "" },
               actions: [{ id: result.slice(8, -1) }],
               noop: false,
             };
           } else if (result === "[noop]") {
-            reply = { response: "", actions: [], noop: true };
+            reply = {
+              response: { en: "" },
+              actions: [],
+              noop: true,
+            };
           } else {
-            reply = { response: result, actions: [], noop: false };
+            reply = {
+              response: { en: result },
+              actions: [],
+              noop: false,
+            };
           }
         } else if ("response" in result) {
           reply = result as CaseChatReply;
@@ -622,7 +644,11 @@ export function CaseChatProvider({
             {
               id: crypto.randomUUID(),
               role: "assistant",
-              content: reply.response,
+              content:
+                reply.response[i18n.language] ??
+                reply.response.en ??
+                Object.values(reply.response)[0] ??
+                "",
               actions: reply.actions,
             },
           ]);

--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -8,6 +8,7 @@ import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import type { ReportModule } from "@/lib/reportModules";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useNotify } from "../../../components/NotificationProvider";
 
 export default function DraftEditor({
@@ -27,8 +28,11 @@ export default function DraftEditor({
   replyTo?: string;
   to?: string;
 }) {
-  const [subject, setSubject] = useState(initialDraft?.subject || "");
-  const [body, setBody] = useState(initialDraft?.body || "");
+  const { i18n } = useTranslation();
+  const [subject, setSubject] = useState(
+    initialDraft?.subject[i18n.language] || "",
+  );
+  const [body, setBody] = useState(initialDraft?.body[i18n.language] || "");
   const [sending, setSending] = useState(false);
   const [snailMail, setSnailMail] = useState(false);
   const [snailMailDisabled, setSnailMailDisabled] = useState(false);
@@ -44,10 +48,10 @@ export default function DraftEditor({
 
   useEffect(() => {
     if (initialDraft) {
-      setSubject(initialDraft.subject);
-      setBody(initialDraft.body);
+      setSubject(initialDraft.subject[i18n.language] || "");
+      setBody(initialDraft.body[i18n.language] || "");
     }
-  }, [initialDraft]);
+  }, [initialDraft, i18n.language]);
 
   async function sendEmail() {
     setSending(true);

--- a/src/app/cases/[id]/draft/DraftPreview.tsx
+++ b/src/app/cases/[id]/draft/DraftPreview.tsx
@@ -8,6 +8,7 @@ import type { ReportModule } from "@/lib/reportModules";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useNotify } from "../../../components/NotificationProvider";
 import { ChatWidget, WidgetActions } from "../widgets";
 
@@ -29,6 +30,7 @@ export default function DraftPreview({
   const router = useRouter();
   const notify = useNotify();
   const [sending, setSending] = useState(false);
+  const { i18n } = useTranslation();
 
   function openCompose() {
     const url = `/cases/${caseId}/compose`;
@@ -45,8 +47,8 @@ export default function DraftPreview({
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        subject: data.email.subject,
-        body: data.email.body,
+        subject: data.email.subject[i18n.language],
+        body: data.email.body[i18n.language],
         attachments: data.attachments,
       }),
     });
@@ -60,15 +62,20 @@ export default function DraftPreview({
     setSending(false);
   }
 
+  const bodyText =
+    data.email.body[i18n.language] ??
+    data.email.body.en ??
+    Object.values(data.email.body)[0] ??
+    "";
   const previewBody =
-    data.email.body.length > 80
-      ? `${data.email.body.slice(0, 77)}...`
-      : data.email.body;
+    bodyText.length > 80 ? `${bodyText.slice(0, 77)}...` : bodyText;
 
   const tooltipContent = (
     <div className="bg-white text-black p-2 rounded shadow max-w-sm space-y-2">
-      <div className="font-semibold text-sm">{data.email.subject}</div>
-      <pre className="whitespace-pre-wrap text-xs">{data.email.body}</pre>
+      <div className="font-semibold text-sm">
+        {data.email.subject[i18n.language]}
+      </div>
+      <pre className="whitespace-pre-wrap text-xs">{bodyText}</pre>
       {data.attachments.length > 0 && (
         <div className="flex gap-1 flex-wrap">
           {data.attachments.map((p) => (
@@ -117,7 +124,7 @@ export default function DraftPreview({
           onClick={openCompose}
           className="text-left w-full"
         >
-          <strong>{data.email.subject}</strong> {previewBody}
+          <strong>{data.email.subject[i18n.language]}</strong> {previewBody}
         </button>
       </Tooltip>
       <WidgetActions>

--- a/src/app/cases/__tests__/caseChatCurrent.test.tsx
+++ b/src/app/cases/__tests__/caseChatCurrent.test.tsx
@@ -18,7 +18,11 @@ describe("CaseChat current session", () => {
         <CaseChat
           caseId="1"
           onChat={async () => ({
-            reply: { response: "ok", actions: [], noop: false },
+            reply: {
+              response: { en: "ok" },
+              actions: [],
+              noop: false,
+            },
           })}
         />,
       );

--- a/src/app/cases/__tests__/caseChatHistory.test.tsx
+++ b/src/app/cases/__tests__/caseChatHistory.test.tsx
@@ -19,7 +19,11 @@ describe("CaseChat history", () => {
         <CaseChat
           caseId="1"
           onChat={async () => ({
-            reply: { response: "ok", actions: [], noop: false },
+            reply: {
+              response: { en: "ok" },
+              actions: [],
+              noop: false,
+            },
           })}
         />,
       );

--- a/src/app/cases/__tests__/caseChatPersistence.test.tsx
+++ b/src/app/cases/__tests__/caseChatPersistence.test.tsx
@@ -19,7 +19,11 @@ describe("CaseChat persistence", () => {
         <CaseChat
           caseId="1"
           onChat={async () => ({
-            reply: { response: "ok", actions: [], noop: false },
+            reply: {
+              response: { en: "ok" },
+              actions: [],
+              noop: false,
+            },
           })}
         />,
       );
@@ -42,7 +46,11 @@ describe("CaseChat persistence", () => {
       <CaseChat
         caseId="1"
         onChat={async () => ({
-          reply: { response: "ok", actions: [], noop: false },
+          reply: {
+            response: { en: "ok" },
+            actions: [],
+            noop: false,
+          },
         })}
       />,
     );

--- a/src/app/cases/__tests__/caseChatPhotoNote.test.tsx
+++ b/src/app/cases/__tests__/caseChatPhotoNote.test.tsx
@@ -22,7 +22,7 @@ describe("CaseChat photo note action", () => {
         caseId="1"
         onChat={async () => ({
           reply: {
-            response: "here",
+            response: { en: "here" },
             actions: [{ photo: "a.jpg", note: "test" }],
             noop: false,
           },

--- a/src/app/cases/__tests__/caseChatTakePhoto.test.tsx
+++ b/src/app/cases/__tests__/caseChatTakePhoto.test.tsx
@@ -32,7 +32,7 @@ describe("CaseChat take photo action", () => {
           caseId="1"
           onChat={async () => ({
             reply: {
-              response: "",
+              response: { en: "" },
               actions: [{ id: "take-photo" }],
               noop: false,
             },

--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -1,5 +1,6 @@
 import type { ViolationReport } from "@/lib/openai";
 import { US_STATES } from "@/lib/usStates";
+import { useTranslation } from "react-i18next";
 import EditableText from "./EditableText";
 
 export default function AnalysisInfo({
@@ -15,13 +16,21 @@ export default function AnalysisInfo({
   onClearPlate?: () => Promise<void> | void;
   onClearState?: () => Promise<void> | void;
 }) {
+  const { i18n } = useTranslation();
   const { violationType, details, location, vehicle = {} } = analysis;
+  const detailText =
+    typeof details === "string"
+      ? details
+      : (details[i18n.language] ??
+        details.en ??
+        Object.values(details)[0] ??
+        "");
   return (
     <div className="flex flex-col gap-1 text-sm">
       <p>
         <span className="font-semibold">Violation:</span> {violationType}
       </p>
-      <p>{details}</p>
+      <p>{detailText}</p>
       {location ? (
         <p>
           <span className="font-semibold">Location clues:</span> {location}

--- a/src/app/components/CaseProgressGraph.tsx
+++ b/src/app/components/CaseProgressGraph.tsx
@@ -159,9 +159,15 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
       if (!plate || !caseData.analysis?.images)
         return caseData.photos[0] ?? null;
       for (const [name, info] of Object.entries(caseData.analysis.images)) {
+        const hi =
+          typeof info.highlights === "string"
+            ? info.highlights
+            : (info.highlights?.[caseData.analysis?.language ?? "en"] ??
+              Object.values(info.highlights ?? {})[0] ??
+              "");
         if (
           info.paperworkInfo?.vehicle?.licensePlateNumber === plate ||
-          info.highlights?.toLowerCase().includes("plate")
+          hi.toLowerCase().includes("plate")
         ) {
           const file = caseData.photos.find((p) => p.split("/").pop() === name);
           if (file) return file;
@@ -286,9 +292,15 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
         if (!plate || !caseData.analysis?.images)
           return caseData.photos[0] ?? null;
         for (const [name, info] of Object.entries(caseData.analysis.images)) {
+          const hi =
+            typeof info.highlights === "string"
+              ? info.highlights
+              : (info.highlights?.[caseData.analysis?.language ?? "en"] ??
+                Object.values(info.highlights ?? {})[0] ??
+                "");
           if (
             info.paperworkInfo?.vehicle?.licensePlateNumber === plate ||
-            info.highlights?.toLowerCase().includes("plate")
+            hi.toLowerCase().includes("plate")
           ) {
             const file = caseData.photos.find(
               (p) => p.split("/").pop() === name,

--- a/src/app/components/ImageHighlights.tsx
+++ b/src/app/components/ImageHighlights.tsx
@@ -1,5 +1,6 @@
 "use client";
 import type { ViolationReport } from "@/lib/openai";
+import { useTranslation } from "react-i18next";
 
 export default function ImageHighlights({
   analysis,
@@ -8,17 +9,30 @@ export default function ImageHighlights({
   analysis: ViolationReport;
   photo: string;
 }) {
+  const { i18n } = useTranslation();
   const name = photo.split("/").pop() || photo;
   const info = analysis.images?.[name];
   if (!info) return null;
+  const highlights =
+    typeof info.highlights === "string"
+      ? info.highlights
+      : (info.highlights?.[i18n.language] ??
+        info.highlights?.en ??
+        Object.values(info.highlights ?? {})[0]);
+  const context =
+    typeof info.context === "string"
+      ? info.context
+      : (info.context?.[i18n.language] ??
+        info.context?.en ??
+        Object.values(info.context ?? {})[0]);
   return (
     <div className="flex flex-col gap-1 text-sm">
       <span>
         <span className="font-semibold">Image score:</span>{" "}
         {info.representationScore.toFixed(2)}
       </span>
-      {info.highlights ? <span>{info.highlights}</span> : null}
-      {info.context ? <span>{info.context}</span> : null}
+      {highlights ? <span>{highlights}</span> : null}
+      {context ? <span>{context}</span> : null}
     </div>
   );
 }

--- a/src/generated/zod/caseChat.ts
+++ b/src/generated/zod/caseChat.ts
@@ -16,7 +16,7 @@ export const caseChatActionSchema = z.union([
 ]);
 
 export const caseChatReplySchema = z.object({
-  response: z.string(),
+  response: z.any(),
   actions: z.array(caseChatActionSchema),
   noop: z.boolean(),
 });

--- a/src/generated/zod/openai.ts
+++ b/src/generated/zod/openai.ts
@@ -35,9 +35,11 @@ export const paperworkAnalysisSchema = z.object({
   info: paperworkInfoSchema.nullable(),
 });
 
+export const localizedTextSchema = z.record(z.string());
+
 export const violationReportSchema = z.object({
   violationType: z.string(),
-  details: z.string(),
+  details: localizedTextSchema,
   location: z.string().optional(),
   vehicle: z.object({
     make: z.string().optional(),
@@ -50,8 +52,8 @@ export const violationReportSchema = z.object({
   images: z.record(
     z.object({
       representationScore: z.number(),
-      highlights: z.string().optional(),
-      context: z.string().optional(),
+      highlights: localizedTextSchema.optional(),
+      context: localizedTextSchema.optional(),
       violation: z.boolean().optional(),
       paperwork: z.boolean().optional(),
       paperworkText: z.string().optional(),

--- a/src/lib/__tests__/caseReport.test.ts
+++ b/src/lib/__tests__/caseReport.test.ts
@@ -48,7 +48,10 @@ describe("draftEmail", () => {
       reportModules["oak-park"],
       sender,
     );
-    expect(result).toEqual({ subject: "s", body: "b" });
+    expect(result).toEqual({
+      subject: { en: "s" },
+      body: { en: "b" },
+    });
   });
 
   it("retries when response is invalid", async () => {
@@ -70,7 +73,10 @@ describe("draftEmail", () => {
       reportModules["oak-park"],
       sender,
     );
-    expect(result).toEqual({ subject: "s2", body: "b2" });
+    expect(result).toEqual({
+      subject: { en: "s2" },
+      body: { en: "b2" },
+    });
   });
 
   it("returns empty draft after repeated failures", async () => {
@@ -84,7 +90,10 @@ describe("draftEmail", () => {
       reportModules["oak-park"],
       sender,
     );
-    expect(result).toEqual({ subject: "", body: "" });
+    expect(result).toEqual({
+      subject: { en: "" },
+      body: { en: "" },
+    });
   });
 });
 
@@ -100,7 +109,10 @@ describe("draftOwnerNotification", () => {
     const result = await draftOwnerNotification(baseCase, [
       "Oak Park Police Department",
     ]);
-    expect(result).toEqual({ subject: "s", body: "b" });
+    expect(result).toEqual({
+      subject: { en: "s" },
+      body: { en: "b" },
+    });
   });
 
   it("retries when response is invalid", async () => {
@@ -120,7 +132,10 @@ describe("draftOwnerNotification", () => {
     const result = await draftOwnerNotification(baseCase, [
       "Oak Park Police Department",
     ]);
-    expect(result).toEqual({ subject: "s2", body: "b2" });
+    expect(result).toEqual({
+      subject: { en: "s2" },
+      body: { en: "b2" },
+    });
   });
 
   it("returns empty draft after repeated failures", async () => {
@@ -132,6 +147,9 @@ describe("draftOwnerNotification", () => {
     const result = await draftOwnerNotification(baseCase, [
       "Oak Park Police Department",
     ]);
-    expect(result).toEqual({ subject: "", body: "" });
+    expect(result).toEqual({
+      subject: { en: "" },
+      body: { en: "" },
+    });
   });
 });

--- a/src/lib/browserAnalysis.ts
+++ b/src/lib/browserAnalysis.ts
@@ -90,7 +90,7 @@ export async function analyzeViolationLocal(
   const best = results[0] ?? {};
   return {
     violationType: best.type ?? "unknown",
-    details: "", // local model provides minimal detail
+    details: { en: "" }, // local model provides minimal detail
     vehicle: {
       licensePlateNumber: best.plate,
     },

--- a/src/lib/caseAnalysis.ts
+++ b/src/lib/caseAnalysis.ts
@@ -251,7 +251,7 @@ export async function reanalyzePhoto(
     }
     const base: ViolationReport = caseData.analysis ?? {
       violationType: "",
-      details: "",
+      details: { en: "" },
       vehicle: {},
       images: {},
     };

--- a/src/lib/caseChat.ts
+++ b/src/lib/caseChat.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import "./zod-setup";
+import { localizedTextSchema } from "./openai";
 
 export type CaseChatAction =
   | { id: string }
@@ -7,13 +8,13 @@ export type CaseChatAction =
   | { photo: string; note: string };
 
 export interface CaseChatReply {
-  response: string;
+  response: import("./openai").LocalizedText;
   actions: CaseChatAction[];
   noop: boolean;
 }
 
 export const caseChatReplySchema = z.object({
-  response: z.string(),
+  response: z.union([z.string(), localizedTextSchema]),
   actions: z.array(
     z.union([
       z.object({ id: z.string() }),

--- a/src/lib/caseUtils.ts
+++ b/src/lib/caseUtils.ts
@@ -2,6 +2,7 @@ function basename(filePath: string): string {
   const parts = filePath.split(/[\\/]/);
   return parts[parts.length - 1];
 }
+import i18n from "../i18n";
 import type { Case } from "./caseStore";
 import type { ViolationReport } from "./openai";
 
@@ -148,11 +149,24 @@ export function getBestViolationPhoto(
   const [name, info] = best;
   const file = caseData.photos.find((p) => basename(p) === name);
   if (!file) return null;
-  return { photo: file, caption: info.highlights };
+  const caption =
+    typeof info.highlights === "string"
+      ? info.highlights
+      : (info.highlights?.[i18n.language] ??
+        info.highlights?.en ??
+        Object.values(info.highlights ?? {})[0]);
+  return { photo: file, caption };
 }
 
 export function getAnalysisSummary(report: ViolationReport): string {
-  const parts = [`Violation: ${report.violationType}`, report.details];
+  const detailText =
+    typeof report.details === "string"
+      ? report.details
+      : (report.details[i18n.language] ??
+        report.details.en ??
+        Object.values(report.details)[0] ??
+        "");
+  const parts = [`Violation: ${report.violationType}`, detailText];
   if (report.location) parts.push(`Location: ${report.location}`);
   const plate: string[] = [];
   if (report.vehicle?.licensePlateState)


### PR DESCRIPTION
## Summary
- remove redundant language fields from schemas and code
- pick translations using react-i18next context
- adjust email draft and chat logic for map-based text
- regenerate zod schemas
- update tests for new structures

## Testing
- `npm test`
- `npm run e2e:smoke` *(fails: Next.js server returned 500 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860393d0f30832b8ebeaeedf948205e