### PR TITLE
Respect selected language during case analysis

### DIFF
--- a/scripts/seedCases.ts
+++ b/scripts/seedCases.ts
@@ -107,7 +107,7 @@ async function seedCase(prompt: string): Promise<void> {
   if (options.withIntersection)
     updates.intersection = `${faker.location.street()} and ${faker.location.street()}`;
   if (Object.keys(updates).length > 0) updateCase(c.id, updates);
-  if (!options.skipAnalysis) await analyzeCase(c);
+  if (!options.skipAnalysis) await analyzeCase(c, "en");
   console.log(`Created case ${c.id} for scenario: ${prompt}`);
 }
 

--- a/scripts/updateMissingAnalysis.ts
+++ b/scripts/updateMissingAnalysis.ts
@@ -13,7 +13,7 @@ async function run() {
       (status !== null && status !== undefined && status >= 500);
     if (shouldRetry) {
       console.log(`Reanalyzing case ${c.id}`);
-      await analyzeCase(c);
+      await analyzeCase(c, "en");
     }
   }
 }

--- a/src/jobs/analyzeCase.ts
+++ b/src/jobs/analyzeCase.ts
@@ -5,8 +5,10 @@ import { migrationsReady } from "@/lib/db";
 
 (async () => {
   await migrationsReady;
-  const { jobData } = workerData as { jobData: Case };
-  await analyzeCase(jobData);
+  const { jobData } = workerData as {
+    jobData: { caseData: Case; lang: string };
+  };
+  await analyzeCase(jobData.caseData, jobData.lang);
   if (parentPort) parentPort.postMessage("done");
 })().catch((err) => {
   console.error("analyzeCase job failed", err);

--- a/src/jobs/analyzePhoto.ts
+++ b/src/jobs/analyzePhoto.ts
@@ -6,9 +6,9 @@ import { migrationsReady } from "@/lib/db";
 (async () => {
   await migrationsReady;
   const { jobData } = workerData as {
-    jobData: { caseData: Case; photo: string };
+    jobData: { caseData: Case; photo: string; lang: string };
   };
-  await reanalyzePhoto(jobData.caseData, jobData.photo);
+  await reanalyzePhoto(jobData.caseData, jobData.photo, jobData.lang);
   if (parentPort) parentPort.postMessage("done");
 })().catch((err) => {
   console.error("analyzePhoto job failed", err);

--- a/src/lib/inboxScanner.ts
+++ b/src/lib/inboxScanner.ts
@@ -75,7 +75,7 @@ export async function scanInbox(): Promise<void> {
           const p = casePhotos[i];
           addCasePhoto(newCase.id, p, photoTimes[p], gpsList[i + 1] || null);
         }
-        analyzeCaseInBackground(newCase);
+        analyzeCaseInBackground(newCase, "en");
         fetchCaseLocationInBackground(newCase);
       }
       if (msg.uid > lastUid) {

--- a/test/anonymousUpload.test.ts
+++ b/test/anonymousUpload.test.ts
@@ -5,7 +5,10 @@ import os from "node:os";
 import path from "node:path";
 import type { Worker } from "node:worker_threads";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-vi.mock("next/headers", () => ({ cookies: () => ({ get: vi.fn() }) }));
+vi.mock("next/headers", () => ({
+  cookies: () => ({ get: vi.fn() }),
+  headers: () => new Headers(),
+}));
 
 const terminateMock = vi.fn();
 const worker = Object.assign(new EventEmitter(), {
@@ -41,6 +44,7 @@ beforeEach(async () => {
       getAll: () => [],
       has: vi.fn(),
     }),
+    headers: () => new Headers(),
   }));
   const db = await import("@/lib/db");
   await db.migrationsReady;

--- a/test/caseAnalysis.test.ts
+++ b/test/caseAnalysis.test.ts
@@ -42,11 +42,11 @@ describe("analyzeCaseInBackground", () => {
       note: null,
       photoNotes: { "/a.jpg": null },
     };
-    analyzeCaseInBackground(c);
+    analyzeCaseInBackground(c, "en");
     expect(runJobMock).toHaveBeenCalledTimes(1);
     expect(isCaseAnalysisActive(c.id)).toBe(true);
 
-    analyzeCaseInBackground(c);
+    analyzeCaseInBackground(c, "en");
     expect(runJobMock).toHaveBeenCalledTimes(1);
 
     worker.emit("exit");

--- a/test/uploadRoute.test.ts
+++ b/test/uploadRoute.test.ts
@@ -13,7 +13,10 @@ import {
   it,
   vi,
 } from "vitest";
-vi.mock("next/headers", () => ({ cookies: () => ({ get: vi.fn() }) }));
+vi.mock("next/headers", () => ({
+  cookies: () => ({ get: vi.fn() }),
+  headers: () => new Headers(),
+}));
 
 let dataDir: string;
 let tmpDir: string;
@@ -53,6 +56,7 @@ beforeEach(async () => {
       getAll: () => [],
       has: vi.fn(),
     }),
+    headers: () => new Headers(),
   }));
   const db = await import("@/lib/db");
   await db.migrationsReady;
@@ -80,7 +84,7 @@ afterEach(() => {
 describe("upload route", () => {
   it("cancels active analysis when uploading additional photo", async () => {
     const c = caseStore.createCase("a.jpg");
-    caseAnalysis.analyzeCaseInBackground(c);
+    caseAnalysis.analyzeCaseInBackground(c, "en");
     expect(runJobMock).toHaveBeenCalledTimes(1);
 
     const fakeReq = {


### PR DESCRIPTION
## Summary
- pass language from request headers/cookies into analysis jobs
- update analysis helpers and workers to accept language parameter
- keep seed and update scripts working with default language
- mock `headers()` in unit tests

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68604e7813bc832bbb104b2e7e8e1965