### PR TITLE
Add translation endpoint

### DIFF
--- a/src/app/api/cases/[id]/translate/route.ts
+++ b/src/app/api/cases/[id]/translate/route.ts
@@ -1,0 +1,50 @@
+import { withCaseAuthorization } from "@/lib/authz";
+import { getCase, setCaseTranslation } from "@/lib/caseStore";
+import { getLlm } from "@/lib/llm";
+import { NextResponse } from "next/server";
+
+function getValueByPath(obj: unknown, path: string): unknown {
+  const parts = path.replace(/\[(\w+)\]/g, ".$1").split(".");
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (typeof current !== "object" || current === null) return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+export const POST = withCaseAuthorization(
+  { obj: "cases", act: "update" },
+  async (req: Request, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const { path, lang } = (await req.json()) as { path: string; lang: string };
+    const c = getCase(id);
+    if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const value = getValueByPath(c, path);
+    if (!value)
+      return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+    const text =
+      typeof value === "string"
+        ? value
+        : typeof value === "object" && value !== null
+          ? ((value as Record<string, string>).en ??
+            Object.values(value as Record<string, string>)[0] ??
+            "")
+          : "";
+    if (!text) return NextResponse.json({ error: "No text" }, { status: 400 });
+    const { client, model } = getLlm("draft_email");
+    const res = await client.chat.completions.create({
+      model,
+      messages: [
+        { role: "system", content: `Translate the following text to ${lang}.` },
+        { role: "user", content: text },
+      ],
+    });
+    const translation = res.choices[0]?.message?.content?.trim() ?? "";
+    const updated = setCaseTranslation(id, path, lang, translation);
+    if (!updated)
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const layered = getCase(id);
+    return NextResponse.json(layered);
+  },
+);

--- a/src/lib/apiContract.ts
+++ b/src/lib/apiContract.ts
@@ -130,6 +130,19 @@ export const apiContract = c.router({
     summary: "Set photo note",
     description: "Update the note for a case photo.",
   }),
+  translateCaseText: c.mutation({
+    method: "POST",
+    path: "/api/cases/:id/translate",
+    pathParams: idParams,
+    body: c.type<{ path: string; lang: string }>(),
+    responses: c.responses({
+      200: caseSchema,
+      400: errorSchema,
+      404: errorSchema,
+    }),
+    summary: "Translate case text",
+    description: "Translate a text field within a case and store it.",
+  }),
   caseStream: c.query({
     method: "GET",
     path: "/api/cases/stream",

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -433,6 +433,36 @@ export function setPhotoNote(
   return current;
 }
 
+export function setCaseTranslation(
+  id: string,
+  path: string,
+  lang: string,
+  text: string,
+): Case | undefined {
+  const current = getCaseRow(id);
+  if (!current) return undefined;
+  const parts = path.replace(/\[(\w+)\]/g, ".$1").split(".");
+  let obj: unknown = current;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (typeof obj !== "object" || obj === null) return undefined;
+    obj = (obj as Record<string, unknown>)[parts[i]];
+  }
+  if (typeof obj !== "object" || obj === null) return undefined;
+  const key = parts[parts.length - 1];
+  const value = (obj as Record<string, unknown>)[key];
+  if (typeof value === "string") {
+    obj[key] = { en: value, [lang]: text };
+  } else if (typeof value === "object" && value !== null) {
+    obj[key] = { ...(value as Record<string, string>), [lang]: text };
+  } else {
+    return undefined;
+  }
+  current.updatedAt = new Date().toISOString();
+  saveCase(current);
+  caseEvents.emit("update", current);
+  return current;
+}
+
 export function addCaseEmail(id: string, email: SentEmail): Case | undefined {
   const current = getCaseRow(id);
   if (!current) return undefined;

--- a/test/e2e/translate.test.ts
+++ b/test/e2e/translate.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createApi } from "./api";
+import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
+import { createPhoto } from "./photo";
+import { poll } from "./poll";
+import { type TestServer, startServer } from "./startServer";
+
+let server: TestServer;
+let api: (path: string, opts?: RequestInit) => Promise<Response>;
+let stub: OpenAIStub;
+let tmpDir: string;
+
+vi.setConfig({ testTimeout: 60000 });
+
+async function signIn(email: string) {
+  const csrf = await api("/api/auth/csrf").then((r) => r.json());
+  await api("/api/auth/signin/email", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      csrfToken: csrf.csrfToken,
+      email,
+      callbackUrl: server.url,
+    }),
+  });
+  const ver = await api("/api/test/verification-url").then((r) => r.json());
+  await api(
+    `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
+  );
+}
+
+async function createCase(): Promise<string> {
+  const file = createPhoto("a");
+  const form = new FormData();
+  form.append("photo", file);
+  const res = await api("/api/upload", { method: "POST", body: form });
+  expect(res.status).toBe(200);
+  const data = (await res.json()) as { caseId: string };
+  return data.caseId;
+}
+
+beforeAll(async () => {
+  stub = await startOpenAIStub([
+    { violationType: "parking", details: "hello", vehicle: {}, images: {} },
+    "hola",
+  ]);
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-translate-"));
+  server = await startServer(3032, {
+    NEXTAUTH_SECRET: "secret",
+    OPENAI_BASE_URL: stub.url,
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
+  });
+  api = createApi(server);
+  await signIn("user@example.com");
+});
+
+afterAll(async () => {
+  await server.close();
+  await stub.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("translate api", () => {
+  it("translates analysis details", async () => {
+    const id = await createCase();
+    const res = await poll(
+      () => api(`/api/cases/${id}`),
+      async (r) => {
+        if (r.status !== 200) return false;
+        const j = await r.clone().json();
+        return j.analysis !== null;
+      },
+      10,
+    );
+    const base = (await res.json()) as { analysis?: { details?: unknown } };
+    expect(base.analysis).toBeTruthy();
+    const tr = await api(`/api/cases/${id}/translate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: "analysis.details", lang: "es" }),
+    });
+    expect(tr.status).toBe(200);
+    const updated = (await tr.json()) as {
+      analysis: { details: Record<string, string> };
+    };
+    expect(updated.analysis.details.es).toBe("hola");
+    expect(stub.requests.length).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add `/api/cases/[id]/translate` for translating case text
- support updating translations in the case store
- document endpoint in API contract
- test translation flow

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68605562defc832b8d65024d8e79b32b