### PR TITLE
Fix case layout rehydration

### DIFF
--- a/src/app/cases/CasesLayoutClient.tsx
+++ b/src/app/cases/CasesLayoutClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 import type { Case } from "@/lib/caseStore";
-import { useParams } from "next/navigation";
+import { useParams, usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 import ClientCasesPage from "./ClientCasesPage";
 
@@ -12,9 +12,13 @@ export default function CasesLayoutClient({
   initialCases: Case[];
 }) {
   const params = useParams<{ id?: string }>();
+  const pathname = usePathname();
   const hasCase = Boolean(params.id);
   return (
-    <div className="lg:grid lg:grid-cols-[20%_80%] h-[calc(100vh-4rem)]">
+    <div
+      key={pathname}
+      className="lg:grid lg:grid-cols-[20%_80%] h-[calc(100vh-4rem)]"
+    >
       <div
         className={`${hasCase ? "hidden lg:block" : ""} border-r overflow-y-auto`}
       >

--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -33,12 +33,13 @@ export default function AnalysisInfo({
       <p>
         {detailText}
         {needsTranslation ? (
-          <span
+          <button
+            type="button"
             onClick={() => onTranslate?.("analysis.details", i18n.language)}
-            className="ml-2 text-blue-500 underline cursor-pointer"
+            className="ml-2 text-blue-500 underline"
           >
             {t("translate")}
-          </span>
+          </button>
         ) : null}
       </p>
       {location ? (


### PR DESCRIPTION
## Summary
- add keyboard support for the analysis translation link
- ensure the case list layout remounts when navigating between pages

## Testing
- `npm test`
- `npm run e2e:smoke` *(fails: Could not complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68606cd65288832bb02373388e4f216e