### PR TITLE
Allow signed in users to see public case photos

### DIFF
--- a/migrations/0018_user_public_cases_read.sql
+++ b/migrations/0018_user_public_cases_read.sql
@@ -1,0 +1,2 @@
+INSERT INTO casbin_rules (ptype, v0, v1, v2) VALUES
+  ('p', 'user', 'public_cases', 'read');

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -91,6 +91,22 @@ describe("anonymous access", () => {
     expect(res.status).toBe(200);
   });
 
+  it("allows logged in user to view photos on public case", async () => {
+    await signIn("user@example.com");
+    const id = await createCase();
+    await api(`/api/cases/${id}/public`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ public: true }),
+    });
+    const caseData = (await api(`/api/cases/${id}`).then((r) => r.json())) as {
+      photos: string[];
+    };
+    const photo = caseData.photos[0];
+    const res = await api(`/uploads/${photo}`);
+    expect(res.status).toBe(200);
+  });
+
   it("rejects private case and stream", async () => {
     await signIn("user@example.com");
     const id = await createCase();


### PR DESCRIPTION
## Summary
- add policy so `user` role can read `public_cases`
- test fetching photo while logged in

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6860466bd340832b9fab801ce49ed244