### PR TITLE
Fix translation path handling for image highlights

### DIFF
--- a/src/app/api/cases/[id]/translate/route.ts
+++ b/src/app/api/cases/[id]/translate/route.ts
@@ -3,7 +3,7 @@ import { getCase, setCaseTranslation } from "@/lib/caseStore";
 import { getLlm } from "@/lib/llm";
 import { NextResponse } from "next/server";
 
-function getValueByPath(obj: unknown, path: string): unknown {
+export function getValueByPath(obj: unknown, path: string): unknown {
   const parts = path.replace(/\[(\w+)\]/g, ".$1").split(".");
   let current: unknown = obj;
   for (let i = 0; i < parts.length; i++) {

--- a/src/app/api/cases/[id]/translate/route.ts
+++ b/src/app/api/cases/[id]/translate/route.ts
@@ -6,9 +6,22 @@ import { NextResponse } from "next/server";
 function getValueByPath(obj: unknown, path: string): unknown {
   const parts = path.replace(/\[(\w+)\]/g, ".$1").split(".");
   let current: unknown = obj;
-  for (const part of parts) {
+  for (let i = 0; i < parts.length; i++) {
     if (typeof current !== "object" || current === null) return undefined;
-    current = (current as Record<string, unknown>)[part];
+    let key = parts[i];
+    let value = (current as Record<string, unknown>)[key];
+    if (value === undefined) {
+      for (let j = i + 1; j < parts.length; j++) {
+        key += `.${parts[j]}`;
+        value = (current as Record<string, unknown>)[key];
+        if (value !== undefined) {
+          i = j;
+          break;
+        }
+      }
+    }
+    if (value === undefined) return undefined;
+    current = value;
   }
   return current;
 }

--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -33,12 +33,13 @@ export default function AnalysisInfo({
       <p>
         {detailText}
         {needsTranslation ? (
-          <span
+          <button
+            type="button"
             onClick={() => onTranslate?.("analysis.details", i18n.language)}
-            className="ml-2 text-blue-500 underline cursor-pointer"
+            className="ml-2 text-blue-500 underline"
           >
             {t("translate")}
-          </span>
+          </button>
         ) : null}
       </p>
       {location ? (

--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -36,7 +36,7 @@ export default function AnalysisInfo({
           <button
             type="button"
             onClick={() => onTranslate?.("analysis.details", i18n.language)}
-            className="ml-2 text-blue-500 underline"
+            className="ml-2 text-blue-500 underline inline bg-transparent p-0 border-none cursor-pointer"
           >
             {t("translate")}
           </button>

--- a/src/app/components/ImageHighlights.tsx
+++ b/src/app/components/ImageHighlights.tsx
@@ -40,7 +40,7 @@ export default function ImageHighlights({
                   i18n.language,
                 )
               }
-              className="ml-2 text-blue-500 underline"
+              className="ml-2 text-blue-500 underline inline bg-transparent p-0 border-none cursor-pointer"
             >
               {t("translate")}
             </button>
@@ -56,7 +56,7 @@ export default function ImageHighlights({
               onClick={() =>
                 onTranslate?.(`analysis.images.${name}.context`, i18n.language)
               }
-              className="ml-2 text-blue-500 underline"
+              className="ml-2 text-blue-500 underline inline bg-transparent p-0 border-none cursor-pointer"
             >
               {t("translate")}
             </button>

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -451,10 +451,28 @@ export function setCaseTranslation(
   let obj: unknown = current;
   for (let i = 0; i < parts.length - 1; i++) {
     if (typeof obj !== "object" || obj === null) return undefined;
-    obj = (obj as Record<string, unknown>)[parts[i]];
+    let key = parts[i];
+    let next = (obj as Record<string, unknown>)[key];
+    if (next === undefined) {
+      for (let j = i + 1; j < parts.length - 1; j++) {
+        key += `.${parts[j]}`;
+        next = (obj as Record<string, unknown>)[key];
+        if (next !== undefined) {
+          i = j;
+          break;
+        }
+      }
+    }
+    if (next === undefined) return undefined;
+    obj = next;
   }
   if (typeof obj !== "object" || obj === null) return undefined;
-  const key = parts[parts.length - 1];
+  let key = parts[parts.length - 1];
+  if (!(key in obj)) {
+    for (let j = parts.length - 2; j >= 0 && !(key in obj); j--) {
+      key = `${parts[j]}.${key}`;
+    }
+  }
   const target = obj as Record<string, unknown>;
   const value = target[key];
   if (typeof value === "string") {

--- a/test/translateRoute.test.ts
+++ b/test/translateRoute.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let dataDir: string;
+let caseStore: typeof import("@/lib/caseStore");
+let route: typeof import("@/app/api/cases/[id]/translate/route");
+
+beforeEach(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "cases-"));
+  process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
+  vi.resetModules();
+  const db = await import("@/lib/db");
+  await db.migrationsReady;
+  caseStore = await import("@/lib/caseStore");
+  route = await import("@/app/api/cases/[id]/translate/route");
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  process.env.CASE_STORE_FILE = undefined;
+  vi.resetModules();
+});
+
+describe("translation helpers", () => {
+  it("gets value when key contains dots", () => {
+    const c = caseStore.createCase("/a.jpg");
+    c.analysis = {
+      violationType: "v",
+      details: { en: "d" },
+      vehicle: {},
+      images: { "a.jpg": { representationScore: 1, highlights: { en: "h" } } },
+    };
+    const val = route.getValueByPath(c, "analysis.images.a.jpg.highlights");
+    expect(val).toEqual({ en: "h" });
+  });
+});


### PR DESCRIPTION
## Summary
- handle `.` characters in translation path splitting
- improve case translation path lookup logic
- make translate link a button for accessibility

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68606819efa4832ba5e9974d0802119a