### PR TITLE
Fix QueryClient initialization

### DIFF
--- a/src/app/query-provider.tsx
+++ b/src/app/query-provider.tsx
@@ -2,13 +2,15 @@
 
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import queryClient from "./queryClient";
+import { useState } from "react";
+import { makeQueryClient } from "./queryClient";
 
 export default function QueryProvider({
   children,
 }: { children: React.ReactNode }) {
+  const [client] = useState(makeQueryClient);
   return (
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={client}>
       {children}
       {process.env.NODE_ENV === "development" && (
         <ReactQueryDevtools initialIsOpen={false} />

--- a/src/app/queryClient.ts
+++ b/src/app/queryClient.ts
@@ -1,19 +1,22 @@
 import { apiFetch } from "@/apiClient";
 import { QueryClient } from "@tanstack/react-query";
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      queryFn: async ({ queryKey }) => {
-        const path = Array.isArray(queryKey)
-          ? String(queryKey[0])
-          : String(queryKey);
-        const res = await apiFetch(path);
-        if (!res.ok) throw new Error(await res.text());
-        return res.json();
+export function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        queryFn: async ({ queryKey }) => {
+          const path = Array.isArray(queryKey)
+            ? String(queryKey[0])
+            : String(queryKey);
+          const res = await apiFetch(path);
+          if (!res.ok) throw new Error(await res.text());
+          return res.json();
+        },
       },
     },
-  },
-});
+  });
+}
 
+const queryClient = makeQueryClient();
 export default queryClient;


### PR DESCRIPTION
## Summary
- initialize React Query client inside the provider
- keep default query client for tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686148324f14832bae865150c8c74f89