### PR TITLE
fix: preserve image context in case chat

### DIFF
--- a/migrations/0019_case_photo_context.sql
+++ b/migrations/0019_case_photo_context.sql
@@ -1,0 +1,1 @@
+ALTER TABLE case_photo_analysis ADD COLUMN context TEXT;

--- a/src/lib/__tests__/caseStore.test.ts
+++ b/src/lib/__tests__/caseStore.test.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let store: typeof import("../caseStore");
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "case-store-"));
+  process.env.CASE_STORE_FILE = path.join(tmpDir, "cases.sqlite");
+  vi.resetModules();
+  const db = await import("../db");
+  await db.migrationsReady;
+  store = await import("../caseStore");
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.resetModules();
+  process.env.CASE_STORE_FILE = undefined;
+});
+
+describe("caseStore", () => {
+  it("persists image context", () => {
+    const c = store.createCase("/a.jpg");
+    store.updateCase(c.id, {
+      analysis: {
+        violationType: "test",
+        details: { en: "" },
+        vehicle: {},
+        images: {
+          "a.jpg": { representationScore: 1, context: { en: "hello" } },
+        },
+      },
+      analysisStatus: "complete",
+    });
+    const loaded = store.getCase(c.id);
+    expect(loaded?.analysis?.images?.["a.jpg"].context).toEqual({
+      en: "hello",
+    });
+  });
+});

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -145,6 +145,18 @@ function rowToCase(row: {
         ...(a.paperworkInfo !== null && {
           paperworkInfo: JSON.parse(a.paperworkInfo),
         }),
+        ...(a.context !== null && {
+          context: normalizeLocalizedText(
+            (() => {
+              try {
+                return JSON.parse(a.context);
+              } catch {
+                return a.context;
+              }
+            })(),
+            base.analysis?.language ?? "en",
+          ),
+        }),
       };
     }
     if (!base.analysis)
@@ -229,6 +241,10 @@ function saveCase(c: Case) {
           paperworkInfo: info.paperworkInfo
             ? JSON.stringify(info.paperworkInfo)
             : null,
+          context:
+            info.context === undefined || info.context === null
+              ? null
+              : JSON.stringify(info.context),
         })
         .run();
     }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -38,6 +38,7 @@ export const casePhotoAnalysis = sqliteTable(
     paperwork: integer("paperwork"),
     paperworkText: text("paperwork_text"),
     paperworkInfo: text("paperwork_info"),
+    context: text("context"),
   },
   (t) => ({
     pk: primaryKey(t.caseId, t.url),


### PR DESCRIPTION
## Summary
- store per-photo context descriptions in the DB
- expose context to the case chat API by persisting it via caseStore
- add regression test
- add migration to add `context` column

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68615569c6b0832b94a0661a1caad8c4