### PR TITLE
Fix chat translation

### DIFF
--- a/src/app/api/cases/[id]/chat/translate/route.ts
+++ b/src/app/api/cases/[id]/chat/translate/route.ts
@@ -1,0 +1,26 @@
+import { withCaseAuthorization } from "@/lib/authz";
+import { getLlm } from "@/lib/llm";
+import { NextResponse } from "next/server";
+
+export const POST = withCaseAuthorization(
+  { obj: "cases", act: "read" },
+  async (req: Request, { params }: { params: Promise<{ id: string }> }) => {
+    const { text, lang } = (await req.json()) as { text: string; lang: string };
+    if (!text || !lang) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+    }
+    const { client, model } = getLlm("draft_email");
+    const res = await client.chat.completions.create({
+      model,
+      messages: [
+        {
+          role: "system",
+          content: `You translate text. Reply only with the translation in ${lang}.`,
+        },
+        { role: "user", content: text },
+      ],
+    });
+    const translation = res.choices[0]?.message?.content?.trim() ?? "";
+    return NextResponse.json({ translation });
+  },
+);

--- a/src/app/api/cases/[id]/translate/route.ts
+++ b/src/app/api/cases/[id]/translate/route.ts
@@ -49,7 +49,10 @@ export const POST = withCaseAuthorization(
     const res = await client.chat.completions.create({
       model,
       messages: [
-        { role: "system", content: `Translate the following text to ${lang}.` },
+        {
+          role: "system",
+          content: `You translate text. Reply only with the translation in ${lang}.`,
+        },
         { role: "user", content: text },
       ],
     });

--- a/src/app/useChatTranslate.ts
+++ b/src/app/useChatTranslate.ts
@@ -1,0 +1,20 @@
+"use client";
+import { apiFetch } from "@/apiClient";
+import { useNotify } from "./components/NotificationProvider";
+
+export default function useChatTranslate(caseId: string) {
+  const notify = useNotify();
+  return async (text: string, lang: string): Promise<string> => {
+    const res = await apiFetch(`/api/cases/${caseId}/chat/translate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text, lang }),
+    });
+    if (!res.ok) {
+      notify("Failed to translate.");
+      throw new Error("Failed to translate.");
+    }
+    const data = (await res.json()) as { translation: string };
+    return data.translation;
+  };
+}

--- a/src/lib/apiContract.ts
+++ b/src/lib/apiContract.ts
@@ -143,6 +143,18 @@ export const apiContract = c.router({
     summary: "Translate case text",
     description: "Translate a text field within a case and store it.",
   }),
+  translateChatMessage: c.mutation({
+    method: "POST",
+    path: "/api/cases/:id/chat/translate",
+    pathParams: idParams,
+    body: c.type<{ text: string; lang: string }>(),
+    responses: c.responses({
+      200: z.object({ translation: z.string() }),
+      400: errorSchema,
+    }),
+    summary: "Translate chat message",
+    description: "Translate a chat message for a case.",
+  }),
   caseStream: c.query({
     method: "GET",
     path: "/api/cases/stream",

--- a/test/e2e/chatTranslate.test.ts
+++ b/test/e2e/chatTranslate.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createApi } from "./api";
+import { type OpenAIStub, startOpenAIStub } from "./openaiStub";
+import { createPhoto } from "./photo";
+import { type TestServer, startServer } from "./startServer";
+
+let server: TestServer;
+let api: (path: string, opts?: RequestInit) => Promise<Response>;
+let stub: OpenAIStub;
+let tmpDir: string;
+
+beforeAll(async () => {
+  stub = await startOpenAIStub(["hello", "hola"]);
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-chat-translate-"));
+  server = await startServer(3042, {
+    NEXTAUTH_SECRET: "secret",
+    OPENAI_BASE_URL: stub.url,
+    CASE_STORE_FILE: path.join(tmpDir, "cases.sqlite"),
+  });
+  api = createApi(server);
+});
+
+afterAll(async () => {
+  await server.close();
+  await stub.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("chat translate api", () => {
+  async function createCase(): Promise<string> {
+    const file = createPhoto("a");
+    const form = new FormData();
+    form.append("photo", file);
+    const res = await api("/api/upload", { method: "POST", body: form });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { caseId: string };
+    return data.caseId;
+  }
+
+  it("translates a chat message", async () => {
+    const id = await createCase();
+    const res = await api(`/api/cases/${id}/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [{ role: "user", content: "Hi" }],
+        lang: "en",
+      }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      reply: { response: Record<string, string> };
+    };
+    const text = data.reply.response.en;
+    const tr = await api(`/api/cases/${id}/chat/translate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text, lang: "es" }),
+    });
+    expect(tr.status).toBe(200);
+    const t = (await tr.json()) as { translation: string };
+    expect(t.translation).toBe("hola");
+    expect(stub.requests.length).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
## Summary
- refine translation prompts to avoid extra text

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68608291f724832baff58669bbc34ad1