### PR TITLE
Fix chat height on mobile

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -229,7 +229,7 @@ export default function ClientCasesPage({
                     : "ring-1 ring-transparent"
               }`}
             >
-              <div
+              <button
                 type="button"
                 onClick={(e) => {
                   if (e.shiftKey) {
@@ -296,7 +296,7 @@ export default function ClientCasesPage({
                     </span>
                   )}
                 </div>
-              </div>
+              </button>
             </li>
           ))}
       </ul>

--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -1,5 +1,7 @@
 "use client";
 import type { CaseChatReply } from "@/lib/caseChat";
+import { useRef } from "react";
+import useViewportHeight from "../../useViewportHeight";
 import {
   CaseChatProvider,
   type ChatResponse,
@@ -30,6 +32,8 @@ export default function CaseChat(props: {
 
 function CaseChatInner({ caseId }: { caseId: string }) {
   const { open, expanded, handleOpen } = useCaseChat();
+  const containerRef = useRef<HTMLDivElement>(null);
+  useViewportHeight(containerRef, open && !expanded);
   return (
     <div
       className={`${
@@ -42,8 +46,9 @@ function CaseChatInner({ caseId }: { caseId: string }) {
     >
       {open ? (
         <div
+          ref={containerRef}
           className={`bg-white dark:bg-gray-900 shadow-lg rounded flex flex-col ${
-            expanded ? "w-full h-full" : "w-screen h-[100dvh] sm:w-80 sm:h-96"
+            expanded ? "w-full h-full" : "w-screen sm:w-80 sm:h-96"
           }`}
         >
           <ChatHeader />

--- a/src/app/useViewportHeight.ts
+++ b/src/app/useViewportHeight.ts
@@ -1,0 +1,24 @@
+"use client";
+import { useEffect } from "react";
+
+export default function useViewportHeight(
+  ref: React.RefObject<HTMLElement>,
+  enabled = true,
+) {
+  useEffect(() => {
+    if (!enabled) return;
+    const el = ref.current;
+    if (!el) return;
+    function setHeight() {
+      const height = window.visualViewport?.height ?? window.innerHeight;
+      el.style.height = `${height}px`;
+    }
+    setHeight();
+    window.visualViewport?.addEventListener("resize", setHeight);
+    window.addEventListener("resize", setHeight);
+    return () => {
+      window.visualViewport?.removeEventListener("resize", setHeight);
+      window.removeEventListener("resize", setHeight);
+    };
+  }, [ref, enabled]);
+}


### PR DESCRIPTION
## Summary
- add `useViewportHeight` hook
- adjust chat container to use dynamic height
- make case list item clickable button for accessibility

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`

------
https://chatgpt.com/codex/tasks/task_e_686149ca4edc832b80ce27ff27e4f767