### PR TITLE
Fix a11y lint error

### DIFF
--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -33,12 +33,13 @@ export default function AnalysisInfo({
       <p>
         {detailText}
         {needsTranslation ? (
-          <span
+          <button
+            type="button"
             onClick={() => onTranslate?.("analysis.details", i18n.language)}
             className="ml-2 text-blue-500 underline cursor-pointer"
           >
             {t("translate")}
-          </span>
+          </button>
         ) : null}
       </p>
       {location ? (


### PR DESCRIPTION
## Summary
- keep `AnalysisInfo` span accessible by changing to a button

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`

------
https://chatgpt.com/codex/tasks/task_e_68606cd65288832bb02373388e4f216e