### PR TITLE
Fix SSR i18n initialization

### DIFF
--- a/src/app/i18n-provider.tsx
+++ b/src/app/i18n-provider.tsx
@@ -52,6 +52,5 @@ export default function I18nProvider({
     };
   }, [ready]);
 
-  if (!ready && !isServer) return null;
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { config } from "@/lib/config";
 import type { Metadata } from "next";
 import { getServerSession } from "next-auth";
 import { cookies, headers } from "next/headers";
+import { initI18n } from "../i18n";
 import AuthProvider from "./auth-provider";
 import NavBar from "./components/NavBar";
 import NotificationProvider from "./components/NotificationProvider";
@@ -40,6 +41,7 @@ export default async function RootLayout({
     }
     storedLang = storedLang ?? "en";
   }
+  await initI18n(storedLang);
   const publicEnv = {
     NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: config.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,
     NEXT_PUBLIC_BASE_PATH: config.NEXT_PUBLIC_BASE_PATH,


### PR DESCRIPTION
## Summary
- load translations on the server in `layout.tsx`
- always render content inside `I18nProvider`

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68607c655a90832ba00844f82292783f