### PR TITLE
Fix translation path parsing

### DIFF
--- a/src/app/api/cases/[id]/translate/route.ts
+++ b/src/app/api/cases/[id]/translate/route.ts
@@ -3,8 +3,36 @@ import { getCase, setCaseTranslation } from "@/lib/caseStore";
 import { getLlm } from "@/lib/llm";
 import { NextResponse } from "next/server";
 
+function splitPath(path: string): string[] {
+  const parts: string[] = [];
+  let buf = "";
+  let inBracket = false;
+  for (const ch of path) {
+    if (ch === "[" && !inBracket) {
+      if (buf) {
+        parts.push(buf);
+        buf = "";
+      }
+      inBracket = true;
+    } else if (ch === "]" && inBracket) {
+      parts.push(buf);
+      buf = "";
+      inBracket = false;
+    } else if (ch === "." && !inBracket) {
+      if (buf) {
+        parts.push(buf);
+        buf = "";
+      }
+    } else {
+      buf += ch;
+    }
+  }
+  if (buf) parts.push(buf);
+  return parts;
+}
+
 function getValueByPath(obj: unknown, path: string): unknown {
-  const parts = path.replace(/\[(\w+)\]/g, ".$1").split(".");
+  const parts = splitPath(path);
   let current: unknown = obj;
   for (const part of parts) {
     if (typeof current !== "object" || current === null) return undefined;

--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -33,12 +33,13 @@ export default function AnalysisInfo({
       <p>
         {detailText}
         {needsTranslation ? (
-          <span
+          <button
+            type="button"
             onClick={() => onTranslate?.("analysis.details", i18n.language)}
-            className="ml-2 text-blue-500 underline cursor-pointer"
+            className="ml-2 text-blue-500 underline"
           >
             {t("translate")}
-          </span>
+          </button>
         ) : null}
       </p>
       {location ? (

--- a/src/app/components/ImageHighlights.tsx
+++ b/src/app/components/ImageHighlights.tsx
@@ -36,7 +36,7 @@ export default function ImageHighlights({
               type="button"
               onClick={() =>
                 onTranslate?.(
-                  `analysis.images.${name}.highlights`,
+                  `analysis.images[${name}].highlights`,
                   i18n.language,
                 )
               }
@@ -54,7 +54,7 @@ export default function ImageHighlights({
             <button
               type="button"
               onClick={() =>
-                onTranslate?.(`analysis.images.${name}.context`, i18n.language)
+                onTranslate?.(`analysis.images[${name}].context`, i18n.language)
               }
               className="ml-2 text-blue-500 underline"
             >

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -447,7 +447,30 @@ export function setCaseTranslation(
 ): Case | undefined {
   const current = getCaseRow(id);
   if (!current) return undefined;
-  const parts = path.replace(/\[(\w+)\]/g, ".$1").split(".");
+  const parts: string[] = [];
+  let buf = "";
+  let inBracket = false;
+  for (const ch of path) {
+    if (ch === "[" && !inBracket) {
+      if (buf) {
+        parts.push(buf);
+        buf = "";
+      }
+      inBracket = true;
+    } else if (ch === "]" && inBracket) {
+      parts.push(buf);
+      buf = "";
+      inBracket = false;
+    } else if (ch === "." && !inBracket) {
+      if (buf) {
+        parts.push(buf);
+        buf = "";
+      }
+    } else {
+      buf += ch;
+    }
+  }
+  if (buf) parts.push(buf);
   let obj: unknown = current;
   for (let i = 0; i < parts.length - 1; i++) {
     if (typeof obj !== "object" || obj === null) return undefined;


### PR DESCRIPTION
## Summary
- fix a11y for translate button in `AnalysisInfo`
- quote photo keys when translating image text
- support dotted keys in translation paths

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68606819efa4832ba5e9974d0802119a