### PR TITLE
fix: localize compose draft fields

### DIFF
--- a/src/app/cases/[id]/draft/DraftEditor.tsx
+++ b/src/app/cases/[id]/draft/DraftEditor.tsx
@@ -5,6 +5,7 @@ import ThumbnailImage from "@/components/thumbnail-image";
 import type { EmailDraft } from "@/lib/caseReport";
 import type { Case } from "@/lib/caseStore";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
+import { getLocalizedText } from "@/lib/localizedText";
 import type { ReportModule } from "@/lib/reportModules";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -30,9 +31,13 @@ export default function DraftEditor({
 }) {
   const { i18n } = useTranslation();
   const [subject, setSubject] = useState(
-    initialDraft?.subject[i18n.language] || "",
+    initialDraft
+      ? getLocalizedText(initialDraft.subject, i18n.language).text
+      : "",
   );
-  const [body, setBody] = useState(initialDraft?.body[i18n.language] || "");
+  const [body, setBody] = useState(
+    initialDraft ? getLocalizedText(initialDraft.body, i18n.language).text : "",
+  );
   const [sending, setSending] = useState(false);
   const [snailMail, setSnailMail] = useState(false);
   const [snailMailDisabled, setSnailMailDisabled] = useState(false);
@@ -49,8 +54,8 @@ export default function DraftEditor({
 
   useEffect(() => {
     if (initialDraft) {
-      setSubject(initialDraft.subject[i18n.language] || "");
-      setBody(initialDraft.body[i18n.language] || "");
+      setSubject(getLocalizedText(initialDraft.subject, i18n.language).text);
+      setBody(getLocalizedText(initialDraft.body, i18n.language).text);
     }
   }, [initialDraft, i18n.language]);
 

--- a/src/app/cases/[id]/followup/FollowUpModal.tsx
+++ b/src/app/cases/[id]/followup/FollowUpModal.tsx
@@ -5,6 +5,7 @@ import type { EmailDraft } from "@/lib/caseReport";
 import type { ReportModule } from "@/lib/reportModules";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 interface DraftData {
   email: EmailDraft;
@@ -23,10 +24,14 @@ export default function FollowUpModal({
   onClose: () => void;
 }) {
   const [data, setData] = useState<DraftData | null>(null);
+  const { i18n } = useTranslation();
 
   useEffect(() => {
     let canceled = false;
-    const url = `/api/cases/${caseId}/followup${replyTo ? `?replyTo=${encodeURIComponent(replyTo)}` : ""}`;
+    const base = `/api/cases/${caseId}/followup${replyTo ? `?replyTo=${encodeURIComponent(replyTo)}` : ""}`;
+    const url = base.includes("?")
+      ? `${base}&lang=${i18n.language}`
+      : `${base}?lang=${i18n.language}`;
     apiFetch(url)
       .then((res) => res.json())
       .then((d) => {
@@ -35,7 +40,7 @@ export default function FollowUpModal({
     return () => {
       canceled = true;
     };
-  }, [caseId, replyTo]);
+  }, [caseId, replyTo, i18n.language]);
 
   return (
     <Dialog.Root open onOpenChange={(o) => !o && onClose()}>

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerModal.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerModal.tsx
@@ -3,6 +3,7 @@ import { apiFetch } from "@/apiClient";
 import type { EmailDraft } from "@/lib/caseReport";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useNotify } from "../../../components/NotificationProvider";
 import NotifyOwnerEditor from "./NotifyOwnerEditor";
 
@@ -27,10 +28,12 @@ export default function NotifyOwnerModal({
 }) {
   const [data, setData] = useState<DraftData | null>(null);
   const notify = useNotify();
+  const { i18n } = useTranslation();
 
   useEffect(() => {
     let canceled = false;
-    apiFetch(`/api/cases/${caseId}/notify-owner`)
+    const url = `/api/cases/${caseId}/notify-owner?lang=${i18n.language}`;
+    apiFetch(url)
       .then(async (res) => {
         if (res.ok) {
           return res.json();
@@ -46,7 +49,7 @@ export default function NotifyOwnerModal({
     return () => {
       canceled = true;
     };
-  }, [caseId, onClose, notify]);
+  }, [caseId, onClose, notify, i18n.language]);
 
   return (
     <Dialog.Root open onOpenChange={(o) => !o && onClose()}>


### PR DESCRIPTION
## Summary
- handle localized text in DraftEditor

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68607b953408832b8549340c50eb7362