### PR TITLE
Fix hydration mismatch from nested buttons

### DIFF
--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -31,9 +31,9 @@ export default function AnalysisInfo({
       <p>
         {detailText}
         {needsTranslation ? (
-          <button type="button" className="ml-2 text-blue-500 underline">
+          <span className="ml-2 text-blue-500 underline cursor-pointer">
             {t("translate")}
-          </button>
+          </span>
         ) : null}
       </p>
       {location ? (

--- a/src/app/components/ImageHighlights.tsx
+++ b/src/app/components/ImageHighlights.tsx
@@ -30,9 +30,9 @@ export default function ImageHighlights({
         <span>
           {highlights}
           {needsHighlights ? (
-            <button type="button" className="ml-2 text-blue-500 underline">
+            <span className="ml-2 text-blue-500 underline cursor-pointer">
               {t("translate")}
-            </button>
+            </span>
           ) : null}
         </span>
       ) : null}
@@ -40,9 +40,9 @@ export default function ImageHighlights({
         <span>
           {context}
           {needsContext ? (
-            <button type="button" className="ml-2 text-blue-500 underline">
+            <span className="ml-2 text-blue-500 underline cursor-pointer">
               {t("translate")}
-            </button>
+            </span>
           ) : null}
         </span>
       ) : null}

--- a/src/lib/__tests__/caseReport.test.ts
+++ b/src/lib/__tests__/caseReport.test.ts
@@ -116,7 +116,10 @@ describe("draftOwnerNotification", () => {
       choices: [
         {
           message: {
-            content: JSON.stringify({ subject: { en: "s" }, body: { en: "b" } }),
+            content: JSON.stringify({
+              subject: { en: "s" },
+              body: { en: "b" },
+            }),
           },
         },
       ],


### PR DESCRIPTION
## Summary
- replace translation buttons with spans to avoid invalid button nesting
- format code to keep lint happy

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686060eac220832bbf124a8de933a9b0