### PR TITLE
Hook translate buttons to API

### DIFF
--- a/src/app/cases/[id]/components/AnalysisStatus.tsx
+++ b/src/app/cases/[id]/components/AnalysisStatus.tsx
@@ -1,5 +1,7 @@
 "use client";
 import AnalysisInfo from "@/app/components/AnalysisInfo";
+import { useTranslation } from "react-i18next";
+import useCaseTranslate from "../../../useCaseTranslate";
 import { useCaseContext } from "../CaseContext";
 import useCaseActions from "../useCaseActions";
 import useCaseProgress from "../useCaseProgress";
@@ -7,7 +9,9 @@ import useCaseProgress from "../useCaseProgress";
 export default function AnalysisStatus({
   readOnly = false,
 }: { readOnly?: boolean }) {
-  const { caseData } = useCaseContext();
+  const { caseId, caseData } = useCaseContext();
+  const { i18n } = useTranslation();
+  const translate = useCaseTranslate(caseId);
   const {
     updatePlateNumber,
     updatePlateState,
@@ -205,6 +209,7 @@ export default function AnalysisStatus({
               ? clearPlateState
               : undefined
         }
+        onTranslate={() => translate("analysis.details", i18n.language)}
       />
     );
   }

--- a/src/app/cases/[id]/components/PhotoSection.tsx
+++ b/src/app/cases/[id]/components/PhotoSection.tsx
@@ -1,6 +1,8 @@
 "use client";
 import CaseJobList from "@/app/components/CaseJobList";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import useCaseTranslate from "../../../useCaseTranslate";
 import { useCaseContext } from "../CaseContext";
 import useCaseActions from "../useCaseActions";
 import useCaseProgress from "../useCaseProgress";
@@ -27,6 +29,8 @@ export default function PhotoSection({
     analysisActive,
     isPhotoReanalysis,
   } = useCaseProgress(reanalyzingPhoto);
+  const { i18n } = useTranslation();
+  const translate = useCaseTranslate(caseId);
   const [hasCamera, setHasCamera] = useState(false);
   useEffect(() => {
     if (
@@ -59,6 +63,7 @@ export default function PhotoSection({
           updatePhotoNote={(v) => updatePhotoNote(selectedPhoto, v)}
           removePhoto={removePhoto}
           reanalyzePhoto={reanalyzePhoto}
+          onTranslate={(path) => translate(path, i18n.language)}
         />
       ) : null}
       <PhotoGallery

--- a/src/app/cases/[id]/components/PhotoViewer.stories.tsx
+++ b/src/app/cases/[id]/components/PhotoViewer.stories.tsx
@@ -37,6 +37,7 @@ export const Default: Story = {
       updatePhotoNote={async () => {}}
       removePhoto={async () => {}}
       reanalyzePhoto={async () => {}}
+      onTranslate={async () => {}}
     />
   ),
 };

--- a/src/app/cases/[id]/components/PhotoViewer.tsx
+++ b/src/app/cases/[id]/components/PhotoViewer.tsx
@@ -23,6 +23,7 @@ export default function PhotoViewer({
   updatePhotoNote,
   removePhoto,
   reanalyzePhoto,
+  onTranslate,
 }: {
   caseData: Case;
   selectedPhoto: string;
@@ -40,6 +41,7 @@ export default function PhotoViewer({
     photo: string,
     detailsEl?: HTMLDetailsElement | null,
   ) => Promise<void>;
+  onTranslate: (path: string) => Promise<void>;
 }) {
   const photoMenuRef = useRef<HTMLDetailsElement>(null);
   useCloseOnOutsideClick(photoMenuRef);
@@ -112,6 +114,7 @@ export default function PhotoViewer({
             <ImageHighlights
               analysis={caseData.analysis}
               photo={selectedPhoto}
+              onTranslate={(path) => onTranslate(path)}
             />
             {progress ? <p>{progressDescription}</p> : null}
           </div>

--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -10,12 +10,14 @@ export default function AnalysisInfo({
   onStateChange,
   onClearPlate,
   onClearState,
+  onTranslate,
 }: {
   analysis: ViolationReport;
   onPlateChange?: (v: string) => Promise<void> | void;
   onStateChange?: (v: string) => Promise<void> | void;
   onClearPlate?: () => Promise<void> | void;
   onClearState?: () => Promise<void> | void;
+  onTranslate?: (path: string, lang: string) => Promise<void> | void;
 }) {
   const { i18n, t } = useTranslation();
   const { violationType, details, location, vehicle = {} } = analysis;
@@ -31,7 +33,11 @@ export default function AnalysisInfo({
       <p>
         {detailText}
         {needsTranslation ? (
-          <button type="button" className="ml-2 text-blue-500 underline">
+          <button
+            type="button"
+            onClick={() => onTranslate?.("analysis.details", i18n.language)}
+            className="ml-2 text-blue-500 underline"
+          >
             {t("translate")}
           </button>
         ) : null}

--- a/src/app/components/ImageHighlights.tsx
+++ b/src/app/components/ImageHighlights.tsx
@@ -6,9 +6,11 @@ import { useTranslation } from "react-i18next";
 export default function ImageHighlights({
   analysis,
   photo,
+  onTranslate,
 }: {
   analysis: ViolationReport;
   photo: string;
+  onTranslate?: (path: string, lang: string) => Promise<void> | void;
 }) {
   const { i18n, t } = useTranslation();
   const name = photo.split("/").pop() || photo;
@@ -30,7 +32,16 @@ export default function ImageHighlights({
         <span>
           {highlights}
           {needsHighlights ? (
-            <button type="button" className="ml-2 text-blue-500 underline">
+            <button
+              type="button"
+              onClick={() =>
+                onTranslate?.(
+                  `analysis.images.${name}.highlights`,
+                  i18n.language,
+                )
+              }
+              className="ml-2 text-blue-500 underline"
+            >
               {t("translate")}
             </button>
           ) : null}
@@ -40,7 +51,13 @@ export default function ImageHighlights({
         <span>
           {context}
           {needsContext ? (
-            <button type="button" className="ml-2 text-blue-500 underline">
+            <button
+              type="button"
+              onClick={() =>
+                onTranslate?.(`analysis.images.${name}.context`, i18n.language)
+              }
+              className="ml-2 text-blue-500 underline"
+            >
               {t("translate")}
             </button>
           ) : null}

--- a/src/app/useCaseTranslate.ts
+++ b/src/app/useCaseTranslate.ts
@@ -1,0 +1,28 @@
+"use client";
+import { apiFetch } from "@/apiClient";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNotify } from "./components/NotificationProvider";
+import { caseQueryKey } from "./hooks/useCase";
+
+export default function useCaseTranslate(caseId: string) {
+  const queryClient = useQueryClient();
+  const notify = useNotify();
+  const mutation = useMutation({
+    async mutationFn({ path, lang }: { path: string; lang: string }) {
+      const res = await apiFetch(`/api/cases/${caseId}/translate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path, lang }),
+      });
+      if (!res.ok) throw new Error("Failed to translate.");
+    },
+    onSuccess() {
+      queryClient.invalidateQueries({ queryKey: caseQueryKey(caseId) });
+    },
+    onError() {
+      notify("Failed to translate.");
+    },
+  });
+  return (path: string, lang: string) =>
+    mutation.mutateAsync({ path, lang }).then(() => {});
+}


### PR DESCRIPTION
## Summary
- add `useCaseTranslate` hook for translating case fields
- wire translate buttons in analysis info and image highlights to call API
- enable translation actions across case pages and photo viewer

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860615661d4832ba0fa8192613c068b