### PR TITLE
Lock body scrolling on mobile chat

### DIFF
--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -152,6 +152,19 @@ export function CaseChatProvider({
   useEffect(() => {
     openRef.current = open;
   }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (window.innerWidth >= 640) return;
+    const htmlStyle = document.documentElement.style.overflow;
+    const bodyStyle = document.body.style.overflow;
+    document.documentElement.style.overflow = "hidden";
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.documentElement.style.overflow = htmlStyle;
+      document.body.style.overflow = bodyStyle;
+    };
+  }, [open]);
   const [draftData, setDraftData] = useState<{
     email: EmailDraft;
     attachments: string[];


### PR DESCRIPTION
## Summary
- prevent page scrolling when case chat is open on mobile

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6860cd2c8108832ba5873918d75f1374