### PR TITLE
Fix hydration mismatch from nested buttons

### DIFF
--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -31,9 +31,9 @@ export default function AnalysisInfo({
       <p>
         {detailText}
         {needsTranslation ? (
-          <button type="button" className="ml-2 text-blue-500 underline">
+          <span className="ml-2 text-blue-500 underline cursor-pointer">
             {t("translate")}
-          </button>
+          </span>
         ) : null}
       </p>
       {location ? (


### PR DESCRIPTION
## Summary
- avoid nested `<button>` elements by rendering the translate link as a `<span>`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686060eac220832bbf124a8de933a9b0