### PR TITLE
fix: avoid nested buttons causing hydration error

### DIFF
--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -31,9 +31,9 @@ export default function AnalysisInfo({
       <p>
         {detailText}
         {needsTranslation ? (
-          <button type="button" className="ml-2 text-blue-500 underline">
+          <span className="ml-2 text-blue-500 underline cursor-pointer">
             {t("translate")}
-          </button>
+          </span>
         ) : null}
       </p>
       {location ? (

--- a/src/lib/__tests__/caseReport.test.ts
+++ b/src/lib/__tests__/caseReport.test.ts
@@ -116,7 +116,10 @@ describe("draftOwnerNotification", () => {
       choices: [
         {
           message: {
-            content: JSON.stringify({ subject: { en: "s" }, body: { en: "b" } }),
+            content: JSON.stringify({
+              subject: { en: "s" },
+              body: { en: "b" },
+            }),
           },
         },
       ],


### PR DESCRIPTION
## Summary
- prevent nested `<button>` usage in AnalysisInfo by using a `<span>`

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686060eac220832bbf124a8de933a9b0