### PR TITLE
Normalize localized text fields

### DIFF
--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -4,6 +4,7 @@ import { getCaseActionStatus } from "@/lib/caseActions";
 import { getCase } from "@/lib/caseStore";
 import { getLlm } from "@/lib/llm";
 import { chatWithSchema } from "@/lib/llmUtils";
+import { normalizeLocalizedText } from "@/lib/localizedText";
 import { NextResponse } from "next/server";
 import { APIError } from "openai/error";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
@@ -85,12 +86,12 @@ export const POST = withCaseAuthorization(
           maxTokens: 800,
         },
       );
-      const lang = (raw as { language?: string }).language ?? "en";
+      const lang =
+        (raw as { language?: string; lang?: string }).lang ??
+        (raw as { language?: string }).language ??
+        "en";
       const reply: import("@/lib/caseChat").CaseChatReply = {
-        response:
-          typeof raw.response === "string"
-            ? { [lang]: raw.response }
-            : raw.response,
+        response: normalizeLocalizedText(raw.response, lang),
         actions: raw.actions,
         noop: raw.noop,
         lang,

--- a/src/lib/__tests__/caseReport.test.ts
+++ b/src/lib/__tests__/caseReport.test.ts
@@ -41,10 +41,7 @@ describe("draftEmail", () => {
       choices: [
         {
           message: {
-            content: JSON.stringify({
-              subject: { en: "s" },
-              body: { en: "b" },
-            }),
+            content: JSON.stringify({ subject: "s", body: "b" }),
           },
         },
       ],
@@ -71,10 +68,7 @@ describe("draftEmail", () => {
         choices: [
           {
             message: {
-              content: JSON.stringify({
-                subject: { en: "s2" },
-                body: { en: "b2" },
-              }),
+              content: JSON.stringify({ subject: "s2", body: "b2" }),
             },
           },
         ],
@@ -116,10 +110,7 @@ describe("draftOwnerNotification", () => {
       choices: [
         {
           message: {
-            content: JSON.stringify({
-              subject: { en: "s" },
-              body: { en: "b" },
-            }),
+            content: JSON.stringify({ subject: "s", body: "b" }),
           },
         },
       ],
@@ -144,10 +135,7 @@ describe("draftOwnerNotification", () => {
         choices: [
           {
             message: {
-              content: JSON.stringify({
-                subject: { en: "s2" },
-                body: { en: "b2" },
-              }),
+              content: JSON.stringify({ subject: "s2", body: "b2" }),
             },
           },
         ],

--- a/src/lib/caseChat.ts
+++ b/src/lib/caseChat.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import "./zod-setup";
-import { localizedTextSchema } from "./openai";
+import { localizedTextSchema, rawLocalizedTextSchema } from "./openai";
 
 export type CaseChatAction =
   | { id: string }
@@ -15,7 +15,7 @@ export interface CaseChatReply {
 }
 
 export const caseChatReplySchema = z.object({
-  response: localizedTextSchema,
+  response: rawLocalizedTextSchema,
   actions: z.array(
     z.union([
       z.object({ id: z.string() }),

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -4,6 +4,7 @@ import { eq, sql } from "drizzle-orm";
 import { caseEvents } from "./caseEvents";
 import { addCaseMember, isCaseMember } from "./caseMembers";
 import { db } from "./db";
+import { normalizeLocalizedText } from "./localizedText";
 import { orm } from "./orm";
 import { casePhotoAnalysis, casePhotos } from "./schema";
 import { fetchCaseVinInBackground } from "./vinLookup";
@@ -127,13 +128,16 @@ function rowToCase(row: {
       images[path.basename(a.url)] = {
         representationScore: a.representationScore,
         ...(a.highlights !== null && {
-          highlights: (() => {
-            try {
-              return JSON.parse(a.highlights);
-            } catch {
-              return { en: a.highlights };
-            }
-          })(),
+          highlights: normalizeLocalizedText(
+            (() => {
+              try {
+                return JSON.parse(a.highlights);
+              } catch {
+                return a.highlights;
+              }
+            })(),
+            base.analysis?.language ?? "en",
+          ),
         }),
         ...(a.violation !== null && { violation: Boolean(a.violation) }),
         ...(a.paperwork !== null && { paperwork: Boolean(a.paperwork) }),

--- a/src/lib/localizedText.ts
+++ b/src/lib/localizedText.ts
@@ -8,3 +8,19 @@ export function getLocalizedText(
   const text = textMap[lang] ?? textMap.en ?? Object.values(textMap)[0] ?? "";
   return { text, needsTranslation: !(lang in textMap) };
 }
+export function normalizeLocalizedText(
+  value: unknown,
+  lang: string,
+): Record<string, string> {
+  if (!value) return {};
+  if (typeof value === "string") return { [lang]: value };
+  if (typeof value === "object") {
+    const obj = value as Record<string, string>;
+    const keys = Object.keys(obj);
+    const known = ["en", "es", "fr"];
+    if (keys.some((k) => known.includes(k))) return obj;
+    if (keys.length === 1) return { [lang]: obj[keys[0]] };
+    return obj;
+  }
+  return {};
+}


### PR DESCRIPTION
## Summary
- map plain analysis text to the active language
- ensure email drafts and chat replies accept strings
- normalize DB highlights
- update tests for new string responses

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6860c165939c832b8c9e765daaf9fe6c