### PR TITLE
Enable MD033 markdownlint rule

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,5 @@
 {
   "default": true,
   "MD013": false,
-  "MD025": { "front_matter_title": "title" },
-  "MD033": false
+  "MD025": { "front_matter_title": "title" }
 }

--- a/website/about.md
+++ b/website/about.md
@@ -2,6 +2,7 @@
 title: About
 layout: layout.njk
 ---
+<!-- markdownlint-disable MD033 -->
 
 <div class="hero">
   <img

--- a/website/features.md
+++ b/website/features.md
@@ -2,6 +2,7 @@
 title: Features
 layout: layout.njk
 ---
+<!-- markdownlint-disable MD033 -->
 
 Photo To Citation automates every step of reporting blocked bike lanes and sidewalks so you don’t have to.
 

--- a/website/index.md
+++ b/website/index.md
@@ -2,6 +2,7 @@
 title: Home
 layout: layout.njk
 ---
+<!-- markdownlint-disable MD033 -->
 
 <div class="hero">
   <h1>Photo To Citation</h1>


### PR DESCRIPTION
## Summary
- re-enable MD033 by default
- disable MD033 inline for website markdown files

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68615935981c832ba125d078c08ac3fa