### PR TITLE
Add hydration smoke test

### DIFF
--- a/src/app/__tests__/hydration.test.tsx
+++ b/src/app/__tests__/hydration.test.tsx
@@ -1,0 +1,24 @@
+import LoggedOutLanding from "@/app/LoggedOutLanding";
+import React from "react";
+import { hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+describe("hydration smoke test", () => {
+  it("hydrates LoggedOutLanding without errors", async () => {
+    const element = <LoggedOutLanding />;
+    const html = renderToString(element);
+    document.body.innerHTML = `<div id="root">${html}</div>`;
+    const root = document.getElementById("root");
+    if (!root) throw new Error("missing root element");
+    const errors: unknown[][] = [];
+    const orig = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args);
+    };
+    hydrateRoot(root, element);
+    await Promise.resolve();
+    console.error = orig;
+    expect(errors.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure logged out landing component hydrates without console errors

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686062fc9430832ba3f172e99cddb6cb