### PR TITLE
Fix case header positioning

### DIFF
--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -96,7 +96,7 @@ export default function ClientThreadPage({
   );
 
   return (
-    <div className="p-8 flex flex-col gap-4">
+    <div className="pt-0 pb-8 px-8 flex flex-col gap-4">
       <div className="sticky top-14 bg-white dark:bg-gray-900 flex justify-between items-center border-b pb-2">
         <div className="flex items-center gap-2">
           <Link

--- a/src/app/components/CaseLayout.tsx
+++ b/src/app/components/CaseLayout.tsx
@@ -12,7 +12,7 @@ export default function CaseLayout({
   children?: ReactNode;
 }) {
   return (
-    <div className="p-8 flex flex-col gap-4">
+    <div className="pt-0 pb-8 px-8 flex flex-col gap-4">
       <div className="sticky top-14 bg-white dark:bg-gray-900 z-20">
         {header}
       </div>


### PR DESCRIPTION
## Summary
- remove top padding from CaseLayout container
- remove top padding from thread page container so header sticks right under NavBar

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68615430e968832badac246fd089987a