### PR TITLE
Fix i18n provider initialization

### DIFF
--- a/src/app/__tests__/point.test.tsx
+++ b/src/app/__tests__/point.test.tsx
@@ -17,21 +17,23 @@ vi.mock("@/app/useAddFilesToCase", () => ({
 }));
 
 describe("Point and Shoot page", () => {
-  it("renders link to cases", () => {
+  it("renders link to cases", async () => {
     render(
       <I18nProvider lang="en">
         <PointAndShootPage />
       </I18nProvider>,
     );
-    expect(screen.getByText("Cases")).toBeInTheDocument();
+    expect(await screen.findByText("Cases")).toBeInTheDocument();
   });
 
-  it("shows default hint when nothing detected", () => {
+  it("shows default hint when nothing detected", async () => {
     render(
       <I18nProvider lang="en">
         <PointAndShootPage />
       </I18nProvider>,
     );
-    expect(screen.getByText("Nothing has been detected")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Nothing has been detected"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/app/components/__tests__/NavBar.test.tsx
+++ b/src/app/components/__tests__/NavBar.test.tsx
@@ -20,7 +20,7 @@ vi.mock("@/app/useSession", () => ({
 }));
 
 describe("NavBar", () => {
-  it("shows point and shoot link on normal pages", () => {
+  it("shows point and shoot link on normal pages", async () => {
     mockedUsePathname.mockReturnValue("/cases");
     render(
       <QueryProvider>
@@ -29,11 +29,11 @@ describe("NavBar", () => {
         </I18nProvider>
       </QueryProvider>,
     );
-    expect(screen.getByText("Point & Shoot")).toBeInTheDocument();
-    expect(screen.getByText("Map View")).toBeInTheDocument();
+    expect(await screen.findByText("Point & Shoot")).toBeInTheDocument();
+    expect(await screen.findByText("Map View")).toBeInTheDocument();
   });
 
-  it("hides the nav except for cases on /point", () => {
+  it("hides the nav except for cases on /point", async () => {
     mockedUsePathname.mockReturnValue("/point");
     render(
       <QueryProvider>
@@ -43,6 +43,6 @@ describe("NavBar", () => {
       </QueryProvider>,
     );
     expect(screen.queryByText("Point & Shoot")).toBeNull();
-    expect(screen.getByText("Cases")).toBeInTheDocument();
+    expect(await screen.findByText("Cases")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- ensure `I18nProvider` waits for init before hydration
- adjust NavBar and Point page tests for async provider

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686055f1c5cc832baf7118f94eb75c87