### PR TITLE
Lock body scrolling on mobile chat

### DIFF
--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -152,6 +152,19 @@ export function CaseChatProvider({
   useEffect(() => {
     openRef.current = open;
   }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (window.innerWidth >= 640) return;
+    const htmlStyle = document.documentElement.style.overflow;
+    const bodyStyle = document.body.style.overflow;
+    document.documentElement.style.overflow = "hidden";
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.documentElement.style.overflow = htmlStyle;
+      document.body.style.overflow = bodyStyle;
+    };
+  }, [open]);
   const [draftData, setDraftData] = useState<{
     email: EmailDraft;
     attachments: string[];

--- a/src/app/cases/[id]/ChatInput.tsx
+++ b/src/app/cases/[id]/ChatInput.tsx
@@ -7,7 +7,10 @@ export default function ChatInput() {
     useCaseChat();
   const { t } = useTranslation();
   return (
-    <div className="border-t p-2 flex flex-col gap-2">
+    <div
+      className="border-t p-2 flex flex-col gap-2"
+      style={{ paddingBottom: "calc(env(safe-area-inset-bottom,0) + 0.5rem)" }}
+    >
       {showJump ? (
         <button
           type="button"


### PR DESCRIPTION
## Summary
- prevent page scrolling when case chat is open on mobile
- keep chat input above Safari's URL bar

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6860cd2c8108832ba5873918d75f1374