### PR TITLE
Fix chat viewport on mobile

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -229,7 +229,7 @@ export default function ClientCasesPage({
                     : "ring-1 ring-transparent"
               }`}
             >
-              <div
+              <button
                 type="button"
                 onClick={(e) => {
                   if (e.shiftKey) {
@@ -296,7 +296,7 @@ export default function ClientCasesPage({
                     </span>
                   )}
                 </div>
-              </div>
+              </button>
             </li>
           ))}
       </ul>

--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -1,5 +1,6 @@
 "use client";
 import type { CaseChatReply } from "@/lib/caseChat";
+import useVisualViewportHeight from "../../hooks/useVisualViewportHeight";
 import {
   CaseChatProvider,
   type ChatResponse,
@@ -30,6 +31,7 @@ export default function CaseChat(props: {
 
 function CaseChatInner({ caseId }: { caseId: string }) {
   const { open, expanded, handleOpen } = useCaseChat();
+  useVisualViewportHeight();
   return (
     <div
       className={`${
@@ -43,8 +45,11 @@ function CaseChatInner({ caseId }: { caseId: string }) {
       {open ? (
         <div
           className={`bg-white dark:bg-gray-900 shadow-lg rounded flex flex-col ${
-            expanded ? "w-full h-full" : "w-screen h-[100dvh] sm:w-80 sm:h-96"
+            expanded ? "w-full h-full" : "w-screen sm:w-80 sm:h-96"
           }`}
+          style={
+            expanded ? undefined : { height: "var(--visual-viewport-height)" }
+          }
         >
           <ChatHeader />
           <ChatMessages caseId={caseId} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,7 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --visual-viewport-height: 100dvh;
 }
 
 @theme inline {

--- a/src/app/hooks/useVisualViewportHeight.ts
+++ b/src/app/hooks/useVisualViewportHeight.ts
@@ -1,0 +1,23 @@
+"use client";
+import { useEffect } from "react";
+
+export default function useVisualViewportHeight() {
+  useEffect(() => {
+    const setHeight = () => {
+      const height = window.visualViewport
+        ? window.visualViewport.height
+        : window.innerHeight;
+      document.documentElement.style.setProperty(
+        "--visual-viewport-height",
+        `${height}px`,
+      );
+    };
+    setHeight();
+    window.visualViewport?.addEventListener("resize", setHeight);
+    window.addEventListener("resize", setHeight);
+    return () => {
+      window.visualViewport?.removeEventListener("resize", setHeight);
+      window.removeEventListener("resize", setHeight);
+    };
+  }, []);
+}

--- a/src/app/hooks/useVisualViewportHeight.ts
+++ b/src/app/hooks/useVisualViewportHeight.ts
@@ -11,6 +11,8 @@ export default function useVisualViewportHeight() {
         "--visual-viewport-height",
         `${height}px`,
       );
+      // prevent the browser from scrolling the page when the keyboard opens
+      window.scrollTo({ top: 0 });
     };
     setHeight();
     window.visualViewport?.addEventListener("resize", setHeight);


### PR DESCRIPTION
## Summary
- ensure chat panel height follows keyboard changes by using `--visual-viewport-height`
- maintain accessibility by replacing a clickable `<div>` with a `<button>` element

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686149ca4edc832b80ce27ff27e4f767