### PR TITLE
Fix React dependency in i18n initialization

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,5 +1,4 @@
 import i18n from "i18next";
-import { initReactI18next } from "react-i18next";
 import enCommon from "../public/locales/en/common.json";
 import esCommon from "../public/locales/es/common.json";
 import frCommon from "../public/locales/fr/common.json";
@@ -8,7 +7,7 @@ const instance = i18n.createInstance();
 
 export async function initI18n(lang: string) {
   if (!instance.isInitialized) {
-    await instance.use(initReactI18next).init({
+    const config = {
       resources: {
         en: { common: enCommon },
         es: { common: esCommon },
@@ -18,7 +17,13 @@ export async function initI18n(lang: string) {
       fallbackLng: "en",
       defaultNS: "common",
       interpolation: { escapeValue: false },
-    });
+    };
+    if (typeof window !== "undefined") {
+      const { initReactI18next } = await import("react-i18next");
+      await instance.use(initReactI18next).init(config);
+    } else {
+      await instance.init(config);
+    }
   } else if (instance.language !== lang) {
     await instance.changeLanguage(lang);
   }


### PR DESCRIPTION
## Summary
- avoid importing `react-i18next` when running on the server

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6860493de620832bad9c4058fb65734a