### PR TITLE
Fix hydration by preloading i18n

### DIFF
--- a/src/app/i18n-provider.tsx
+++ b/src/app/i18n-provider.tsx
@@ -52,6 +52,5 @@ export default function I18nProvider({
     };
   }, [ready]);
 
-  if (!ready && !isServer) return null;
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { config } from "@/lib/config";
 import type { Metadata, Viewport } from "next";
 import { getServerSession } from "next-auth";
 import { cookies, headers } from "next/headers";
+import { initI18n as initServerI18n } from "../i18n.server";
 import AuthProvider from "./auth-provider";
 import NavBar from "./components/NavBar";
 import NotificationProvider from "./components/NotificationProvider";
@@ -47,6 +48,7 @@ export default async function RootLayout({
     }
     storedLang = storedLang ?? "en";
   }
+  await initServerI18n(storedLang);
   const publicEnv = {
     NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: config.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,
     NEXT_PUBLIC_BASE_PATH: config.NEXT_PUBLIC_BASE_PATH,


### PR DESCRIPTION
## Summary
- initialize i18n on the server before rendering
- always render children in `I18nProvider`

## Testing
- `npm run lint`
- `npm test`
- `CI=1 npm run e2e:smoke` *(fails: command stuck - see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68614d20e6a4832bbae2e31302380da2