### PR TITLE
feat: lock body scroll on mobile chat

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -1,5 +1,7 @@
 "use client";
 import type { CaseChatReply } from "@/lib/caseChat";
+import isMobile from "is-mobile";
+import { useEffect } from "react";
 import {
   CaseChatProvider,
   type ChatResponse,
@@ -30,6 +32,21 @@ export default function CaseChat(props: {
 
 function CaseChatInner({ caseId }: { caseId: string }) {
   const { open, expanded, handleOpen } = useCaseChat();
+
+  useEffect(() => {
+    if (!isMobile()) return;
+    const body = document.body;
+    const prevOverflow = body.style.overflow;
+    const prevHeight = body.style.height;
+    if (open) {
+      body.style.overflow = "hidden";
+      body.style.height = "100dvh";
+    }
+    return () => {
+      body.style.overflow = prevOverflow;
+      body.style.height = prevHeight;
+    };
+  }, [open]);
   return (
     <div
       className={`${

--- a/src/app/cases/__tests__/caseChatBodyScroll.test.tsx
+++ b/src/app/cases/__tests__/caseChatBodyScroll.test.tsx
@@ -1,0 +1,28 @@
+import CaseChat from "@/app/cases/[id]/CaseChat";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async () => ({ ok: true, json: async () => ({ photos: [] }) })),
+);
+
+vi.mock("is-mobile", () => ({ default: () => true }));
+
+describe("CaseChat body scroll lock", () => {
+  it("locks and restores body scroll", () => {
+    document.body.style.overflow = "auto";
+    document.body.style.height = "";
+    const { getByText, getByLabelText } = render(<CaseChat caseId="1" />);
+    fireEvent.click(getByText("Chat"));
+    expect(document.body.style.overflow).toBe("hidden");
+    expect(document.body.style.height).toBe("100dvh");
+    fireEvent.click(getByLabelText("Close chat"));
+    expect(document.body.style.overflow).toBe("auto");
+    expect(document.body.style.height).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- prevent viewport scroll on mobile Safari when chat is open by locking `body` scroll
- test body scroll lock behavior

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860cd2c8108832ba5873918d75f1374