### PR TITLE
Fix e2e tests for localized text

### DIFF
--- a/test/e2e/chat.test.ts
+++ b/test/e2e/chat.test.ts
@@ -49,10 +49,10 @@ describe("chat api", () => {
     });
     expect(res.status).toBe(200);
     const data = (await res.json()) as {
-      reply: { response: string; noop: boolean };
+      reply: { response: Record<string, string>; noop: boolean };
       system: string;
     };
-    expect(data.reply.response).toBe("hello");
+    expect(data.reply.response).toEqual({ en: "hello" });
     expect(data.reply.noop).toBe(false);
     expect(data.system).toBeTruthy();
     expect(stub.requests.length).toBeGreaterThan(0);

--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -40,11 +40,11 @@ beforeAll(async () => {
   stub = await startOpenAIStub([
     {
       violationType: "parking",
-      details: "car parked illegally",
+      details: { en: "car parked illegally" },
       vehicle: {},
       images: {},
     },
-    { subject: "s", body: "b" },
+    { subject: { en: "s" }, body: { en: "b" } },
   ]);
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   const env = {
@@ -126,7 +126,7 @@ describe("follow up", () => {
     const res = await fetchFollowup(id);
     expect(res.status).toBe(200);
     const data = await res.json();
-    expect(data.email.subject).toBe("s");
+    expect(data.email.subject).toEqual({ en: "s" });
     const request = stub.requests.at(-1) as {
       body: { messages: Array<{ content: string }> };
     };

--- a/test/e2e/translate.test.ts
+++ b/test/e2e/translate.test.ts
@@ -44,7 +44,12 @@ async function createCase(): Promise<string> {
 
 beforeAll(async () => {
   stub = await startOpenAIStub([
-    { violationType: "parking", details: "hello", vehicle: {}, images: {} },
+    {
+      violationType: "parking",
+      details: { en: "hello" },
+      vehicle: {},
+      images: {},
+    },
     "hola",
   ]);
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-translate-"));


### PR DESCRIPTION
## Summary
- update e2e tests to use new localized text objects
- adjust expectations for localized replies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686062636c54832b9d166159da08665b