### PR TITLE
Display flags in language menu

### DIFF
--- a/src/app/components/LanguageSwitcher.tsx
+++ b/src/app/components/LanguageSwitcher.tsx
@@ -1,6 +1,17 @@
 "use client";
 import i18n from "../../i18n";
 
+const FLAGS: Record<string, string> = {
+  en: "\u{1F1FA}\u{1F1F8}",
+  es: "\u{1F1EA}\u{1F1F8}",
+  fr: "\u{1F1EB}\u{1F1F7}",
+};
+const LABELS: Record<string, string> = {
+  en: "English",
+  es: "Espa\u00f1ol",
+  fr: "Fran\u00e7ais",
+};
+
 export default function LanguageSwitcher() {
   return (
     <select
@@ -12,9 +23,15 @@ export default function LanguageSwitcher() {
         i18n.changeLanguage(lang);
       }}
     >
-      <option value="en">EN</option>
-      <option value="es">ES</option>
-      <option value="fr">FR</option>
+      <option value="en" aria-label={LABELS.en}>
+        {FLAGS.en}
+      </option>
+      <option value="es" aria-label={LABELS.es}>
+        {FLAGS.es}
+      </option>
+      <option value="fr" aria-label={LABELS.fr}>
+        {FLAGS.fr}
+      </option>
     </select>
   );
 }


### PR DESCRIPTION
## Summary
- show flag emojis for EN/ES/FR in LanguageSwitcher

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686084d24a2c832bbf6fb18613852c44