### PR TITLE
Fix chat input height in Safari

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -43,7 +43,7 @@ function CaseChatInner({ caseId }: { caseId: string }) {
       {open ? (
         <div
           className={`bg-white dark:bg-gray-900 shadow-lg rounded flex flex-col ${
-            expanded ? "w-full h-full" : "w-screen h-screen sm:w-80 sm:h-96"
+            expanded ? "w-full h-full" : "w-screen h-[100dvh] sm:w-80 sm:h-96"
           }`}
         >
           <ChatHeader />


### PR DESCRIPTION
## Summary
- adjust CaseChat container height to 100dvh for mobile Safari

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68613a65de84832bb8bc22a26931ae7f