### PR TITLE
Add language tracking to case chat

### DIFF
--- a/src/app/cases/[id]/CaseChat.stories.tsx
+++ b/src/app/cases/[id]/CaseChat.stories.tsx
@@ -18,7 +18,11 @@ export const WithLiveLlm: Story = {
     const [baseUrl, setBaseUrl] = useState("");
 
     async function onChat(
-      messages: Array<{ role: "user" | "assistant"; content: string }>,
+      messages: Array<{
+        role: "user" | "assistant";
+        content: string;
+        lang: string;
+      }>,
     ): Promise<CaseChatReply> {
       if (!apiKey)
         return {
@@ -90,6 +94,7 @@ export const CaseAction: Story = {
   render: function CaseActionStory() {
     usePhotoStub();
     const reply: CaseChatReply = {
+      lang: "en",
       response: { en: "Notify the owner?" },
       actions: [{ id: "notify-owner" }],
       noop: false,
@@ -102,6 +107,7 @@ export const EditAction: Story = {
   render: function EditActionStory() {
     usePhotoStub();
     const reply: CaseChatReply = {
+      lang: "en",
       response: { en: "Plate looks like ABC123" },
       actions: [{ field: "plate", value: "ABC123" }],
       noop: false,
@@ -114,6 +120,7 @@ export const PhotoNoteAction: Story = {
   render: function PhotoNoteActionStory() {
     usePhotoStub();
     const reply: CaseChatReply = {
+      lang: "en",
       response: { en: "Add note to photo" },
       actions: [{ photo: "a.jpg", note: "Clear" }],
       noop: false,
@@ -126,6 +133,7 @@ export const MixedActions: Story = {
   render: function MixedActionsStory() {
     usePhotoStub();
     const reply: CaseChatReply = {
+      lang: "en",
       response: { en: "Multiple suggestions" },
       actions: [
         { id: "compose" },
@@ -142,6 +150,7 @@ export const ResponseOnly: Story = {
   render: function ResponseOnlyStory() {
     usePhotoStub();
     const reply: CaseChatReply = {
+      lang: "en",
       response: { en: "Just a regular response" },
       actions: [],
       noop: false,
@@ -154,6 +163,7 @@ export const Noop: Story = {
   render: function NoopStory() {
     usePhotoStub();
     const reply: CaseChatReply = {
+      lang: "en",
       response: { en: "" },
       actions: [],
       noop: true,

--- a/src/app/cases/__tests__/caseChatCurrent.test.tsx
+++ b/src/app/cases/__tests__/caseChatCurrent.test.tsx
@@ -19,6 +19,7 @@ describe("CaseChat current session", () => {
           caseId="1"
           onChat={async () => ({
             reply: {
+              lang: "en",
               response: { en: "ok" },
               actions: [],
               noop: false,

--- a/src/app/cases/__tests__/caseChatHistory.test.tsx
+++ b/src/app/cases/__tests__/caseChatHistory.test.tsx
@@ -20,6 +20,7 @@ describe("CaseChat history", () => {
           caseId="1"
           onChat={async () => ({
             reply: {
+              lang: "en",
               response: { en: "ok" },
               actions: [],
               noop: false,

--- a/src/app/cases/__tests__/caseChatPersistence.test.tsx
+++ b/src/app/cases/__tests__/caseChatPersistence.test.tsx
@@ -20,6 +20,7 @@ describe("CaseChat persistence", () => {
           caseId="1"
           onChat={async () => ({
             reply: {
+              lang: "en",
               response: { en: "ok" },
               actions: [],
               noop: false,
@@ -47,6 +48,7 @@ describe("CaseChat persistence", () => {
         caseId="1"
         onChat={async () => ({
           reply: {
+            lang: "en",
             response: { en: "ok" },
             actions: [],
             noop: false,

--- a/src/app/cases/__tests__/caseChatPhotoNote.test.tsx
+++ b/src/app/cases/__tests__/caseChatPhotoNote.test.tsx
@@ -22,6 +22,7 @@ describe("CaseChat photo note action", () => {
         caseId="1"
         onChat={async () => ({
           reply: {
+            lang: "en",
             response: { en: "here" },
             actions: [{ photo: "a.jpg", note: "test" }],
             noop: false,

--- a/src/app/cases/__tests__/caseChatTakePhoto.test.tsx
+++ b/src/app/cases/__tests__/caseChatTakePhoto.test.tsx
@@ -32,6 +32,7 @@ describe("CaseChat take photo action", () => {
           caseId="1"
           onChat={async () => ({
             reply: {
+              lang: "en",
               response: { en: "" },
               actions: [{ id: "take-photo" }],
               noop: false,

--- a/src/generated/zod/caseChat.ts
+++ b/src/generated/zod/caseChat.ts
@@ -16,6 +16,7 @@ export const caseChatActionSchema = z.union([
 ]);
 
 export const caseChatReplySchema = z.object({
+  lang: z.string(),
   response: z.any(),
   actions: z.array(caseChatActionSchema),
   noop: z.boolean(),

--- a/src/lib/caseChat.ts
+++ b/src/lib/caseChat.ts
@@ -8,12 +8,14 @@ export type CaseChatAction =
   | { photo: string; note: string };
 
 export interface CaseChatReply {
+  lang: string;
   response: import("./openai").LocalizedText;
   actions: CaseChatAction[];
   noop: boolean;
 }
 
 export const caseChatReplySchema = z.object({
+  lang: z.string(),
   response: localizedTextSchema,
   actions: z.array(
     z.union([


### PR DESCRIPTION
## Summary
- store language on messages and chat replies
- include language hints in chat prompts
- show Translate button when message language differs from UI language
- update unit tests and stories

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68606109511c832bbd202ca2432bb40e