### PR TITLE
Fix cases layout hydration issue

### DIFF
--- a/src/app/cases/CasesLayoutClient.tsx
+++ b/src/app/cases/CasesLayoutClient.tsx
@@ -2,25 +2,33 @@
 import type { Case } from "@/lib/caseStore";
 import { useParams } from "next/navigation";
 import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
 import ClientCasesPage from "./ClientCasesPage";
 
 export default function CasesLayoutClient({
   children,
   initialCases,
+  hasCase,
 }: {
   children: ReactNode;
   initialCases: Case[];
+  hasCase: boolean;
 }) {
   const params = useParams<{ id?: string }>();
-  const hasCase = Boolean(params.id);
+  const [currentHasCase, setCurrentHasCase] = useState(hasCase);
+  useEffect(() => {
+    setCurrentHasCase(Boolean(params.id));
+  }, [params.id]);
   return (
     <div className="lg:grid lg:grid-cols-[20%_80%] h-[calc(100vh-4rem)]">
       <div
-        className={`${hasCase ? "hidden lg:block" : ""} border-r overflow-y-auto`}
+        className={`${currentHasCase ? "hidden lg:block" : ""} border-r overflow-y-auto`}
       >
         <ClientCasesPage initialCases={initialCases} />
       </div>
-      <div className={`${hasCase ? "" : "hidden lg:block"} overflow-y-auto`}>
+      <div
+        className={`${currentHasCase ? "" : "hidden lg:block"} overflow-y-auto`}
+      >
         {children}
       </div>
     </div>

--- a/src/app/cases/layout.tsx
+++ b/src/app/cases/layout.tsx
@@ -13,9 +13,13 @@ export default async function CasesLayout({
   children: ReactNode;
   params: Promise<{ id?: string }>;
 }) {
-  await params;
+  const { id } = await params;
   const session = await getServerSession(authOptions);
   const list = getCases();
   const cases = session ? list : list.filter((c) => c.public);
-  return <CasesLayoutClient initialCases={cases}>{children}</CasesLayoutClient>;
+  return (
+    <CasesLayoutClient initialCases={cases} hasCase={Boolean(id)}>
+      {children}
+    </CasesLayoutClient>
+  );
 }

--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -33,12 +33,18 @@ export default function AnalysisInfo({
       <p>
         {detailText}
         {needsTranslation ? (
-          <span
+          <button
+            type="button"
             onClick={() => onTranslate?.("analysis.details", i18n.language)}
-            className="ml-2 text-blue-500 underline cursor-pointer"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                onTranslate?.("analysis.details", i18n.language);
+              }
+            }}
+            className="ml-2 text-blue-500 underline cursor-pointer bg-transparent border-0 p-0"
           >
             {t("translate")}
-          </span>
+          </button>
         ) : null}
       </p>
       {location ? (


### PR DESCRIPTION
## Summary
- add keyboard handler to translate button
- pass case id to layout client to avoid hydration mismatch

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68606cd65288832bb02373388e4f216e