### PR TITLE
Add localized text helper and translation buttons

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -6,6 +6,7 @@
   "authorityNotifications": "notifications sent to authorities",
   "avgTimeToNotify": "average time to notify authorities",
   "casesWithNotification": "cases with authority notification",
+  "translate": "Translate",
   "nav": {
     "newCaseFromImage": "New Case from Image",
     "pointShoot": "Point & Shoot",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -6,6 +6,7 @@
   "authorityNotifications": "notificaciones enviadas a las autoridades",
   "avgTimeToNotify": "tiempo promedio para notificar a las autoridades",
   "casesWithNotification": "casos con notificación a la autoridad",
+  "translate": "Traducir",
   "nav": {
     "newCaseFromImage": "Nuevo caso desde imagen",
     "pointShoot": "Apuntar y Disparar",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -6,6 +6,7 @@
   "authorityNotifications": "notifications envoyées aux autorités",
   "avgTimeToNotify": "temps moyen pour notifier les autorités",
   "casesWithNotification": "cas avec notification aux autorités",
+  "translate": "Traduire",
   "nav": {
     "newCaseFromImage": "Nouveau cas depuis une image",
     "pointShoot": "Pointer et capturer",

--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -1,3 +1,4 @@
+import { getLocalizedText } from "@/lib/localizedText";
 import type { ViolationReport } from "@/lib/openai";
 import { US_STATES } from "@/lib/usStates";
 import { useTranslation } from "react-i18next";
@@ -16,21 +17,25 @@ export default function AnalysisInfo({
   onClearPlate?: () => Promise<void> | void;
   onClearState?: () => Promise<void> | void;
 }) {
-  const { i18n } = useTranslation();
+  const { i18n, t } = useTranslation();
   const { violationType, details, location, vehicle = {} } = analysis;
-  const detailText =
-    typeof details === "string"
-      ? details
-      : (details[i18n.language] ??
-        details.en ??
-        Object.values(details)[0] ??
-        "");
+  const { text: detailText, needsTranslation } = getLocalizedText(
+    details,
+    i18n.language,
+  );
   return (
     <div className="flex flex-col gap-1 text-sm">
       <p>
         <span className="font-semibold">Violation:</span> {violationType}
       </p>
-      <p>{detailText}</p>
+      <p>
+        {detailText}
+        {needsTranslation ? (
+          <button type="button" className="ml-2 text-blue-500 underline">
+            {t("translate")}
+          </button>
+        ) : null}
+      </p>
       {location ? (
         <p>
           <span className="font-semibold">Location clues:</span> {location}

--- a/src/app/components/ImageHighlights.tsx
+++ b/src/app/components/ImageHighlights.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { getLocalizedText } from "@/lib/localizedText";
 import type { ViolationReport } from "@/lib/openai";
 import { useTranslation } from "react-i18next";
 
@@ -9,30 +10,42 @@ export default function ImageHighlights({
   analysis: ViolationReport;
   photo: string;
 }) {
-  const { i18n } = useTranslation();
+  const { i18n, t } = useTranslation();
   const name = photo.split("/").pop() || photo;
   const info = analysis.images?.[name];
   if (!info) return null;
-  const highlights =
-    typeof info.highlights === "string"
-      ? info.highlights
-      : (info.highlights?.[i18n.language] ??
-        info.highlights?.en ??
-        Object.values(info.highlights ?? {})[0]);
-  const context =
-    typeof info.context === "string"
-      ? info.context
-      : (info.context?.[i18n.language] ??
-        info.context?.en ??
-        Object.values(info.context ?? {})[0]);
+  const { text: highlights, needsTranslation: needsHighlights } =
+    getLocalizedText(info.highlights, i18n.language);
+  const { text: context, needsTranslation: needsContext } = getLocalizedText(
+    info.context,
+    i18n.language,
+  );
   return (
     <div className="flex flex-col gap-1 text-sm">
       <span>
         <span className="font-semibold">Image score:</span>{" "}
         {info.representationScore.toFixed(2)}
       </span>
-      {highlights ? <span>{highlights}</span> : null}
-      {context ? <span>{context}</span> : null}
+      {highlights ? (
+        <span>
+          {highlights}
+          {needsHighlights ? (
+            <button type="button" className="ml-2 text-blue-500 underline">
+              {t("translate")}
+            </button>
+          ) : null}
+        </span>
+      ) : null}
+      {context ? (
+        <span>
+          {context}
+          {needsContext ? (
+            <button type="button" className="ml-2 text-blue-500 underline">
+              {t("translate")}
+            </button>
+          ) : null}
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/src/lib/__tests__/localizedText.test.ts
+++ b/src/lib/__tests__/localizedText.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { getLocalizedText } from "../localizedText";
+
+describe("getLocalizedText", () => {
+  it("returns string directly", () => {
+    const result = getLocalizedText("hello", "en");
+    expect(result).toEqual({ text: "hello", needsTranslation: false });
+  });
+
+  it("picks matching language", () => {
+    const result = getLocalizedText({ en: "hi", es: "hola" }, "es");
+    expect(result).toEqual({ text: "hola", needsTranslation: false });
+  });
+
+  it("falls back and marks translation needed", () => {
+    const result = getLocalizedText({ en: "hi" }, "fr");
+    expect(result).toEqual({ text: "hi", needsTranslation: true });
+  });
+});

--- a/src/lib/localizedText.ts
+++ b/src/lib/localizedText.ts
@@ -1,0 +1,10 @@
+export function getLocalizedText(
+  textMap: string | Record<string, string> | undefined,
+  lang: string,
+): { text: string; needsTranslation: boolean } {
+  if (!textMap) return { text: "", needsTranslation: false };
+  if (typeof textMap === "string")
+    return { text: textMap, needsTranslation: false };
+  const text = textMap[lang] ?? textMap.en ?? Object.values(textMap)[0] ?? "";
+  return { text, needsTranslation: !(lang in textMap) };
+}


### PR DESCRIPTION
## Summary
- introduce `getLocalizedText` helper
- display translation buttons in `AnalysisInfo` and `ImageHighlights`
- add `translate` label in localization files
- test helper

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68604fe37850832b9ab4371f79820f3e