### PR TITLE
Update authority draft schema to i18n map

### DIFF
--- a/src/app/cases/[id]/ComposeWrapper.stories.tsx
+++ b/src/app/cases/[id]/ComposeWrapper.stories.tsx
@@ -48,7 +48,10 @@ function mockFetch() {
     if (url.includes(`/cases/${base.id}/report`)) {
       return new Response(
         JSON.stringify({
-          email: { subject: "Violation Report", body: "Report body" },
+          email: {
+            subject: { en: "Violation Report" },
+            body: { en: "Report body" },
+          },
           attachments: base.photos,
           module: reportModules["oak-park"],
         }),

--- a/src/app/cases/[id]/draft/DraftModal.stories.tsx
+++ b/src/app/cases/[id]/draft/DraftModal.stories.tsx
@@ -48,7 +48,10 @@ function mockFetch() {
     if (url.includes(`/cases/${base.id}/report`)) {
       return new Response(
         JSON.stringify({
-          email: { subject: "Violation Report", body: "Report body" },
+          email: {
+            subject: { en: "Violation Report" },
+            body: { en: "Report body" },
+          },
           attachments: base.photos,
           module: reportModules["oak-park"],
         }),

--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -33,12 +33,13 @@ export default function AnalysisInfo({
       <p>
         {detailText}
         {needsTranslation ? (
-          <span
+          <button
+            type="button"
             onClick={() => onTranslate?.("analysis.details", i18n.language)}
             className="ml-2 text-blue-500 underline cursor-pointer"
           >
             {t("translate")}
-          </span>
+          </button>
         ) : null}
       </p>
       {location ? (

--- a/src/lib/caseReport.ts
+++ b/src/lib/caseReport.ts
@@ -58,7 +58,10 @@ export async function draftEmail(
       : "unknown location");
   const schema = {
     type: "object",
-    properties: { subject: { type: "string" }, body: { type: "string" } },
+    properties: {
+      subject: { type: "object", additionalProperties: { type: "string" } },
+      body: { type: "object", additionalProperties: { type: "string" } },
+    },
   };
   const paperworkTexts = analysis?.images
     ? Object.values(analysis.images)
@@ -150,7 +153,10 @@ export async function draftFollowUp(
       : "unknown location");
   const schema = {
     type: "object",
-    properties: { subject: { type: "string" }, body: { type: "string" } },
+    properties: {
+      subject: { type: "object", additionalProperties: { type: "string" } },
+      body: { type: "object", additionalProperties: { type: "string" } },
+    },
   };
   const code = await getViolationCode(
     "oak-park",
@@ -240,7 +246,10 @@ export async function draftOwnerNotification(
       : "unknown location");
   const schema = {
     type: "object",
-    properties: { subject: { type: "string" }, body: { type: "string" } },
+    properties: {
+      subject: { type: "object", additionalProperties: { type: "string" } },
+      body: { type: "object", additionalProperties: { type: "string" } },
+    },
   };
   const authorityList = authorities.join(", ");
   const authorityLine =


### PR DESCRIPTION
## Summary
- switch the report draft schema to use i18n-aware subject/body format
- adjust follow-up and owner notification schemas
- fix AnalysisInfo translation button a11y
- update storybook mocks for new schema

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68606a94d4d0832bbcddc370a8d71c39