### PR TITLE
Refactor i18n provider to initialize synchronously

### DIFF
--- a/src/app/__tests__/hydration-i18n.test.tsx
+++ b/src/app/__tests__/hydration-i18n.test.tsx
@@ -1,0 +1,29 @@
+import LoggedOutLanding from "@/app/LoggedOutLanding";
+import I18nProvider from "@/app/i18n-provider";
+import React from "react";
+import { hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+describe("i18n hydration smoke test", () => {
+  it("hydrates LoggedOutLanding with I18nProvider without errors", async () => {
+    const element = (
+      <I18nProvider lang="en">
+        <LoggedOutLanding />
+      </I18nProvider>
+    );
+    const html = renderToString(element);
+    document.body.innerHTML = `<div id="root">${html}</div>`;
+    const root = document.getElementById("root");
+    if (!root) throw new Error("missing root element");
+    const errors: unknown[][] = [];
+    const orig = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args);
+    };
+    hydrateRoot(root, element);
+    await Promise.resolve();
+    console.error = orig;
+    expect(errors.length).toBe(0);
+  });
+});

--- a/src/app/i18n-provider.tsx
+++ b/src/app/i18n-provider.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { I18nextProvider } from "react-i18next";
 import i18n, { initI18n } from "../i18n";
 
@@ -7,26 +7,14 @@ export default function I18nProvider({
   children,
   lang,
 }: { children: React.ReactNode; lang: string }) {
-  const isServer = typeof window === "undefined";
-  if (isServer && !i18n.isInitialized) {
+  if (!i18n.isInitialized) {
     void initI18n(lang);
+  } else if (i18n.language !== lang) {
+    void i18n.changeLanguage(lang);
   }
-  const [ready, setReady] = useState(i18n.isInitialized || isServer);
 
   useEffect(() => {
-    if (isServer) return;
-    let ignore = false;
-    void (async () => {
-      await initI18n(lang);
-      if (!ignore) setReady(true);
-    })();
-    return () => {
-      ignore = true;
-    };
-  }, [lang, isServer]);
-
-  useEffect(() => {
-    if (!ready || typeof window === "undefined") return;
+    if (typeof window === "undefined") return;
     // Fallback to the browser's preferred languages if no cookie is set
     if (!document.cookie.includes("language=")) {
       const supported = ["en", "es", "fr"];
@@ -50,8 +38,7 @@ export default function I18nProvider({
     return () => {
       i18n.off("languageChanged", handler);
     };
-  }, [ready]);
+  }, []);
 
-  if (!ready && !isServer) return null;
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,4 +1,5 @@
 import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
 import enCommon from "../public/locales/en/common.json";
 import esCommon from "../public/locales/es/common.json";
 import frCommon from "../public/locales/fr/common.json";
@@ -17,15 +18,11 @@ export async function initI18n(lang: string) {
       fallbackLng: "en",
       defaultNS: "common",
       interpolation: { escapeValue: false },
+      initImmediate: false,
     };
-    if (typeof window !== "undefined") {
-      const { initReactI18next } = await import("react-i18next");
-      await instance.use(initReactI18next).init(config);
-    } else {
-      await instance.init(config);
-    }
+    instance.use(initReactI18next).init(config);
   } else if (instance.language !== lang) {
-    await instance.changeLanguage(lang);
+    instance.changeLanguage(lang);
   }
   return instance;
 }


### PR DESCRIPTION
## Summary
- initialize i18n synchronously using `initImmediate: false`
- remove async initialization logic from `I18nProvider`
- keep the effect that updates cookies and `<html lang>`
- add hydration test verifying the provider

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Could not locate the bindings file `better_sqlite3.node`)*
- `npm run e2e:smoke` *(failed: process terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68615232635c832bb1b60dcb46b3ed26