### PR TITLE
Localize authority drafts

### DIFF
--- a/src/app/api/cases/[id]/followup/route.ts
+++ b/src/app/api/cases/[id]/followup/route.ts
@@ -40,6 +40,7 @@ export const GET = withCaseAuthorization(
     const { id } = await params;
     const url = new URL(req.url);
     const replyTo = url.searchParams.get("replyTo");
+    const lang = url.searchParams.get("lang") ?? "en";
     log(`followup GET case=${id} replyTo=${replyTo ?? "none"}`);
     const c = getCase(id);
     if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -55,7 +56,7 @@ export const GET = withCaseAuthorization(
     const sender = session?.user
       ? { name: session.user.name ?? null, email: session.user.email ?? null }
       : undefined;
-    const email = await draftFollowUp(c, recipient, thread, sender);
+    const email = await draftFollowUp(c, recipient, thread, sender, lang);
     log(`drafted email subject: ${email.subject}`);
     return NextResponse.json({
       email,

--- a/src/app/api/cases/[id]/notify-owner/route.ts
+++ b/src/app/api/cases/[id]/notify-owner/route.ts
@@ -15,7 +15,7 @@ import { NextResponse } from "next/server";
 export const GET = withCaseAuthorization(
   { obj: "cases" },
   async (
-    _req: Request,
+    req: Request,
     {
       params,
       session: _session,
@@ -25,6 +25,8 @@ export const GET = withCaseAuthorization(
     },
   ) => {
     const { id } = await params;
+    const url = new URL(req.url);
+    const lang = url.searchParams.get("lang") ?? "en";
     const c = getCase(id);
     if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
     const contactInfo = getCaseOwnerContactInfo(c);
@@ -37,7 +39,7 @@ export const GET = withCaseAuthorization(
     )
       ? [reportModule.authorityName]
       : [];
-    const email = await draftOwnerNotification(c, authorities);
+    const email = await draftOwnerNotification(c, authorities, lang);
     return NextResponse.json({
       email,
       attachments: c.photos,

--- a/src/app/api/cases/[id]/report/route.ts
+++ b/src/app/api/cases/[id]/report/route.ts
@@ -9,7 +9,7 @@ import { NextResponse } from "next/server";
 export const GET = withCaseAuthorization(
   { obj: "cases" },
   async (
-    _req: Request,
+    req: Request,
     {
       params,
       session,
@@ -21,13 +21,15 @@ export const GET = withCaseAuthorization(
     },
   ) => {
     const { id } = await params;
+    const url = new URL(req.url);
+    const lang = url.searchParams.get("lang") ?? "en";
     const c = getCase(id);
     if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
     const reportModule = reportModules["oak-park"];
     const sender = session?.user
       ? { name: session.user.name ?? null, email: session.user.email ?? null }
       : undefined;
-    const email = await draftEmail(c, reportModule, sender);
+    const email = await draftEmail(c, reportModule, sender, lang);
     return NextResponse.json({
       email,
       attachments: c.photos,

--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -251,7 +251,9 @@ export function CaseChatProvider({
     setDraftAnchorId(anchorId ?? null);
     setDraftLoading(true);
     setDraftData(null);
-    const res = await apiFetch(`/api/cases/${caseId}/report`);
+    const res = await apiFetch(
+      `/api/cases/${caseId}/report?lang=${i18n.language}`,
+    );
     if (res.ok) {
       const data = (await res.json()) as {
         email: EmailDraft;

--- a/src/app/cases/[id]/ComposeWrapper.stories.tsx
+++ b/src/app/cases/[id]/ComposeWrapper.stories.tsx
@@ -48,7 +48,10 @@ function mockFetch() {
     if (url.includes(`/cases/${base.id}/report`)) {
       return new Response(
         JSON.stringify({
-          email: { subject: "Violation Report", body: "Report body" },
+          email: {
+            subject: { en: "Violation Report" },
+            body: { en: "Report body" },
+          },
           attachments: base.photos,
           module: reportModules["oak-park"],
         }),

--- a/src/app/cases/[id]/draft/DraftModal.stories.tsx
+++ b/src/app/cases/[id]/draft/DraftModal.stories.tsx
@@ -48,7 +48,10 @@ function mockFetch() {
     if (url.includes(`/cases/${base.id}/report`)) {
       return new Response(
         JSON.stringify({
-          email: { subject: "Violation Report", body: "Report body" },
+          email: {
+            subject: { en: "Violation Report" },
+            body: { en: "Report body" },
+          },
           attachments: base.photos,
           module: reportModules["oak-park"],
         }),

--- a/src/app/cases/[id]/draft/DraftModal.tsx
+++ b/src/app/cases/[id]/draft/DraftModal.tsx
@@ -4,6 +4,7 @@ import type { EmailDraft } from "@/lib/caseReport";
 import type { ReportModule } from "@/lib/reportModules";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useNotify } from "../../../components/NotificationProvider";
 import DraftEditor from "./DraftEditor";
 
@@ -25,11 +26,12 @@ export default function DraftModal({
   const [data, setData] = useState<DraftData | null>(initialData ?? null);
   const [fullScreen, setFullScreen] = useState(false);
   const notify = useNotify();
+  const { i18n } = useTranslation();
 
   useEffect(() => {
     if (initialData) return;
     let canceled = false;
-    apiFetch(`/api/cases/${caseId}/report`)
+    apiFetch(`/api/cases/${caseId}/report?lang=${i18n.language}`)
       .then(async (res) => {
         if (res.ok) {
           return res.json();
@@ -45,7 +47,7 @@ export default function DraftModal({
     return () => {
       canceled = true;
     };
-  }, [caseId, initialData, onClose, notify]);
+  }, [caseId, initialData, onClose, notify, i18n.language]);
 
   useEffect(() => {
     if (initialData) setData(initialData);

--- a/src/app/cases/[id]/draft/page.tsx
+++ b/src/app/cases/[id]/draft/page.tsx
@@ -3,6 +3,7 @@ import { getAuthorizedCase } from "@/lib/caseAccess";
 import { draftEmail } from "@/lib/caseReport";
 import { reportModules } from "@/lib/reportModules";
 import { getServerSession } from "next-auth/next";
+import { cookies, headers } from "next/headers";
 import { notFound } from "next/navigation";
 import DraftEditor from "./DraftEditor";
 
@@ -19,7 +20,22 @@ export default async function DraftPage({
   const sender = session?.user
     ? { name: session.user.name ?? null, email: session.user.email ?? null }
     : undefined;
-  const email = await draftEmail(c, reportModule, sender);
+  const cookieStore = cookies();
+  let lang = cookieStore.get("language")?.value;
+  if (!lang) {
+    const headerList = headers();
+    const accept = headerList.get("accept-language") ?? "";
+    const supported = ["en", "es", "fr"];
+    for (const part of accept.split(",")) {
+      const code = part.split(";")[0].trim().toLowerCase().split("-")[0];
+      if (supported.includes(code)) {
+        lang = code;
+        break;
+      }
+    }
+    lang = lang ?? "en";
+  }
+  const email = await draftEmail(c, reportModule, sender, lang);
   return (
     <DraftEditor
       caseId={id}

--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -33,12 +33,13 @@ export default function AnalysisInfo({
       <p>
         {detailText}
         {needsTranslation ? (
-          <span
+          <button
+            type="button"
             onClick={() => onTranslate?.("analysis.details", i18n.language)}
             className="ml-2 text-blue-500 underline cursor-pointer"
           >
             {t("translate")}
-          </span>
+          </button>
         ) : null}
       </p>
       {location ? (

--- a/src/lib/caseReport.ts
+++ b/src/lib/caseReport.ts
@@ -34,6 +34,7 @@ export async function draftEmail(
   caseData: Case,
   mod: ReportModule,
   sender?: { name?: string | null; email?: string | null },
+  lang = "en",
 ): Promise<EmailDraft> {
   const analysis = caseData.analysis;
   const vehicle = analysis?.vehicle ?? {};
@@ -58,7 +59,10 @@ export async function draftEmail(
       : "unknown location");
   const schema = {
     type: "object",
-    properties: { subject: { type: "string" }, body: { type: "string" } },
+    properties: {
+      subject: { type: "object", additionalProperties: { type: "string" } },
+      body: { type: "object", additionalProperties: { type: "string" } },
+    },
   };
   const paperworkTexts = analysis?.images
     ? Object.values(analysis.images)
@@ -93,7 +97,7 @@ Mention that photos are attached. Respond with JSON matching this schema: ${JSON
   const baseMessages: ChatCompletionMessageParam[] = [
     {
       role: "system",
-      content: "You create email drafts for municipal authorities.",
+      content: `You create email drafts for municipal authorities. Reply in ${lang}.`,
     },
     { role: "user", content: prompt } as ChatCompletionMessageParam,
   ];
@@ -130,6 +134,7 @@ export async function draftFollowUp(
   recipient: string,
   historyEmails: SentEmail[] = caseData.sentEmails ?? [],
   sender?: { name?: string | null; email?: string | null },
+  lang = "en",
 ): Promise<EmailDraft> {
   log(
     `draftFollowUp recipient=${recipient} history=${historyEmails
@@ -150,7 +155,10 @@ export async function draftFollowUp(
       : "unknown location");
   const schema = {
     type: "object",
-    properties: { subject: { type: "string" }, body: { type: "string" } },
+    properties: {
+      subject: { type: "object", additionalProperties: { type: "string" } },
+      body: { type: "object", additionalProperties: { type: "string" } },
+    },
   };
   const code = await getViolationCode(
     "oak-park",
@@ -179,7 +187,7 @@ Ask about the current citation status and mention that photos are attached again
   const baseMessages: ChatCompletionMessageParam[] = [
     {
       role: "system",
-      content: "You create email drafts for municipal authorities.",
+      content: `You create email drafts for municipal authorities. Reply in ${lang}.`,
     },
     ...history,
     { role: "user", content: prompt } as ChatCompletionMessageParam,
@@ -216,6 +224,7 @@ Ask about the current citation status and mention that photos are attached again
 export async function draftOwnerNotification(
   caseData: Case,
   authorities: string[],
+  lang = "en",
 ): Promise<EmailDraft> {
   const analysis = caseData.analysis;
   const vehicle = analysis?.vehicle ?? {};
@@ -240,7 +249,10 @@ export async function draftOwnerNotification(
       : "unknown location");
   const schema = {
     type: "object",
-    properties: { subject: { type: "string" }, body: { type: "string" } },
+    properties: {
+      subject: { type: "object", additionalProperties: { type: "string" } },
+      body: { type: "object", additionalProperties: { type: "string" } },
+    },
   };
   const authorityList = authorities.join(", ");
   const authorityLine =
@@ -262,8 +274,7 @@ export async function draftOwnerNotification(
   const baseMessages: ChatCompletionMessageParam[] = [
     {
       role: "system",
-      content:
-        "You create anonymous notification emails for vehicle owners about violations.",
+      content: `You create anonymous notification emails for vehicle owners about violations. Reply in ${lang}.`,
     },
     { role: "user", content: prompt } as ChatCompletionMessageParam,
   ];


### PR DESCRIPTION
## Summary
- add language parameter to draft email helpers
- return localized text from compose draft APIs
- detect browser language for drafting pages
- request drafts in the current language from chat widget and modal
- fix accessibility lint error in `AnalysisInfo`

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68606a94d4d0832bbcddc370a8d71c39