### PR TITLE
chore: re-enable markdown lint rule

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,6 @@
 {
   "default": true,
-  "MD013": false,
+  "MD013": { "line_length": 120 },
   "MD025": { "front_matter_title": "title" },
   "MD033": false
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Photo To Citation
 
-Photo To Citation is an experimental app that helps residents of Oak Park, IL report vehicle violations that jeopardize pedestrian and non‑motorized safety. The goal is to take an uploaded photo of a violation and automatically produce a report that can be sent to the appropriate civil authorities. The system attempts to track each report until it becomes an official citation, even when that involves manual steps like mailing forms or payments.
+Photo To Citation is an experimental app that helps residents of Oak Park, IL
+report vehicle violations that jeopardize pedestrian and non‑motorized safety.
+The goal is to take an uploaded photo of a violation and automatically produce a
+report that can be sent to the appropriate civil authorities. The system
+attempts to track each report until it becomes an official citation, even when
+that involves manual steps like mailing forms or payments.
 
 ## Tech Stack
 
@@ -110,11 +115,18 @@ npm run squash:migrations -- --keep 5
 Omit the `--keep` option to retain the latest 10 migrations. Pass `--help` for
 usage details.
 
-Migrations are stored as SQL files under the `migrations` folder and applied at runtime. The default SQLite database is `data/cases.sqlite`. Per-photo analysis results now live in the `case_photo_analysis` table instead of the JSON `analysis.images` field.
+Migrations are stored as SQL files under the `migrations` folder and applied at
+runtime. The default SQLite database is `data/cases.sqlite`. Per-photo analysis
+results now live in the `case_photo_analysis` table instead of the JSON
+`analysis.images` field.
 
 ## Administration
 
-Visit `/admin` to manage users and Casbin policies. Admins can invite collaborators by entering an email address. The app creates the user with the `user` role and sends an invitation link. Super admins may edit the Casbin rule list directly in the UI. After saving, the server reloads the policy set so changes take effect immediately.
+Visit `/admin` to manage users and Casbin policies. Admins can invite
+collaborators by entering an email address. The app creates the user with the
+`user` role and sends an invitation link. Super admins may edit the Casbin rule
+list directly in the UI. After saving, the server reloads the policy set so
+changes take effect immediately.
 
 ## OpenAI Integration
 
@@ -417,13 +429,21 @@ The workflow caches build layers with GitHub Actions so subsequent runs reuse th
 The `docker-build-photo-citation.yml` workflow publishes a second image tagged
 `photo-citation` for NAS deployments requiring `NEXT_PUBLIC_BASE_PATH=/photo-citation`.
 
-Run Traefik separately and it will use the labels in `docker-compose.example.yaml` to route traffic to `https://730op.synology.me/photo-citation`.
+Run Traefik separately and it will use the labels in
+`docker-compose.example.yaml` to route traffic to
+`https://730op.synology.me/photo-citation`.
 
-Set `NEXT_PUBLIC_BASE_PATH=/photo-citation` in your `.env` (or container environment) and remove the Traefik `stripprefix` middleware so the app serves correctly at that subpath. The `next.config.ts` file applies this base path to both `basePath` and `assetPrefix` so that the runtime bundle and assets load from `/photo-citation` as well.
+Set `NEXT_PUBLIC_BASE_PATH=/photo-citation` in your `.env` (or container
+environment) and remove the Traefik `stripprefix` middleware so the app serves
+correctly at that subpath. The `next.config.ts` file applies this base path to
+both `basePath` and `assetPrefix` so that the runtime bundle and assets load
+from `/photo-citation` as well.
 
 ## Marketing Website
 
-This repo includes a simple [Eleventy](https://www.11ty.dev/) setup under the `website` directory for the marketing site. Pages are written in Markdown and compiled to static HTML.
+This repo includes a simple [Eleventy](https://www.11ty.dev/) setup under the
+`website` directory for the marketing site. Pages are written in Markdown and
+compiled to static HTML.
 
 Build the site with:
 
@@ -433,7 +453,9 @@ npm run website
 
 The output is written to `website/dist`.
 
-The build step uses OpenAI to generate marketing images when they are missing in the `gh-pages` branch. Set an `OPENAI_API_KEY` secret in your repository so the GitHub Action can access the API.
+The build step uses OpenAI to generate marketing images when they are missing in
+the `gh-pages` branch. Set an `OPENAI_API_KEY` secret in your repository so the
+GitHub Action can access the API.
 
 Images are declared directly in the markdown with a `data-image-gen` attribute:
 
@@ -441,15 +463,24 @@ Images are declared directly in the markdown with a `data-image-gen` attribute:
 <img src="autogen/cat.png" alt="Draw a 2D pixel art cat" width="256" height="256" data-image-gen />
 ```
 
-The build script scans the site for these tags and calls `client.images.generate`. Any JSON placed in the `data-image-gen` attribute is passed through to the API. Width and height attributes become the generated size unless overridden in the JSON.
+The build script scans the site for these tags and calls
+`client.images.generate`. Any JSON placed in the `data-image-gen` attribute is
+passed through to the API. Width and height attributes become the generated size
+unless overridden in the JSON.
 
 ## Privacy and Data Use
 
-All photos, contact details and analysis results are stored only to generate the corresponding citation reports. The app relies on external services such as OpenAI for image analysis and third‑party mail providers for physical letters. No uploaded content is sold or shared outside of those providers. You can delete any case to permanently remove the associated data.
+All photos, contact details and analysis results are stored only to generate the
+corresponding citation reports. The app relies on external services such as
+OpenAI for image analysis and third‑party mail providers for physical letters.
+No uploaded content is sold or shared outside of those providers. You can delete
+any case to permanently remove the associated data.
 
 ## Notifications
 
-Wrap your application with `<NotificationProvider>` in `src/app/layout.tsx`. Use the `useNotify` hook in client components to show toast and system notifications:
+Wrap your application with `<NotificationProvider>` in `src/app/layout.tsx`.
+Use the `useNotify` hook in client components to show toast and system
+notifications:
 
 ```tsx
 "use client";
@@ -465,7 +496,10 @@ The provider requests browser permission so these messages can also appear as na
 
 ## Browser Debugging
 
-Set `NEXT_PUBLIC_BROWSER_DEBUG` to `true` in your `.env` to enable a JSON overlay. Hold the Option key while hovering over case images, details, or chat messages to reveal the tooltip. The tooltip remains visible while you move the cursor over it so you can easily copy the JSON.
+Set `NEXT_PUBLIC_BROWSER_DEBUG` to `true` in your `.env` to enable a JSON
+overlay. Hold the Option key while hovering over case images, details, or chat
+messages to reveal the tooltip. The tooltip remains visible while you move the
+cursor over it so you can easily copy the JSON.
 
 ## Project Links
 

--- a/docs/auth-plan.md
+++ b/docs/auth-plan.md
@@ -1,6 +1,8 @@
 # Authentication and Authorization Plan
 
-This document proposes an approach for user login, role management, and access control in **Photo To Citation**. The goal is to follow well‑supported standards and libraries while keeping the codebase maintainable.
+This document proposes an approach for user login, role management, and access
+control in **Photo To Citation**. The goal is to follow well‑supported
+standards and libraries while keeping the codebase maintainable.
 
 ## 1. Authentication
 
@@ -23,7 +25,9 @@ This document proposes an approach for user login, role management, and access c
 - anonymous
 ```text
 
-Roles are stored on the `User` record. The `anonymous` role represents unauthenticated visitors. The super admin can promote other users to admin or superadmin.
+Roles are stored on the `User` record. The `anonymous` role represents
+unauthenticated visitors. The super admin can promote other users to admin or
+superadmin.
 
 ## 3. Access Control
 
@@ -54,7 +58,9 @@ Roles are stored on the `User` record. The `anonymous` role represents unauthent
 - JSON Web Tokens for stateless sessions.
 - Argon2 for password hashing if password auth is enabled.
 
-This approach uses well‑maintained libraries (NextAuth.js and Casbin) and keeps control of permissions in the database so that collaboration and public cases can be implemented consistently across features.
+This approach uses well‑maintained libraries (NextAuth.js and Casbin) and keeps
+control of permissions in the database so that collaboration and public cases
+can be implemented consistently across features.
 
 ## 7. Implementation Tasks
 
@@ -83,7 +89,8 @@ A proposed sequence of milestones so each change can be merged and deployed inde
    - Hide or disable actions the current user cannot perform.
    - Include integration tests for common user flows.
 
-Each milestone is small enough to be reviewed and deployed on its own while steadily building up the full authentication and authorization feature set.
+Each milestone is small enough to be reviewed and deployed on its own while
+steadily building up the full authentication and authorization feature set.
 
 ## Permissions Matrix
 
@@ -95,7 +102,12 @@ The repository uses NextAuth for authentication and Casbin for authorization. Th
 - superadmin
 ```text
 
-The super admin can promote other users, and Casbin policies determine what each role may do. Case collaboration introduces a `CaseMember` table with `owner` and `collaborator` roles, plus a `public` flag allowing anonymous viewing of a case. An admin interface lets admins manage users, while super admins can edit policies directly. The policy migration seeds basic rules, including `("user", "upload", "create")` so authenticated users can submit photos by default.
+The super admin can promote other users, and Casbin policies determine what each
+role may do. Case collaboration introduces a `CaseMember` table with `owner` and
+`collaborator` roles, plus a `public` flag allowing anonymous viewing of a case.
+An admin interface lets admins manage users, while super admins can edit
+policies directly. The policy migration seeds basic rules, including `("user",
+"upload", "create")` so authenticated users can submit photos by default.
 
 Below is a consolidated permissions matrix based on the existing code and this plan.
 
@@ -119,7 +131,9 @@ Below is a consolidated permissions matrix based on the existing code and this p
 
 ### Notes
 
-- The upload API now uses `withAuthorization("upload", "create")`, so only logged-in roles with that permission may create cases. The initial Casbin policy migration seeds this rule for the `user` role.
+- The upload API now uses `withAuthorization("upload", "create")`, so only
+  logged-in roles with that permission may create cases. The initial Casbin
+  policy migration seeds this rule for the `user` role.
 - The collaborator role is per-case and allows commenting on an invited case as noted in the docs.
 - Admin and Super Admin roles inherit all user abilities; Super Admin additionally controls policy editing.
 - A case marked `public` is viewable by anyone without authentication.

--- a/docs/case-chat-actions.md
+++ b/docs/case-chat-actions.md
@@ -1,6 +1,9 @@
 # Case Chat Actions
 
-Case Chat replies are JSON objects with a `response` string, an `actions` array, and a `noop` boolean. Each action may reference a case action, suggest an edit, or add a photo note. When `noop` is `true` the assistant had nothing useful to add, even if it produced conversational text.
+Case Chat replies are JSON objects with a `response` string, an `actions` array,
+and a `noop` boolean. Each action may reference a case action, suggest an edit,
+or add a photo note. When `noop` is `true` the assistant had nothing useful to
+add, even if it produced conversational text.
 
 Example:
 

--- a/docs/credit-system.md
+++ b/docs/credit-system.md
@@ -4,7 +4,9 @@ This document explains how user credits work in **Photo To Citation**.
 
 ## Overview
 
-Certain features may require credits. Each user account has a balance that is incremented when credits are purchased. Superadmins control the exchange rate so the number of credits per dollar can change over time.
+Certain features may require credits. Each user account has a balance that is
+incremented when credits are purchased. Superadmins control the exchange rate so
+the number of credits per dollar can change over time.
 
 ## Purchasing Credits
 
@@ -15,10 +17,13 @@ Certain features may require credits. Each user account has a balance that is in
 
 ## Managing the Exchange Rate
 
-Superadmins can view and update the exchange rate via `/api/credits/exchange-rate`. Sending a `PUT` request with a JSON body such as `{ "usdPerCredit": 0.25 }` updates `data/creditSettings.json`.
+Superadmins can view and update the exchange rate via `/api/credits/exchange-rate`.
+Sending a `PUT` request with a JSON body such as `{ "usdPerCredit": 0.25 }`
+updates `data/creditSettings.json`.
 
 ## Checking Balances
 
-Users can retrieve their current balance from `/api/credits/balance`. Each successful purchase appears in the `credit_transactions` table for auditing.
+Users can retrieve their current balance from `/api/credits/balance`. Each
+successful purchase appears in the `credit_transactions` table for auditing.
 
 Updates are wrapped in a single SQLite transaction to prevent double spending or partial writes.

--- a/website/about.md
+++ b/website/about.md
@@ -3,6 +3,8 @@ title: About
 layout: layout.njk
 ---
 
+<!-- markdownlint-disable MD013 -->
+
 <div class="hero">
   <img
     src="{{ '/images/community.png' | url }}"

--- a/website/features.md
+++ b/website/features.md
@@ -3,6 +3,8 @@ title: Features
 layout: layout.njk
 ---
 
+<!-- markdownlint-disable MD013 -->
+
 Photo To Citation automates every step of reporting blocked bike lanes and sidewalks so you don’t have to.
 
 <ul class="features">

--- a/website/index.md
+++ b/website/index.md
@@ -3,6 +3,8 @@ title: Home
 layout: layout.njk
 ---
 
+<!-- markdownlint-disable MD013 -->
+
 <div class="hero">
   <h1>Photo To Citation</h1>
   <img


### PR DESCRIPTION
## Summary
- configure MD013 line length checks
- wrap long lines in README and docs
- disable MD013 only for website markdown

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68615935981c832ba125d078c08ac3fa