### PR TITLE
feat: translate chat messages

### DIFF
--- a/src/app/api/cases/[id]/chat/translate/route.ts
+++ b/src/app/api/cases/[id]/chat/translate/route.ts
@@ -1,0 +1,21 @@
+import { withCaseAuthorization } from "@/lib/authz";
+import { getLlm } from "@/lib/llm";
+import { NextResponse } from "next/server";
+
+export const POST = withCaseAuthorization(
+  { obj: "cases", act: "read" },
+  async (req: Request) => {
+    const { text, lang } = (await req.json()) as { text: string; lang: string };
+    if (!text) return NextResponse.json({ error: "No text" }, { status: 400 });
+    const { client, model } = getLlm("draft_email");
+    const res = await client.chat.completions.create({
+      model,
+      messages: [
+        { role: "system", content: `Translate the following text to ${lang}.` },
+        { role: "user", content: text },
+      ],
+    });
+    const translation = res.choices[0]?.message?.content?.trim() ?? "";
+    return NextResponse.json({ translation });
+  },
+);

--- a/test/e2e/translate.test.ts
+++ b/test/e2e/translate.test.ts
@@ -50,6 +50,7 @@ beforeAll(async () => {
       vehicle: {},
       images: {},
     },
+    { response: "ok", actions: [], noop: false, lang: "en" },
     "hola",
   ]);
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-translate-"));
@@ -93,5 +94,26 @@ describe("translate api", () => {
     };
     expect(updated.analysis.details.es).toBe("hola");
     expect(stub.requests.length).toBeGreaterThan(1);
+  });
+
+  it("translates chat message", async () => {
+    const id = await createCase();
+    await api(`/api/cases/${id}/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [{ role: "user", content: "Hi" }],
+        lang: "en",
+      }),
+    });
+    const tr = await api(`/api/cases/${id}/chat/translate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "ok", lang: "es" }),
+    });
+    expect(tr.status).toBe(200);
+    const data = (await tr.json()) as { translation: string };
+    expect(data.translation).toBe("hola");
+    expect(stub.requests.length).toBeGreaterThan(2);
   });
 });


### PR DESCRIPTION
## Summary
- add server route to translate chat messages
- persist translations in CaseChatProvider
- test chat translation via e2e

## Testing
- `npm test`
- `npm run e2e:smoke`

------
https://chatgpt.com/codex/tasks/task_e_68608291f724832baff58669bbc34ad1