### PR TITLE
Centralize z-index variables

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -301,7 +301,7 @@ export default function ClientCasesPage({
           ))}
       </ul>
       {dragging ? (
-        <div className="absolute inset-0 bg-black/50 text-white flex items-center justify-center pointer-events-none text-xl z-10">
+        <div className="absolute inset-0 bg-black/50 text-white flex items-center justify-center pointer-events-none text-xl z-nav">
           {dropCase
             ? t("addPhotosToCase", { id: dropCase })
             : t("dropPhotosToCreateCase")}

--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -38,8 +38,8 @@ function CaseChatInner({ caseId }: { caseId: string }) {
         expanded
           ? "relative h-full"
           : open
-            ? "fixed inset-0 sm:bottom-4 sm:right-4 sm:inset-auto z-40"
-            : "fixed bottom-4 right-4 z-40"
+            ? "fixed inset-0 sm:bottom-4 sm:right-4 sm:inset-auto z-chat"
+            : "fixed bottom-4 right-4 z-chat"
       } text-sm`}
     >
       {open ? (

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -115,7 +115,7 @@ function ClientCasePage({
         </CaseLayout>
       </div>
       {readOnly || !dragging ? null : (
-        <div className="absolute inset-0 bg-black/50 text-white flex items-center justify-center pointer-events-none text-xl z-10">
+        <div className="absolute inset-0 bg-black/50 text-white flex items-center justify-center pointer-events-none text-xl z-nav">
           {t("dropToAddPhotos")}
         </div>
       )}

--- a/src/app/cases/[id]/draft/DraftModal.tsx
+++ b/src/app/cases/[id]/draft/DraftModal.tsx
@@ -56,9 +56,9 @@ export default function DraftModal({
   return (
     <Dialog.Root open onOpenChange={(o) => !o && onClose()}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-modal" />
         <Dialog.Content
-          className={`fixed inset-0 flex p-4 z-50 ${fullScreen ? "items-stretch justify-stretch" : "items-center justify-center"}`}
+          className={`fixed inset-0 flex p-4 z-modal ${fullScreen ? "items-stretch justify-stretch" : "items-center justify-center"}`}
         >
           <div
             className={`bg-white dark:bg-gray-900 rounded shadow w-full ${fullScreen ? "h-full max-w-none" : "max-w-xl"}`}

--- a/src/app/cases/[id]/followup/FollowUpModal.tsx
+++ b/src/app/cases/[id]/followup/FollowUpModal.tsx
@@ -45,8 +45,8 @@ export default function FollowUpModal({
   return (
     <Dialog.Root open onOpenChange={(o) => !o && onClose()}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
-        <Dialog.Content className="fixed inset-0 flex items-center justify-center p-4 z-50">
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-modal" />
+        <Dialog.Content className="fixed inset-0 flex items-center justify-center p-4 z-modal">
           <div className="bg-white dark:bg-gray-900 rounded shadow max-w-xl w-full">
             {data ? (
               <DraftEditor

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerModal.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerModal.tsx
@@ -54,8 +54,8 @@ export default function NotifyOwnerModal({
   return (
     <Dialog.Root open onOpenChange={(o) => !o && onClose()}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
-        <Dialog.Content className="fixed inset-0 flex items-center justify-center p-4 z-50">
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-modal" />
+        <Dialog.Content className="fixed inset-0 flex items-center justify-center p-4 z-modal">
           <div className="bg-white dark:bg-gray-900 rounded shadow max-w-xl w-full">
             {data ? (
               <NotifyOwnerEditor

--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -166,7 +166,7 @@ export default function ClientThreadPage({
         ))}
       </ul>
       {viewImage ? (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-modal">
           <div className="bg-white dark:bg-gray-900 rounded shadow max-w-3xl w-full">
             <div className="relative w-full h-[80vh]">
               <img

--- a/src/app/components/CaseLayout.tsx
+++ b/src/app/components/CaseLayout.tsx
@@ -13,7 +13,7 @@ export default function CaseLayout({
 }) {
   return (
     <div className="p-8 flex flex-col gap-4">
-      <div className="sticky top-14 bg-white dark:bg-gray-900 z-20">
+      <div className="sticky top-14 bg-white dark:bg-gray-900 z-sticky">
         {header}
       </div>
       <div className="grid grid-cols-1 md:grid-cols-[35%_65%] lg:grid-cols-[30%_70%] gap-4 md:gap-6">

--- a/src/app/components/CaseProgressGraph.tsx
+++ b/src/app/components/CaseProgressGraph.tsx
@@ -483,7 +483,7 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
         const tooltip = document.createElement("div");
         tooltip.innerHTML = content;
         tooltip.className =
-          "z-50 rounded bg-black/80 text-white text-xs p-2 shadow";
+          "z-tooltip rounded bg-black/80 text-white text-xs p-2 shadow";
         tooltip.style.position = "absolute";
         let cleanupAuto: (() => void) | null = null;
         const show = () => {

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -132,7 +132,7 @@ export default function NavBar() {
   );
 
   return (
-    <nav className="py-4 px-8 flex items-center justify-between bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 relative sticky top-0 z-10">
+    <nav className="py-4 px-8 flex items-center justify-between bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 relative sticky top-0 z-nav">
       <Link
         href="/"
         className="text-lg font-semibold hover:text-gray-600 dark:hover:text-gray-300"

--- a/src/app/components/ZoomableImage.tsx
+++ b/src/app/components/ZoomableImage.tsx
@@ -177,7 +177,7 @@ export default function ZoomableImage({ src, alt }: Props) {
         <button
           type="button"
           onClick={() => setTransform({ scale: 1, x: 0, y: 0 })}
-          className="absolute top-1 left-1 z-20 bg-black/60 text-white rounded px-1 text-xs"
+          className="absolute top-1 left-1 z-sticky bg-black/60 text-white rounded px-1 text-xs"
         >
           Reset zoom
         </button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,11 @@
   --background: #ffffff;
   --foreground: #171717;
   --visual-viewport-height: 100dvh;
+  --z-nav: 10;
+  --z-sticky: 20;
+  --z-chat: 40;
+  --z-modal: 50;
+  --z-tooltip: 60;
 }
 
 @theme inline {
@@ -83,4 +88,26 @@ body {
 
 .animate-translate-flag {
   animation: translate-flag 0.6s ease-in-out infinite;
+}
+
+@layer utilities {
+  .z-nav {
+    z-index: var(--z-nav);
+  }
+
+  .z-sticky {
+    z-index: var(--z-sticky);
+  }
+
+  .z-chat {
+    z-index: var(--z-chat);
+  }
+
+  .z-modal {
+    z-index: var(--z-modal);
+  }
+
+  .z-tooltip {
+    z-index: var(--z-tooltip);
+  }
 }

--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -148,7 +148,7 @@ export default function PointAndShootPage() {
   return (
     <div className="relative h-[100dvh] overflow-hidden bg-black">
       {cameraError && (
-        <div className="absolute inset-x-0 top-0 z-10 bg-red-600 text-white text-center py-2">
+        <div className="absolute inset-x-0 top-0 z-nav bg-red-600 text-white text-center py-2">
           {cameraError}
         </div>
       )}
@@ -163,11 +163,11 @@ export default function PointAndShootPage() {
       </video>
       <canvas ref={canvasRef} className="hidden" />
       {uploading ? (
-        <div className="absolute inset-0 bg-black/50 text-white flex items-center justify-center pointer-events-none text-xl z-10">
+        <div className="absolute inset-0 bg-black/50 text-white flex items-center justify-center pointer-events-none text-xl z-nav">
           {t("uploadingPhoto")}
         </div>
       ) : null}
-      <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-nav">
         <div
           className="bg-black/40 text-white px-2 py-1 rounded text-xl"
           data-testid="hint"

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -70,7 +70,7 @@ export default function Tooltip({
             ref={refs.setFloating}
             style={floatingStyles}
             {...getFloatingProps()}
-            className="z-50 rounded bg-black/80 px-2 py-1 text-xs text-white shadow"
+            className="z-tooltip rounded bg-black/80 px-2 py-1 text-xs text-white shadow"
           >
             {label}
           </div>


### PR DESCRIPTION
## Summary
- define z-index variables in `globals.css`
- reference shared z-index classes in overlays and modals

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686153b66754832bba8e7b3332c82d28