### PR TITLE
Implement animated translation button

### DIFF
--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -19,8 +19,8 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
+import InlineTranslateButton from "../../components/InlineTranslateButton";
 import { useNotify } from "../../components/NotificationProvider";
-import TranslateIcon from "../../components/TranslateIcon";
 import useChatTranslate from "../../useChatTranslate";
 
 export interface Message {
@@ -518,22 +518,20 @@ export function CaseChatProvider({
   }
 
   async function handleTranslate(msg: Message) {
-    try {
-      const tr = await chatTranslate(msg.content, i18n.language);
-      setMessages((list) =>
-        list.map((m) =>
-          m.id === msg.id
-            ? {
-                ...m,
-                translations: {
-                  ...(m.translations ?? {}),
-                  [i18n.language]: tr,
-                },
-              }
-            : m,
-        ),
-      );
-    } catch {}
+    const tr = await chatTranslate(msg.content, i18n.language);
+    setMessages((list) =>
+      list.map((m) =>
+        m.id === msg.id
+          ? {
+              ...m,
+              translations: {
+                ...(m.translations ?? {}),
+                [i18n.language]: tr,
+              },
+            }
+          : m,
+      ),
+    );
   }
 
   function renderActions(actions: CaseChatAction[], msgId: string) {
@@ -613,14 +611,10 @@ export function CaseChatProvider({
       <span>
         {text}
         {needsTranslation ? (
-          <button
-            type="button"
-            onClick={() => void handleTranslate(m)}
-            aria-label={t("translate")}
-            className="ml-2 text-blue-500 hover:text-blue-700"
-          >
-            <TranslateIcon lang={i18n.language} />
-          </button>
+          <InlineTranslateButton
+            lang={i18n.language}
+            onTranslate={() => handleTranslate(m)}
+          />
         ) : null}
       </span>
     );

--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -3,7 +3,7 @@ import type { ViolationReport } from "@/lib/openai";
 import { US_STATES } from "@/lib/usStates";
 import { useTranslation } from "react-i18next";
 import EditableText from "./EditableText";
-import TranslateIcon from "./TranslateIcon";
+import InlineTranslateButton from "./InlineTranslateButton";
 
 export default function AnalysisInfo({
   analysis,
@@ -34,19 +34,10 @@ export default function AnalysisInfo({
       <p>
         {detailText}
         {needsTranslation ? (
-          <button
-            type="button"
-            onClick={() => onTranslate?.("analysis.details", i18n.language)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                onTranslate?.("analysis.details", i18n.language);
-              }
-            }}
-            aria-label={t("translate")}
-            className="ml-2 text-blue-500 hover:text-blue-700"
-          >
-            <TranslateIcon lang={i18n.language} />
-          </button>
+          <InlineTranslateButton
+            lang={i18n.language}
+            onTranslate={() => onTranslate?.("analysis.details", i18n.language)}
+          />
         ) : null}
       </p>
       {location ? (

--- a/src/app/components/ImageHighlights.tsx
+++ b/src/app/components/ImageHighlights.tsx
@@ -2,7 +2,7 @@
 import { getLocalizedText } from "@/lib/localizedText";
 import type { ViolationReport } from "@/lib/openai";
 import { useTranslation } from "react-i18next";
-import TranslateIcon from "./TranslateIcon";
+import InlineTranslateButton from "./InlineTranslateButton";
 
 export default function ImageHighlights({
   analysis,
@@ -33,19 +33,15 @@ export default function ImageHighlights({
         <span>
           {highlights}
           {needsHighlights ? (
-            <button
-              type="button"
-              onClick={() =>
+            <InlineTranslateButton
+              lang={i18n.language}
+              onTranslate={() =>
                 onTranslate?.(
                   `analysis.images.${name}.highlights`,
                   i18n.language,
                 )
               }
-              aria-label={t("translate")}
-              className="ml-2 text-blue-500 hover:text-blue-700"
-            >
-              <TranslateIcon lang={i18n.language} />
-            </button>
+            />
           ) : null}
         </span>
       ) : null}
@@ -53,16 +49,12 @@ export default function ImageHighlights({
         <span>
           {context}
           {needsContext ? (
-            <button
-              type="button"
-              onClick={() =>
+            <InlineTranslateButton
+              lang={i18n.language}
+              onTranslate={() =>
                 onTranslate?.(`analysis.images.${name}.context`, i18n.language)
               }
-              aria-label={t("translate")}
-              className="ml-2 text-blue-500 hover:text-blue-700"
-            >
-              <TranslateIcon lang={i18n.language} />
-            </button>
+            />
           ) : null}
         </span>
       ) : null}

--- a/src/app/components/InlineTranslateButton.tsx
+++ b/src/app/components/InlineTranslateButton.tsx
@@ -1,0 +1,39 @@
+"use client";
+import { useState } from "react";
+import TranslateIcon from "./TranslateIcon";
+
+export default function InlineTranslateButton({
+  lang,
+  onTranslate,
+}: {
+  lang: string;
+  onTranslate: () => Promise<void> | void;
+}) {
+  const [state, setState] = useState<"idle" | "loading" | "error">("idle");
+
+  async function handleClick() {
+    if (state === "loading") return;
+    setState("loading");
+    try {
+      await Promise.resolve(onTranslate());
+      setState("idle");
+    } catch {
+      setState("error");
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label="translate"
+      className="ml-2 text-blue-500 hover:text-blue-700"
+    >
+      <TranslateIcon
+        lang={lang}
+        loading={state === "loading"}
+        error={state === "error"}
+      />
+    </button>
+  );
+}

--- a/src/app/components/TranslateIcon.tsx
+++ b/src/app/components/TranslateIcon.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { FaArrowRight } from "react-icons/fa";
+import { useMemo } from "react";
+import { FaArrowRight, FaSyncAlt } from "react-icons/fa";
 
 const FLAGS: Record<string, string> = {
   en: "\u{1F1FA}\u{1F1F8}",
@@ -7,12 +8,33 @@ const FLAGS: Record<string, string> = {
   fr: "\u{1F1EB}\u{1F1F7}",
 };
 
-export default function TranslateIcon({ lang }: { lang: string }) {
-  const flag = FLAGS[lang] ?? "\u{1F3F3}\u{FE0F}";
+export default function TranslateIcon({
+  lang,
+  loading = false,
+  error = false,
+}: {
+  lang: string;
+  loading?: boolean;
+  error?: boolean;
+}) {
+  const flag = useMemo(() => FLAGS[lang] ?? "\u{1F3F3}\u{FE0F}", [lang]);
+  const ArrowIcon = error ? FaSyncAlt : FaArrowRight;
   return (
-    <span className="inline-flex items-center text-xs">
-      <FaArrowRight className="mr-0.5" />
-      <span aria-label={lang}>{flag}</span>
+    <span className="inline-flex items-center text-xs relative">
+      <ArrowIcon
+        className={`mr-0.5 ${loading ? "animate-translate-arrow" : ""}`}
+      />
+      <span
+        aria-label={lang}
+        className={`relative ${loading ? "animate-translate-flag" : ""}`}
+      >
+        {flag}
+        {error ? (
+          <span className="absolute inset-0 flex items-center justify-center text-red-600">
+            ✖
+          </span>
+        ) : null}
+      </span>
     </span>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,3 +55,31 @@ body {
 .json-null {
   color: #808080;
 }
+
+@keyframes translate-arrow {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  50% {
+    transform: translateX(2px);
+  }
+}
+
+@keyframes translate-flag {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  50% {
+    transform: translateX(-2px);
+  }
+}
+
+.animate-translate-arrow {
+  animation: translate-arrow 0.6s ease-in-out infinite;
+}
+
+.animate-translate-flag {
+  animation: translate-flag 0.6s ease-in-out infinite;
+}


### PR DESCRIPTION
## Summary
- add animation keyframes for translate arrow and flag
- enhance TranslateIcon with loading and error states
- create InlineTranslateButton component for per-button state
- integrate InlineTranslateButton in AnalysisInfo, ImageHighlights and CaseChatProvider
- propagate translation errors for individual buttons

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6860ba3a1ba8832bb5748740bb9e504f