### PR TITLE
fix: remove top gap in case header

### DIFF
--- a/src/app/components/CaseLayout.tsx
+++ b/src/app/components/CaseLayout.tsx
@@ -12,7 +12,7 @@ export default function CaseLayout({
   children?: ReactNode;
 }) {
   return (
-    <div className="p-8 flex flex-col gap-4">
+    <div className="flex flex-col gap-4 px-8 pb-8">
       <div className="sticky top-14 bg-white dark:bg-gray-900 z-20">
         {header}
       </div>


### PR DESCRIPTION
## Summary
- remove extra top padding in CaseLayout so the case header sits directly below the main nav

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68615430e968832badac246fd089987a