### PR TITLE
fix: load react query devtools on client

### DIFF
--- a/src/app/query-provider.tsx
+++ b/src/app/query-provider.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import { QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import dynamic from "next/dynamic";
 import queryClient from "./queryClient";
+
+const ReactQueryDevtools = dynamic(
+  () =>
+    import("@tanstack/react-query-devtools").then(
+      (mod) => mod.ReactQueryDevtools,
+    ),
+  { ssr: false },
+);
 
 export default function QueryProvider({
   children,


### PR DESCRIPTION
## Summary
- dynamically import React Query devtools with `ssr: false`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686148324f14832bae865150c8c74f89