### PR TITLE
fix i18n overlay

### DIFF
--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -126,7 +126,9 @@ function rowToCase(row: {
     for (const a of analysisRows) {
       images[path.basename(a.url)] = {
         representationScore: a.representationScore,
-        ...(a.highlights !== null && { highlights: a.highlights }),
+        ...(a.highlights !== null && {
+          highlights: JSON.parse(a.highlights) as Record<string, string>,
+        }),
         ...(a.violation !== null && { violation: Boolean(a.violation) }),
         ...(a.paperwork !== null && { paperwork: Boolean(a.paperwork) }),
         ...(a.paperworkText !== null && { paperworkText: a.paperworkText }),
@@ -200,9 +202,7 @@ function saveCase(c: Case) {
           highlights:
             info.highlights === undefined || info.highlights === null
               ? null
-              : typeof info.highlights === "string"
-                ? info.highlights
-                : JSON.stringify(info.highlights),
+              : JSON.stringify(info.highlights),
           violation:
             info.violation === undefined || info.violation === null
               ? null

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -185,6 +185,28 @@ describe("caseStore", () => {
     expect(stored?.photoNotes?.["/p.jpg"]).toBe("foo");
   });
 
+  it("parses localized image highlights", () => {
+    const { createCase, updateCase, getCase } = caseStore;
+    const c = createCase("/a.jpg", null);
+    updateCase(c.id, {
+      analysis: {
+        violationType: "parking",
+        details: { en: "desc" },
+        vehicle: {},
+        images: {
+          "a.jpg": {
+            representationScore: 0.9,
+            highlights: { en: "caption" },
+          },
+        },
+      },
+    });
+    const stored = getCase(c.id);
+    expect(stored?.analysis?.images["a.jpg"].highlights).toEqual({
+      en: "caption",
+    });
+  });
+
   it("handles session-based cases", () => {
     const { createCase, getCasesBySession, claimCasesForSession, getCase } =
       caseStore;

--- a/test/violationUtils.test.ts
+++ b/test/violationUtils.test.ts
@@ -51,12 +51,12 @@ describe("getBestViolationPhoto", () => {
           "a.jpg": {
             representationScore: 0.4,
             violation: true,
-            highlights: "a caption",
+            highlights: { en: "a caption" },
           },
           "b.jpg": {
             representationScore: 0.9,
             violation: true,
-            highlights: "best caption",
+            highlights: { en: "best caption" },
           },
         },
       },


### PR DESCRIPTION
## Summary
- parse JSON stored for image highlights
- update `getBestViolationPhoto` test to expect localized text object

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68604fbda79c832b9912fcb5f9608b3d