### PR TITLE
Fix chat API e2e test

### DIFF
--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -33,12 +33,18 @@ export default function AnalysisInfo({
       <p>
         {detailText}
         {needsTranslation ? (
-          <span
+          <button
+            type="button"
             onClick={() => onTranslate?.("analysis.details", i18n.language)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                onTranslate?.("analysis.details", i18n.language);
+              }
+            }}
             className="ml-2 text-blue-500 underline cursor-pointer"
           >
             {t("translate")}
-          </span>
+          </button>
         ) : null}
       </p>
       {location ? (

--- a/test/e2e/chat.test.ts
+++ b/test/e2e/chat.test.ts
@@ -13,7 +13,12 @@ let stub: OpenAIStub;
 let tmpDir: string;
 
 beforeAll(async () => {
-  stub = await startOpenAIStub({ response: "hello", actions: [], noop: false });
+  stub = await startOpenAIStub({
+    response: "hello",
+    actions: [],
+    noop: false,
+    lang: "en",
+  });
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-chat-"));
   server = await startServer(3012, {
     NEXTAUTH_SECRET: "secret",


### PR DESCRIPTION
## Summary
- add `lang` when starting chat OpenAI stub
- make translation link accessible by turning it into a button

## Testing
- `npm test`
- `npm run e2e:smoke` *(fails: process terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68606a0ec1e4832bb466118a6a202ebd