### PR TITLE
Resolve TypeScript errors

### DIFF
--- a/scripts/migrateAnalysisImages.ts
+++ b/scripts/migrateAnalysisImages.ts
@@ -34,7 +34,12 @@ async function run() {
           caseId: row.id,
           url: photoRow.url,
           representationScore: info.representationScore,
-          highlights: info.highlights ?? null,
+          highlights:
+            info.highlights === undefined || info.highlights === null
+              ? null
+              : typeof info.highlights === "string"
+                ? info.highlights
+                : JSON.stringify(info.highlights),
           violation:
             info.violation === undefined || info.violation === null
               ? null

--- a/src/app/cases/ClientCasesPage.stories.tsx
+++ b/src/app/cases/ClientCasesPage.stories.tsx
@@ -37,7 +37,7 @@ export const MultipleCases: Story = {
         ...caseBase,
         analysis: {
           violationType: "parking",
-          details: "Blocking sidewalk",
+          details: { en: "Blocking sidewalk" },
           vehicle: { licensePlateNumber: "ABC123" },
           location: "Oak Park",
           images: {},

--- a/src/app/cases/[id]/ClientCasePage.stories.tsx
+++ b/src/app/cases/[id]/ClientCasePage.stories.tsx
@@ -26,7 +26,7 @@ const base: Case = {
   vinOverride: null,
   analysis: {
     violationType: "parking",
-    details: "Blocking sidewalk",
+    details: { en: "Blocking sidewalk" },
     location: "Oak Park",
     vehicle: {
       licensePlateNumber: "ABC123",

--- a/src/app/cases/[id]/ComposeWrapper.stories.tsx
+++ b/src/app/cases/[id]/ComposeWrapper.stories.tsx
@@ -27,7 +27,7 @@ const base: Case = {
   vinOverride: null,
   analysis: {
     violationType: "parking",
-    details: "Blocking sidewalk",
+    details: { en: "Blocking sidewalk" },
     location: "Oak Park",
     vehicle: {
       licensePlateNumber: "ABC123",

--- a/src/app/cases/[id]/draft/DraftModal.stories.tsx
+++ b/src/app/cases/[id]/draft/DraftModal.stories.tsx
@@ -27,7 +27,7 @@ const base: Case = {
   vinOverride: null,
   analysis: {
     violationType: "parking",
-    details: "Blocking sidewalk",
+    details: { en: "Blocking sidewalk" },
     location: "Oak Park",
     vehicle: {
       licensePlateNumber: "ABC123",

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
@@ -27,8 +27,8 @@ export default function NotifyOwnerEditor({
   availableMethods: string[];
   caseId: string;
 }) {
-  const [subject, setSubject] = useState(initialDraft?.subject || "");
-  const [body, setBody] = useState(initialDraft?.body || "");
+  const [subject, setSubject] = useState(initialDraft?.subject.en ?? "");
+  const [body, setBody] = useState(initialDraft?.body.en ?? "");
   const [sending, setSending] = useState(false);
   const [results, setResults] = useState<
     Record<string, { status: string; error?: string }>
@@ -41,8 +41,8 @@ export default function NotifyOwnerEditor({
 
   useEffect(() => {
     if (initialDraft) {
-      setSubject(initialDraft.subject);
-      setBody(initialDraft.body);
+      setSubject(initialDraft.subject.en ?? "");
+      setBody(initialDraft.body.en ?? "");
     }
   }, [initialDraft]);
 

--- a/src/generated/zod/openai.ts
+++ b/src/generated/zod/openai.ts
@@ -41,6 +41,7 @@ export const violationReportSchema = z.object({
   violationType: z.string(),
   details: localizedTextSchema,
   location: z.string().optional(),
+  language: z.string().optional(),
   vehicle: z.object({
     make: z.string().optional(),
     model: z.string().optional(),

--- a/src/lib/__tests__/caseReport.test.ts
+++ b/src/lib/__tests__/caseReport.test.ts
@@ -17,7 +17,7 @@ const baseCase: Case = {
   intersection: null,
   analysis: {
     violationType: "test",
-    details: "details",
+    details: { en: "details" },
     vehicle: {},
     images: { "foo.jpg": { representationScore: 1, violation: true } },
   },
@@ -39,7 +39,14 @@ describe("draftEmail", () => {
     const { client } = getLlm("draft_email");
     vi.spyOn(client.chat.completions, "create").mockResolvedValueOnce({
       choices: [
-        { message: { content: JSON.stringify({ subject: "s", body: "b" }) } },
+        {
+          message: {
+            content: JSON.stringify({
+              subject: { en: "s" },
+              body: { en: "b" },
+            }),
+          },
+        },
       ],
     } as unknown as ChatCompletion);
 
@@ -63,7 +70,12 @@ describe("draftEmail", () => {
       .mockResolvedValueOnce({
         choices: [
           {
-            message: { content: JSON.stringify({ subject: "s2", body: "b2" }) },
+            message: {
+              content: JSON.stringify({
+                subject: { en: "s2" },
+                body: { en: "b2" },
+              }),
+            },
           },
         ],
       } as unknown as ChatCompletion);
@@ -102,7 +114,11 @@ describe("draftOwnerNotification", () => {
     const { client } = getLlm("draft_email");
     vi.spyOn(client.chat.completions, "create").mockResolvedValueOnce({
       choices: [
-        { message: { content: JSON.stringify({ subject: "s", body: "b" }) } },
+        {
+          message: {
+            content: JSON.stringify({ subject: { en: "s" }, body: { en: "b" } }),
+          },
+        },
       ],
     } as unknown as ChatCompletion);
 
@@ -124,7 +140,12 @@ describe("draftOwnerNotification", () => {
       .mockResolvedValueOnce({
         choices: [
           {
-            message: { content: JSON.stringify({ subject: "s2", body: "b2" }) },
+            message: {
+              content: JSON.stringify({
+                subject: { en: "s2" },
+                body: { en: "b2" },
+              }),
+            },
           },
         ],
       } as unknown as ChatCompletion);

--- a/src/lib/caseChat.ts
+++ b/src/lib/caseChat.ts
@@ -14,7 +14,7 @@ export interface CaseChatReply {
 }
 
 export const caseChatReplySchema = z.object({
-  response: z.union([z.string(), localizedTextSchema]),
+  response: localizedTextSchema,
   actions: z.array(
     z.union([
       z.object({ id: z.string() }),

--- a/src/lib/caseReport.ts
+++ b/src/lib/caseReport.ts
@@ -24,8 +24,8 @@ function logBadResponse(
 }
 
 export const emailDraftSchema = z.object({
-  subject: z.union([z.string(), localizedTextSchema]),
-  body: z.union([z.string(), localizedTextSchema]),
+  subject: localizedTextSchema,
+  body: localizedTextSchema,
 });
 
 export type EmailDraft = z.infer<typeof emailDraftSchema>;
@@ -110,13 +110,8 @@ Mention that photos are attached. Respond with JSON matching this schema: ${JSON
     const text = res.choices[0]?.message?.content ?? "{}";
     try {
       const parsed = JSON.parse(text);
-      const lang = (parsed as { language?: string }).language ?? "en";
       const raw = emailDraftSchema.parse(parsed);
-      const subject =
-        typeof raw.subject === "string" ? { [lang]: raw.subject } : raw.subject;
-      const body =
-        typeof raw.body === "string" ? { [lang]: raw.body } : raw.body;
-      return { subject, body };
+      return raw;
     } catch (err) {
       logBadResponse(attempt, text, err);
       if (attempt === 2) return { subject: { en: "" }, body: { en: "" } };
@@ -204,13 +199,8 @@ Ask about the current citation status and mention that photos are attached again
     const text = res.choices[0]?.message?.content ?? "{}";
     try {
       const parsed = JSON.parse(text);
-      const lang = (parsed as { language?: string }).language ?? "en";
       const raw = emailDraftSchema.parse(parsed);
-      const subject =
-        typeof raw.subject === "string" ? { [lang]: raw.subject } : raw.subject;
-      const body =
-        typeof raw.body === "string" ? { [lang]: raw.body } : raw.body;
-      return { subject, body };
+      return raw;
     } catch (err) {
       logBadResponse(attempt, text, err);
       if (attempt === 2) return { subject: { en: "" }, body: { en: "" } };
@@ -289,13 +279,8 @@ export async function draftOwnerNotification(
     const text = res.choices[0]?.message?.content ?? "{}";
     try {
       const parsed = JSON.parse(text);
-      const lang = (parsed as { language?: string }).language ?? "en";
       const raw = emailDraftSchema.parse(parsed);
-      const subject =
-        typeof raw.subject === "string" ? { [lang]: raw.subject } : raw.subject;
-      const body =
-        typeof raw.body === "string" ? { [lang]: raw.body } : raw.body;
-      return { subject, body };
+      return raw;
     } catch (err) {
       logBadResponse(attempt, text, err);
       if (attempt === 2) return { subject: { en: "" }, body: { en: "" } };

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -126,7 +126,15 @@ function rowToCase(row: {
     for (const a of analysisRows) {
       images[path.basename(a.url)] = {
         representationScore: a.representationScore,
-        ...(a.highlights !== null && { highlights: a.highlights }),
+        ...(a.highlights !== null && {
+          highlights: (() => {
+            try {
+              return JSON.parse(a.highlights);
+            } catch {
+              return { en: a.highlights };
+            }
+          })(),
+        }),
         ...(a.violation !== null && { violation: Boolean(a.violation) }),
         ...(a.paperwork !== null && { paperwork: Boolean(a.paperwork) }),
         ...(a.paperworkText !== null && { paperworkText: a.paperworkText }),

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -53,7 +53,7 @@ describe("caseStore", () => {
     const updated = updateCase(c.id, {
       analysis: {
         violationType: "foo",
-        details: "bar",
+        details: { en: "bar" },
         vehicle: {},
         images: {
           "foo.jpg": { representationScore: 0.6, violation: true },

--- a/test/vinLookup.test.ts
+++ b/test/vinLookup.test.ts
@@ -72,7 +72,7 @@ describe("vinLookup", () => {
     caseStore.updateCase(c.id, {
       analysis: {
         violationType: "",
-        details: "",
+        details: { en: "" },
         vehicle: { licensePlateNumber: "ABC123", licensePlateState: "IL" },
         images: {},
       },
@@ -105,7 +105,7 @@ describe("vinLookup", () => {
     updateCase(c.id, {
       analysis: {
         violationType: "", // minimal
-        details: "",
+        details: { en: "" },
         vehicle: { licensePlateNumber: "ABC123", licensePlateState: "IL" },
         images: {},
       },

--- a/test/violationUtils.test.ts
+++ b/test/violationUtils.test.ts
@@ -6,7 +6,7 @@ describe("hasViolation", () => {
     expect(
       hasViolation({
         violationType: "",
-        details: "",
+        details: { en: "" },
         vehicle: {},
         images: { a: { representationScore: 1, violation: true } },
       }),
@@ -17,7 +17,7 @@ describe("hasViolation", () => {
     expect(
       hasViolation({
         violationType: "",
-        details: "",
+        details: { en: "" },
         vehicle: {},
         images: { a: { representationScore: 1, violation: false } },
       }),
@@ -28,13 +28,18 @@ describe("hasViolation", () => {
     expect(
       hasViolation({
         violationType: "parking",
-        details: "",
+        details: { en: "" },
         vehicle: {},
         images: {},
       }),
     ).toBe(true);
     expect(
-      hasViolation({ violationType: "", details: "", vehicle: {}, images: {} }),
+      hasViolation({
+        violationType: "",
+        details: { en: "" },
+        vehicle: {},
+        images: {},
+      }),
     ).toBe(false);
   });
 });
@@ -45,18 +50,18 @@ describe("getBestViolationPhoto", () => {
       photos: ["/a.jpg", "/b.jpg"],
       analysis: {
         violationType: "parking",
-        details: "",
+        details: { en: "" },
         vehicle: {},
         images: {
           "a.jpg": {
             representationScore: 0.4,
             violation: true,
-            highlights: "a caption",
+            highlights: { en: "a caption" },
           },
           "b.jpg": {
             representationScore: 0.9,
             violation: true,
-            highlights: "best caption",
+            highlights: { en: "best caption" },
           },
         },
       },
@@ -69,7 +74,7 @@ describe("getBestViolationPhoto", () => {
       photos: ["/a.jpg"],
       analysis: {
         violationType: "parking",
-        details: "",
+        details: { en: "" },
         vehicle: {},
         images: {
           "a.jpg": { representationScore: 0.5, violation: false },


### PR DESCRIPTION
## Summary
- require LocalizedText objects instead of unions
- update violation analysis schema to return language maps
- adjust components and tests for LocalizedText
- parse stored highlights as JSON

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68605034a718832b83971c6a43600e26