### PR TITLE
fix: mobile chat viewport

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -229,7 +229,7 @@ export default function ClientCasesPage({
                     : "ring-1 ring-transparent"
               }`}
             >
-              <div
+              <button
                 type="button"
                 onClick={(e) => {
                   if (e.shiftKey) {
@@ -296,7 +296,7 @@ export default function ClientCasesPage({
                     </span>
                   )}
                 </div>
-              </div>
+              </button>
             </li>
           ))}
       </ul>

--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -1,4 +1,5 @@
 "use client";
+import useVisualViewportHeight from "@/app/hooks/useVisualViewportHeight";
 import type { CaseChatReply } from "@/lib/caseChat";
 import {
   CaseChatProvider,
@@ -30,6 +31,7 @@ export default function CaseChat(props: {
 
 function CaseChatInner({ caseId }: { caseId: string }) {
   const { open, expanded, handleOpen } = useCaseChat();
+  const vh = useVisualViewportHeight();
   return (
     <div
       className={`${
@@ -43,8 +45,9 @@ function CaseChatInner({ caseId }: { caseId: string }) {
       {open ? (
         <div
           className={`bg-white dark:bg-gray-900 shadow-lg rounded flex flex-col ${
-            expanded ? "w-full h-full" : "w-screen h-[100dvh] sm:w-80 sm:h-96"
+            expanded ? "w-full h-full" : "w-screen sm:w-80 sm:h-96"
           }`}
+          style={expanded ? undefined : { height: vh ? `${vh}px` : "100dvh" }}
         >
           <ChatHeader />
           <ChatMessages caseId={caseId} />

--- a/src/app/hooks/useVisualViewportHeight.ts
+++ b/src/app/hooks/useVisualViewportHeight.ts
@@ -1,0 +1,21 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function useVisualViewportHeight() {
+  const [height, setHeight] = useState(0);
+  useEffect(() => {
+    function update() {
+      setHeight(
+        typeof window.visualViewport?.height === "number"
+          ? window.visualViewport.height
+          : window.innerHeight,
+      );
+    }
+    update();
+    window.visualViewport?.addEventListener("resize", update);
+    return () => {
+      window.visualViewport?.removeEventListener("resize", update);
+    };
+  }, []);
+  return height;
+}


### PR DESCRIPTION
## Summary
- ensure Case Chat fills visible viewport height
- add visual viewport hook for dynamic height
- fix lint error with button semantics

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686149ca4edc832b80ce27ff27e4f767