### PR TITLE
Fix map overlay layering

### DIFF
--- a/src/app/components/CaseLayout.tsx
+++ b/src/app/components/CaseLayout.tsx
@@ -13,7 +13,9 @@ export default function CaseLayout({
 }) {
   return (
     <div className="p-8 flex flex-col gap-4">
-      <div className="sticky top-14 bg-white dark:bg-gray-900">{header}</div>
+      <div className="sticky top-14 bg-white dark:bg-gray-900 z-20">
+        {header}
+      </div>
       <div className="grid grid-cols-1 md:grid-cols-[35%_65%] lg:grid-cols-[30%_70%] gap-4 md:gap-6">
         <div>{left}</div>
         <div className="flex flex-col gap-4">{right}</div>

--- a/src/app/components/MapPreview.tsx
+++ b/src/app/components/MapPreview.tsx
@@ -24,22 +24,22 @@ export default function MapPreview({
       className={`relative ${className ?? ""}`}
       style={{ aspectRatio: `${width} / ${height}` }}
     >
-      {link ? (
-        <a
-          href={link}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="absolute inset-0 z-10"
-        >
-          <span className="sr-only">View on map</span>
-        </a>
-      ) : null}
       <img
         src={url}
         alt={`Map preview at ${lat}, ${lon}`}
         className="object-cover absolute inset-0 w-full h-full"
         loading="lazy"
       />
+      {link ? (
+        <a
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="absolute inset-0"
+        >
+          <span className="sr-only">View on map</span>
+        </a>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- ensure CaseLayout header stays on top by giving it stacking context
- rely on DOM ordering for map link overlay

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686139f9a1f4832b85237201941bf7c2