### PR TITLE
Fix hydration issue by initializing i18n

### DIFF
--- a/src/app/i18n-provider.tsx
+++ b/src/app/i18n-provider.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { I18nextProvider } from "react-i18next";
 import i18n, { initI18n } from "../i18n";
 
@@ -11,47 +11,39 @@ export default function I18nProvider({
   if (isServer && !i18n.isInitialized) {
     void initI18n(lang);
   }
-  const [ready, setReady] = useState(i18n.isInitialized || isServer);
 
   useEffect(() => {
     if (isServer) return;
     let ignore = false;
+    let handler: ((lng: string) => void) | null = null;
     void (async () => {
       await initI18n(lang);
-      if (!ignore) setReady(true);
+      if (ignore) return;
+      if (!document.cookie.includes("language=")) {
+        const supported = ["en", "es", "fr"];
+        for (const l of navigator.languages ?? []) {
+          const code = l.toLowerCase().split("-")[0];
+          if (supported.includes(code)) {
+            void i18n.changeLanguage(code);
+            break;
+          }
+        }
+      }
+      document.documentElement.lang = i18n.language;
+      localStorage.setItem("language", i18n.language);
+      document.cookie = `language=${i18n.language}; path=/; max-age=31536000`;
+      handler = (lng: string) => {
+        document.documentElement.lang = lng;
+        localStorage.setItem("language", lng);
+        document.cookie = `language=${lng}; path=/; max-age=31536000`;
+      };
+      i18n.on("languageChanged", handler);
     })();
     return () => {
       ignore = true;
+      if (handler) i18n.off("languageChanged", handler);
     };
   }, [lang, isServer]);
 
-  useEffect(() => {
-    if (!ready || typeof window === "undefined") return;
-    // Fallback to the browser's preferred languages if no cookie is set
-    if (!document.cookie.includes("language=")) {
-      const supported = ["en", "es", "fr"];
-      for (const l of navigator.languages ?? []) {
-        const code = l.toLowerCase().split("-")[0];
-        if (supported.includes(code)) {
-          void i18n.changeLanguage(code);
-          break;
-        }
-      }
-    }
-    document.documentElement.lang = i18n.language;
-    localStorage.setItem("language", i18n.language);
-    document.cookie = `language=${i18n.language}; path=/; max-age=31536000`;
-    const handler = (lng: string) => {
-      document.documentElement.lang = lng;
-      localStorage.setItem("language", lng);
-      document.cookie = `language=${lng}; path=/; max-age=31536000`;
-    };
-    i18n.on("languageChanged", handler);
-    return () => {
-      i18n.off("languageChanged", handler);
-    };
-  }, [ready]);
-
-  if (!ready && !isServer) return null;
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { config } from "@/lib/config";
 import type { Metadata, Viewport } from "next";
 import { getServerSession } from "next-auth";
 import { cookies, headers } from "next/headers";
+import { initI18n } from "../i18n";
 import AuthProvider from "./auth-provider";
 import NavBar from "./components/NavBar";
 import NotificationProvider from "./components/NotificationProvider";
@@ -47,6 +48,7 @@ export default async function RootLayout({
     }
     storedLang = storedLang ?? "en";
   }
+  await initI18n(storedLang);
   const publicEnv = {
     NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: config.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,
     NEXT_PUBLIC_BASE_PATH: config.NEXT_PUBLIC_BASE_PATH,


### PR DESCRIPTION
## Summary
- initialize i18n on the server in `RootLayout`
- remove blocking state from `I18nProvider` so markup matches during hydration

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68614d20e6a4832bbae2e31302380da2