### PR TITLE
Fix hydration error due to nested buttons

### DIFF
--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -31,9 +31,9 @@ export default function AnalysisInfo({
       <p>
         {detailText}
         {needsTranslation ? (
-          <button type="button" className="ml-2 text-blue-500 underline">
+          <span className="ml-2 text-blue-500 underline cursor-pointer">
             {t("translate")}
-          </button>
+          </span>
         ) : null}
       </p>
       {location ? (


### PR DESCRIPTION
## Summary
- ensure translation link in `AnalysisInfo` isn't rendered as a `<button>` when used inside clickable list items

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686060eac220832bbf124a8de933a9b0