### PR TITLE
Fix mobile chat viewport height

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -229,7 +229,7 @@ export default function ClientCasesPage({
                     : "ring-1 ring-transparent"
               }`}
             >
-              <div
+              <button
                 type="button"
                 onClick={(e) => {
                   if (e.shiftKey) {
@@ -296,7 +296,7 @@ export default function ClientCasesPage({
                     </span>
                   )}
                 </div>
-              </div>
+              </button>
             </li>
           ))}
       </ul>

--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -1,4 +1,5 @@
 "use client";
+import useVisualViewportHeight from "@/app/useVisualViewportHeight";
 import type { CaseChatReply } from "@/lib/caseChat";
 import {
   CaseChatProvider,
@@ -30,6 +31,7 @@ export default function CaseChat(props: {
 
 function CaseChatInner({ caseId }: { caseId: string }) {
   const { open, expanded, handleOpen } = useCaseChat();
+  const viewportHeight = useVisualViewportHeight();
   return (
     <div
       className={`${
@@ -43,8 +45,9 @@ function CaseChatInner({ caseId }: { caseId: string }) {
       {open ? (
         <div
           className={`bg-white dark:bg-gray-900 shadow-lg rounded flex flex-col ${
-            expanded ? "w-full h-full" : "w-screen h-[100dvh] sm:w-80 sm:h-96"
+            expanded ? "w-full h-full" : "w-screen sm:w-80 sm:h-96"
           }`}
+          style={expanded ? undefined : { height: `${viewportHeight}px` }}
         >
           <ChatHeader />
           <ChatMessages caseId={caseId} />

--- a/src/app/useVisualViewportHeight.ts
+++ b/src/app/useVisualViewportHeight.ts
@@ -1,0 +1,23 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function useVisualViewportHeight() {
+  const [height, setHeight] = useState(
+    typeof window === "undefined"
+      ? 0
+      : (window.visualViewport?.height ?? window.innerHeight),
+  );
+  useEffect(() => {
+    function update() {
+      setHeight(window.visualViewport?.height ?? window.innerHeight);
+    }
+    update();
+    window.visualViewport?.addEventListener("resize", update);
+    window.addEventListener("resize", update);
+    return () => {
+      window.visualViewport?.removeEventListener("resize", update);
+      window.removeEventListener("resize", update);
+    };
+  }, []);
+  return height;
+}


### PR DESCRIPTION
## Summary
- ensure chat overlay resizes with the visual viewport height
- make case list entries keyboard accessible

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686149ca4edc832b80ce27ff27e4f767