### PR TITLE
Enable translation of chat messages

### DIFF
--- a/src/app/api/cases/[id]/chat/translate/route.ts
+++ b/src/app/api/cases/[id]/chat/translate/route.ts
@@ -1,0 +1,25 @@
+import { withCaseAuthorization } from "@/lib/authz";
+import { getCase } from "@/lib/caseStore";
+import { getLlm } from "@/lib/llm";
+import { NextResponse } from "next/server";
+
+export const POST = withCaseAuthorization(
+  { obj: "cases", act: "read" },
+  async (req: Request, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const { text, lang } = (await req.json()) as { text: string; lang: string };
+    if (!text) return NextResponse.json({ error: "No text" }, { status: 400 });
+    const c = getCase(id);
+    if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const { client, model } = getLlm("draft_email");
+    const res = await client.chat.completions.create({
+      model,
+      messages: [
+        { role: "system", content: `Translate the following text to ${lang}.` },
+        { role: "user", content: text },
+      ],
+    });
+    const translation = res.choices[0]?.message?.content?.trim() ?? "";
+    return NextResponse.json({ text: translation });
+  },
+);

--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -570,11 +570,34 @@ export function CaseChatProvider({
 
   function renderContent(m: Message) {
     const needsTranslation = m.lang !== i18n.language;
+    async function handleTranslate() {
+      const res = await apiFetch(`/api/cases/${caseId}/chat/translate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: m.content, lang: i18n.language }),
+      });
+      if (res.ok) {
+        const data = (await res.json()) as { text: string };
+        setMessages((msgs) =>
+          msgs.map((msg) =>
+            msg.id === m.id
+              ? { ...msg, content: data.text, lang: i18n.language }
+              : msg,
+          ),
+        );
+      } else {
+        notify("Failed to translate.");
+      }
+    }
     return (
       <span>
         {m.content}
         {needsTranslation ? (
-          <button type="button" className="ml-2 text-blue-500 underline">
+          <button
+            type="button"
+            onClick={() => void handleTranslate()}
+            className="ml-2 text-blue-500 underline"
+          >
             {t("translate")}
           </button>
         ) : null}

--- a/src/lib/apiContract.ts
+++ b/src/lib/apiContract.ts
@@ -143,6 +143,19 @@ export const apiContract = c.router({
     summary: "Translate case text",
     description: "Translate a text field within a case and store it.",
   }),
+  translateChatMessage: c.mutation({
+    method: "POST",
+    path: "/api/cases/:id/chat/translate",
+    pathParams: idParams,
+    body: c.type<{ text: string; lang: string }>(),
+    responses: c.responses({
+      200: z.object({ text: z.string() }),
+      400: errorSchema,
+      404: errorSchema,
+    }),
+    summary: "Translate chat message",
+    description: "Translate a chat message using the LLM.",
+  }),
   caseStream: c.query({
     method: "GET",
     path: "/api/cases/stream",

--- a/test/e2e/chatTranslate.test.ts
+++ b/test/e2e/chatTranslate.test.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createApi } from "./api";
+import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
+import { createPhoto } from "./photo";
+import { type TestServer, startServer } from "./startServer";
+
+let server: TestServer;
+let api: (path: string, opts?: RequestInit) => Promise<Response>;
+let stub: OpenAIStub;
+let tmpDir: string;
+
+beforeAll(async () => {
+  stub = await startOpenAIStub("hola");
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-chat-translate-"));
+  server = await startServer(3042, {
+    NEXTAUTH_SECRET: "secret",
+    OPENAI_BASE_URL: stub.url,
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
+  });
+  api = createApi(server);
+});
+
+afterAll(async () => {
+  await server.close();
+  await stub.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("chat translate api", () => {
+  async function createCase(): Promise<string> {
+    const file = createPhoto("a");
+    const form = new FormData();
+    form.append("photo", file);
+    const res = await api("/api/upload", { method: "POST", body: form });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { caseId: string };
+    return data.caseId;
+  }
+
+  it("translates chat messages", async () => {
+    const id = await createCase();
+    const res = await api(`/api/cases/${id}/chat/translate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hello", lang: "es" }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { text: string };
+    expect(data.text).toBe("hola");
+    expect(stub.requests.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add API endpoint to translate chat messages
- update API contract for new chat translation route
- support translate button in chat bubbles
- test chat translation API

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68607c47f444832bbd8198106d14ea08