### PR TITLE
Fix translate test flake

### DIFF
--- a/test/e2e/translate.test.ts
+++ b/test/e2e/translate.test.ts
@@ -78,7 +78,7 @@ describe("translate api", () => {
         const j = await r.clone().json();
         return j.analysis !== null;
       },
-      10,
+      20,
     );
     const base = (await res.json()) as { analysis?: { details?: unknown } };
     expect(base.analysis).toBeTruthy();


### PR DESCRIPTION
## Summary
- extend polling for analysis in translate API test

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686064c2b6cc832b9ab6551c30004f14