### PR TITLE
Add flag icon for translate button

### DIFF
--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -19,6 +19,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { useNotify } from "../../components/NotificationProvider";
+import TranslateIcon from "../../components/TranslateIcon";
 
 export interface Message {
   id: string;
@@ -574,8 +575,12 @@ export function CaseChatProvider({
       <span>
         {m.content}
         {needsTranslation ? (
-          <button type="button" className="ml-2 text-blue-500 underline">
-            {t("translate")}
+          <button
+            type="button"
+            className="ml-1 text-blue-500"
+            aria-label={t("translate")}
+          >
+            <TranslateIcon lang={i18n.language} />
           </button>
         ) : null}
       </span>

--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -3,6 +3,7 @@ import type { ViolationReport } from "@/lib/openai";
 import { US_STATES } from "@/lib/usStates";
 import { useTranslation } from "react-i18next";
 import EditableText from "./EditableText";
+import TranslateIcon from "./TranslateIcon";
 
 export default function AnalysisInfo({
   analysis,
@@ -41,9 +42,10 @@ export default function AnalysisInfo({
                 onTranslate?.("analysis.details", i18n.language);
               }
             }}
-            className="ml-2 text-blue-500 underline"
+            className="ml-1 text-blue-500"
+            aria-label={t("translate")}
           >
-            {t("translate")}
+            <TranslateIcon lang={i18n.language} />
           </button>
         ) : null}
       </p>

--- a/src/app/components/ImageHighlights.tsx
+++ b/src/app/components/ImageHighlights.tsx
@@ -2,6 +2,7 @@
 import { getLocalizedText } from "@/lib/localizedText";
 import type { ViolationReport } from "@/lib/openai";
 import { useTranslation } from "react-i18next";
+import TranslateIcon from "./TranslateIcon";
 
 export default function ImageHighlights({
   analysis,
@@ -40,9 +41,10 @@ export default function ImageHighlights({
                   i18n.language,
                 )
               }
-              className="ml-2 text-blue-500 underline"
+              className="ml-1 text-blue-500"
+              aria-label={t("translate")}
             >
-              {t("translate")}
+              <TranslateIcon lang={i18n.language} />
             </button>
           ) : null}
         </span>
@@ -56,9 +58,10 @@ export default function ImageHighlights({
               onClick={() =>
                 onTranslate?.(`analysis.images.${name}.context`, i18n.language)
               }
-              className="ml-2 text-blue-500 underline"
+              className="ml-1 text-blue-500"
+              aria-label={t("translate")}
             >
-              {t("translate")}
+              <TranslateIcon lang={i18n.language} />
             </button>
           ) : null}
         </span>

--- a/src/app/components/TranslateIcon.tsx
+++ b/src/app/components/TranslateIcon.tsx
@@ -1,0 +1,26 @@
+"use client";
+import type { ReactElement } from "react";
+
+export default function TranslateIcon({
+  lang,
+  className = "",
+}: {
+  lang: string;
+  className?: string;
+}): ReactElement {
+  const flags: Record<string, string> = {
+    en: "\uD83C\uDDFA\uD83C\uDDF8", // 🇺🇸
+    es: "\uD83C\uDDEA\uD83C\uDDF8", // 🇪🇸
+    fr: "\uD83C\uDDEB\uD83C\uDDF7", // 🇫🇷
+  };
+  const flag = flags[lang] ?? "\uD83C\uDFF3\uFE0F"; // 🏳️
+  return (
+    <span
+      className={`inline-flex items-center ${className}`}
+      aria-hidden="true"
+    >
+      <span className="mr-0.5">\u2192</span>
+      <span>{flag}</span>
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- use a new `TranslateIcon` component for inline translation buttons
- show an arrow pointing to the target language's flag

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68607d1aa07c832b94dd3069330f67c3