### PR TITLE
feat: geocode point and shoot photos

### DIFF
--- a/src/app/cases/[id]/camera/TakePhotoWidget.tsx
+++ b/src/app/cases/[id]/camera/TakePhotoWidget.tsx
@@ -16,9 +16,15 @@ export default function TakePhotoWidget({
   const uploadCase = useAddFilesToCase(caseId);
   const [error, setError] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
+  const [gps, setGps] = useState<{ lat: number; lon: number } | null>(null);
   const { t } = useTranslation();
 
   useEffect(() => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition((pos) => {
+        setGps({ lat: pos.coords.latitude, lon: pos.coords.longitude });
+      });
+    }
     let stream: MediaStream | null = null;
     async function startCamera() {
       if (!navigator.mediaDevices?.getUserMedia) {
@@ -67,7 +73,7 @@ export default function TakePhotoWidget({
       const dt = new DataTransfer();
       dt.items.add(file);
       setUploading(true);
-      await uploadCase(dt.files);
+      await uploadCase(dt.files, gps);
       setUploading(false);
       onClose();
     }, "image/jpeg");

--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -23,12 +23,21 @@ export default function PointAndShootPage() {
   const [analysisHint, setAnalysisHint] = useState<string | null>(null);
   const [cameraError, setCameraError] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
+  const [gps, setGps] = useState<{ lat: number; lon: number } | null>(null);
   const { t } = useTranslation();
   const params = useSearchParams();
   const caseId = params.get("case") || null;
   const addFiles = useAddFilesToCase(caseId ?? "");
   const newCase = useNewCaseFromFiles();
   const uploadCase = caseId ? addFiles : newCase;
+
+  useEffect(() => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition((pos) => {
+        setGps({ lat: pos.coords.latitude, lon: pos.coords.longitude });
+      });
+    }
+  }, []);
 
   useEffect(() => {
     async function startCamera() {
@@ -127,7 +136,7 @@ export default function PointAndShootPage() {
       const file = new File([blob], "photo.jpg", { type: "image/jpeg" });
       const dt = new DataTransfer();
       dt.items.add(file);
-      await uploadCase(dt.files);
+      await uploadCase(dt.files, gps);
     }, "image/jpeg");
   }
 

--- a/src/app/useAddFilesToCase.ts
+++ b/src/app/useAddFilesToCase.ts
@@ -14,13 +14,20 @@ export default function useAddFilesToCase(caseId: string) {
     mutationFn: async (formData: FormData) =>
       apiFetch("/api/upload", { method: "POST", body: formData }),
   });
-  return async (files: FileList | null) => {
+  return async (
+    files: FileList | null,
+    gps?: { lat: number; lon: number } | null,
+  ) => {
     if (!files || files.length === 0) return;
     const results = await Promise.all(
       Array.from(files).map((file) => {
         const formData = new FormData();
         formData.append("photo", file);
         formData.append("caseId", caseId);
+        if (gps) {
+          formData.append("lat", String(gps.lat));
+          formData.append("lon", String(gps.lon));
+        }
         return uploadMutation.mutateAsync(formData);
       }),
     );

--- a/src/app/useNewCaseFromFiles.ts
+++ b/src/app/useNewCaseFromFiles.ts
@@ -14,7 +14,10 @@ export default function useNewCaseFromFiles() {
     mutationFn: async (formData: FormData) =>
       apiFetch("/api/upload", { method: "POST", body: formData }),
   });
-  return async (files: FileList | null) => {
+  return async (
+    files: FileList | null,
+    gps?: { lat: number; lon: number } | null,
+  ) => {
     if (!files || files.length === 0) return;
     const id = crypto.randomUUID();
     const preview = URL.createObjectURL(files[0]);
@@ -24,6 +27,10 @@ export default function useNewCaseFromFiles() {
         const formData = new FormData();
         formData.append("photo", file);
         formData.append("caseId", id);
+        if (gps) {
+          formData.append("lat", String(gps.lat));
+          formData.append("lon", String(gps.lon));
+        }
         const upload = uploadMutation.mutateAsync(formData);
         if (idx === 0) {
           upload.then(() => {


### PR DESCRIPTION
## Summary
- capture browser geolocation in point-and-shoot pages and camera widget
- pass location through file upload helpers
- accept optional latitude/longitude in upload API
- test upload route GPS support
- skip GPS override for file uploads in point-and-shoot

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6860c1ef8b48832b907be279b5c0997e