### PR TITLE
fix: initialize i18n before hydration

### DIFF
--- a/src/app/__tests__/point.test.tsx
+++ b/src/app/__tests__/point.test.tsx
@@ -17,21 +17,23 @@ vi.mock("@/app/useAddFilesToCase", () => ({
 }));
 
 describe("Point and Shoot page", () => {
-  it("renders link to cases", () => {
+  it("renders link to cases", async () => {
     render(
       <I18nProvider lang="en">
         <PointAndShootPage />
       </I18nProvider>,
     );
-    expect(screen.getByText("Cases")).toBeInTheDocument();
+    expect(await screen.findByText("Cases")).toBeInTheDocument();
   });
 
-  it("shows default hint when nothing detected", () => {
+  it("shows default hint when nothing detected", async () => {
     render(
       <I18nProvider lang="en">
         <PointAndShootPage />
       </I18nProvider>,
     );
-    expect(screen.getByText("Nothing has been detected")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Nothing has been detected"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/app/components/__tests__/NavBar.test.tsx
+++ b/src/app/components/__tests__/NavBar.test.tsx
@@ -20,7 +20,7 @@ vi.mock("@/app/useSession", () => ({
 }));
 
 describe("NavBar", () => {
-  it("shows point and shoot link on normal pages", () => {
+  it("shows point and shoot link on normal pages", async () => {
     mockedUsePathname.mockReturnValue("/cases");
     render(
       <QueryProvider>
@@ -29,11 +29,11 @@ describe("NavBar", () => {
         </I18nProvider>
       </QueryProvider>,
     );
-    expect(screen.getByText("Point & Shoot")).toBeInTheDocument();
-    expect(screen.getByText("Map View")).toBeInTheDocument();
+    expect(await screen.findByText("Point & Shoot")).toBeInTheDocument();
+    expect(await screen.findByText("Map View")).toBeInTheDocument();
   });
 
-  it("hides the nav except for cases on /point", () => {
+  it("hides the nav except for cases on /point", async () => {
     mockedUsePathname.mockReturnValue("/point");
     render(
       <QueryProvider>
@@ -43,6 +43,6 @@ describe("NavBar", () => {
       </QueryProvider>,
     );
     expect(screen.queryByText("Point & Shoot")).toBeNull();
-    expect(screen.getByText("Cases")).toBeInTheDocument();
+    expect(await screen.findByText("Cases")).toBeInTheDocument();
   });
 });

--- a/src/app/i18n-provider.tsx
+++ b/src/app/i18n-provider.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { I18nextProvider } from "react-i18next";
 import i18n, { initI18n } from "../i18n";
 
@@ -7,14 +7,26 @@ export default function I18nProvider({
   children,
   lang,
 }: { children: React.ReactNode; lang: string }) {
-  if (!i18n.isInitialized) {
-    void initI18n(lang);
-  } else if (i18n.language !== lang) {
+  const isServer = typeof window === "undefined";
+  if (isServer && !i18n.isInitialized) {
     void initI18n(lang);
   }
+  const [ready, setReady] = useState(i18n.isInitialized || isServer);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
+    if (isServer) return;
+    let ignore = false;
+    void (async () => {
+      await initI18n(lang);
+      if (!ignore) setReady(true);
+    })();
+    return () => {
+      ignore = true;
+    };
+  }, [lang, isServer]);
+
+  useEffect(() => {
+    if (!ready || typeof window === "undefined") return;
     // Fallback to the browser's preferred languages if no cookie is set
     if (!document.cookie.includes("language=")) {
       const supported = ["en", "es", "fr"];
@@ -38,6 +50,8 @@ export default function I18nProvider({
     return () => {
       i18n.off("languageChanged", handler);
     };
-  }, []);
+  }, [ready]);
+
+  if (!ready && !isServer) return null;
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
 }


### PR DESCRIPTION
## Summary
- ensure I18nProvider waits for init before rendering
- adjust NavBar and Point page tests for async provider

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686055f1c5cc832baf7118f94eb75c87