### PR TITLE
Fix flakey reanalysis test

### DIFF
--- a/test/e2e/chatTranslate.test.ts
+++ b/test/e2e/chatTranslate.test.ts
@@ -13,7 +13,11 @@ let stub: OpenAIStub;
 let tmpDir: string;
 
 beforeAll(async () => {
-  stub = await startOpenAIStub(["hello", "hola"]);
+  stub = await startOpenAIStub([
+    { violationType: "parking", details: {}, vehicle: {}, images: {} },
+    { response: { en: "hello" }, actions: [], noop: false, lang: "en" },
+    "hola",
+  ]);
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-chat-translate-"));
   server = await startServer(3042, {
     NEXTAUTH_SECRET: "secret",

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -93,7 +93,7 @@ describe("reanalysis", () => {
         { violationType: "parking", details: "d", vehicle: {}, images: {} },
         () => {
           const start = Date.now();
-          while (Date.now() - start < 200) {}
+          while (Date.now() - start < 2000) {}
           return {
             violationType: "parking",
             details: "d",


### PR DESCRIPTION
## Summary
- stabilize reanalyze-photo e2e test by giving longer OpenAI stub delay
- fix chat translation test to use valid JSON

## Testing
- `npm test`
- `npx vitest run -c vitest.e2e.config.ts test/e2e/chatTranslate.test.ts`
- `npx vitest run -c vitest.e2e.config.ts test/e2e/reanalyze.test.ts`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6860cc3ca6a4832bbc90c43f2dd96692