### PR TITLE
Fix chat missing photo context

### DIFF
--- a/migrations/0019_case_photo_context.sql
+++ b/migrations/0019_case_photo_context.sql
@@ -1,0 +1,2 @@
+ALTER TABLE case_photo_analysis ADD COLUMN context TEXT;
+

--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -139,6 +139,18 @@ function rowToCase(row: {
             base.analysis?.language ?? "en",
           ),
         }),
+        ...(a.context !== null && {
+          context: normalizeLocalizedText(
+            (() => {
+              try {
+                return JSON.parse(a.context as string);
+              } catch {
+                return a.context as string;
+              }
+            })(),
+            base.analysis?.language ?? "en",
+          ),
+        }),
         ...(a.violation !== null && { violation: Boolean(a.violation) }),
         ...(a.paperwork !== null && { paperwork: Boolean(a.paperwork) }),
         ...(a.paperworkText !== null && { paperworkText: a.paperworkText }),
@@ -213,6 +225,10 @@ function saveCase(c: Case) {
             info.highlights === undefined || info.highlights === null
               ? null
               : JSON.stringify(info.highlights),
+          context:
+            info.context === undefined || info.context === null
+              ? null
+              : JSON.stringify(info.context),
           violation:
             info.violation === undefined || info.violation === null
               ? null

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -34,6 +34,7 @@ export const casePhotoAnalysis = sqliteTable(
     url: text("url").notNull(),
     representationScore: real("representation_score").notNull(),
     highlights: text("highlights"),
+    context: text("context"),
     violation: integer("violation"),
     paperwork: integer("paperwork"),
     paperworkText: text("paperwork_text"),

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -197,6 +197,7 @@ describe("caseStore", () => {
           "a.jpg": {
             representationScore: 0.9,
             highlights: { en: "caption" },
+            context: { en: "full" },
           },
         },
       },
@@ -204,6 +205,9 @@ describe("caseStore", () => {
     const stored = getCase(c.id);
     expect(stored?.analysis?.images["a.jpg"].highlights).toEqual({
       en: "caption",
+    });
+    expect(stored?.analysis?.images["a.jpg"].context).toEqual({
+      en: "full",
     });
   });
 


### PR DESCRIPTION
## Summary
- persist photo context when saving case analysis
- expose stored context to case chat
- add DB migration for context column
- test case store retains photo context

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68615569c6b0832b94a0661a1caad8c4