### PR TITLE
fix: align case header with app header

### DIFF
--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -97,7 +97,7 @@ export default function ClientThreadPage({
 
   return (
     <div className="p-8 flex flex-col gap-4">
-      <div className="sticky top-14 bg-white dark:bg-gray-900 flex justify-between items-center border-b pb-2">
+      <div className="sticky top-16 bg-white dark:bg-gray-900 flex justify-between items-center border-b pb-2">
         <div className="flex items-center gap-2">
           <Link
             href={`/cases/${caseId}`}

--- a/src/app/components/CaseLayout.tsx
+++ b/src/app/components/CaseLayout.tsx
@@ -13,7 +13,7 @@ export default function CaseLayout({
 }) {
   return (
     <div className="p-8 flex flex-col gap-4">
-      <div className="sticky top-14 bg-white dark:bg-gray-900 z-20">
+      <div className="sticky top-16 bg-white dark:bg-gray-900 z-20">
         {header}
       </div>
       <div className="grid grid-cols-1 md:grid-cols-[35%_65%] lg:grid-cols-[30%_70%] gap-4 md:gap-6">


### PR DESCRIPTION
## Summary
- keep case header flush with the app header

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68615430e968832badac246fd089987a