### PR TITLE
Fix typecheck errors

### DIFF
--- a/src/app/cases/[id]/CaseChat.stories.tsx
+++ b/src/app/cases/[id]/CaseChat.stories.tsx
@@ -25,6 +25,7 @@ export const WithLiveLlm: Story = {
           response: { en: "" },
           actions: [],
           noop: true,
+          lang: "en",
         };
       const client = new OpenAI({
         apiKey,
@@ -38,12 +39,14 @@ export const WithLiveLlm: Story = {
       });
       const text = res.choices[0]?.message?.content ?? "";
       try {
-        return JSON.parse(text) as CaseChatReply;
+        const parsed = JSON.parse(text) as CaseChatReply;
+        return { ...parsed, lang: parsed.lang ?? "en" };
       } catch {
         return {
           response: { en: text },
           actions: [],
           noop: false,
+          lang: "en",
         };
       }
     }
@@ -93,6 +96,7 @@ export const CaseAction: Story = {
       response: { en: "Notify the owner?" },
       actions: [{ id: "notify-owner" }],
       noop: false,
+      lang: "en",
     };
     return <CaseChat caseId="1" onChat={async () => reply} />;
   },
@@ -105,6 +109,7 @@ export const EditAction: Story = {
       response: { en: "Plate looks like ABC123" },
       actions: [{ field: "plate", value: "ABC123" }],
       noop: false,
+      lang: "en",
     };
     return <CaseChat caseId="1" onChat={async () => reply} />;
   },
@@ -117,6 +122,7 @@ export const PhotoNoteAction: Story = {
       response: { en: "Add note to photo" },
       actions: [{ photo: "a.jpg", note: "Clear" }],
       noop: false,
+      lang: "en",
     };
     return <CaseChat caseId="1" onChat={async () => reply} />;
   },
@@ -133,6 +139,7 @@ export const MixedActions: Story = {
         { photo: "a.jpg", note: "Zoom here" },
       ],
       noop: false,
+      lang: "en",
     };
     return <CaseChat caseId="1" onChat={async () => reply} />;
   },
@@ -145,6 +152,7 @@ export const ResponseOnly: Story = {
       response: { en: "Just a regular response" },
       actions: [],
       noop: false,
+      lang: "en",
     };
     return <CaseChat caseId="1" onChat={async () => reply} />;
   },
@@ -157,6 +165,7 @@ export const Noop: Story = {
       response: { en: "" },
       actions: [],
       noop: true,
+      lang: "en",
     };
     return <CaseChat caseId="1" onChat={async () => reply} />;
   },

--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -170,7 +170,7 @@ export function CaseChatProvider({
       const data = JSON.parse(raw) as ChatSession[];
       return data.map((s) => ({
         ...s,
-        messages: s.messages.map((m) => ({ lang: "en", ...m })),
+        messages: s.messages.map((m) => ({ ...m, lang: m.lang ?? "en" })),
       }));
     } catch {
       return [];
@@ -288,18 +288,21 @@ export function CaseChatProvider({
               response: { en: "" },
               actions: [{ id: result.slice(8, -1) }],
               noop: false,
+              lang: i18n.language,
             };
           } else if (result === "[noop]") {
             reply = {
               response: { en: "" },
               actions: [],
               noop: true,
+              lang: i18n.language,
             };
           } else {
             reply = {
               response: { en: result },
               actions: [],
               noop: false,
+              lang: i18n.language,
             };
           }
         } else if ("response" in result) {
@@ -597,18 +600,21 @@ export function CaseChatProvider({
               response: { en: "" },
               actions: [{ id: result.slice(8, -1) }],
               noop: false,
+              lang: i18n.language,
             };
           } else if (result === "[noop]") {
             reply = {
               response: { en: "" },
               actions: [],
               noop: true,
+              lang: i18n.language,
             };
           } else {
             reply = {
               response: { en: result },
               actions: [],
               noop: false,
+              lang: i18n.language,
             };
           }
         } else if ("response" in result) {

--- a/src/app/cases/[id]/draft/page.tsx
+++ b/src/app/cases/[id]/draft/page.tsx
@@ -20,10 +20,10 @@ export default async function DraftPage({
   const sender = session?.user
     ? { name: session.user.name ?? null, email: session.user.email ?? null }
     : undefined;
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
   let lang = cookieStore.get("language")?.value;
   if (!lang) {
-    const headerList = headers();
+    const headerList = await headers();
     const accept = headerList.get("accept-language") ?? "";
     const supported = ["en", "es", "fr"];
     for (const part of accept.split(",")) {

--- a/src/app/cases/__tests__/caseChatPersistence.test.tsx
+++ b/src/app/cases/__tests__/caseChatPersistence.test.tsx
@@ -23,6 +23,7 @@ describe("CaseChat persistence", () => {
               response: { en: "ok" },
               actions: [],
               noop: false,
+              lang: "en",
             },
           })}
         />,


### PR DESCRIPTION
## Summary
- default message language when loading history
- include language in case chat replies
- await cookies and headers in draft page
- update persistence test data

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68607f75f4d8832b82ad68de8472de4e