### PR TITLE
feat: notify retry when LLM output invalid

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -208,6 +208,7 @@
   "stepPrefix": "Step {{step}} of {{steps}}:",
   "analysisCanceled": "Analysis canceled.",
   "analysisFailed": "Analysis failed.",
+  "analysisRestarting": "Restarting analysis due to invalid response (attempt {{attempt}} of 3)...",
   "photoActionsMenu": "Photo actions menu",
   "reanalyzePhoto": "Reanalyze Photo",
   "deleteImage": "Delete Image",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -208,6 +208,7 @@
   "stepPrefix": "Paso {{step}} de {{steps}}:",
   "analysisCanceled": "Análisis cancelado.",
   "analysisFailed": "Análisis fallido.",
+  "analysisRestarting": "Reiniciando el análisis debido a una respuesta no válida (intento {{attempt}} de 3)...",
   "photoActionsMenu": "Menú de acciones de foto",
   "reanalyzePhoto": "Re-analizar foto",
   "deleteImage": "Eliminar imagen",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -208,6 +208,7 @@
   "stepPrefix": "Étape {{step}} sur {{steps}}:",
   "analysisCanceled": "Analyse annulée.",
   "analysisFailed": "Échec de l'analyse.",
+  "analysisRestarting": "Redémarrage de l'analyse en raison d'une réponse invalide (tentative {{attempt}} sur 3)...",
   "photoActionsMenu": "Menu d'actions de la photo",
   "reanalyzePhoto": "Ré-analyser la photo",
   "deleteImage": "Supprimer l'image",

--- a/src/app/cases/[id]/useCaseProgress.ts
+++ b/src/app/cases/[id]/useCaseProgress.ts
@@ -21,7 +21,9 @@ export default function useCaseProgress(reanalyzingPhoto: string | null) {
       ? progress.index > 0
         ? (progress.index / progress.total) * 100
         : undefined
-      : Math.min((progress.received / progress.total) * 100, 100)
+      : progress.stage === "stream"
+        ? Math.min((progress.received / progress.total) * 100, 100)
+        : undefined
     : undefined;
 
   let progressDescription = "";
@@ -40,6 +42,9 @@ export default function useCaseProgress(reanalyzingPhoto: string | null) {
               count: progress.total,
             })
           : t("uploadingPhotos"));
+    } else if (progress.stage === "retry") {
+      progressDescription =
+        prefix + t("analysisRestarting", { attempt: progress.attempt });
     } else {
       progressDescription =
         prefix +

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -38,12 +38,14 @@ export default function CaseToolbar({
             count: progress.total,
           })
         : t("uploadingPhotos")
-      : progress.done
-        ? t("processingResults")
-        : t("analyzingTokens", {
-            received: progress.received,
-            total: progress.total,
-          })
+      : progress.stage === "retry"
+        ? t("analysisRestarting", { attempt: progress.attempt })
+        : progress.done
+          ? t("processingResults")
+          : t("analyzingTokens", {
+              received: progress.received,
+              total: progress.total,
+            })
     : null;
   const progressText = progress
     ? `${progress.steps ? `Step ${progress.step} of ${progress.steps}: ` : ""}${reqText}`
@@ -54,7 +56,9 @@ export default function CaseToolbar({
       ? progress.index > 0
         ? (progress.index / progress.total) * 100
         : undefined
-      : Math.min((progress.received / progress.total) * 100, 100)
+      : progress.stage === "stream"
+        ? Math.min((progress.received / progress.total) * 100, 100)
+        : undefined
     : undefined;
   const overallValue =
     progress?.steps !== undefined && progress.step !== undefined


### PR DESCRIPTION
## Summary
- add retry stage to `LlmProgress` so users can see when analysis restarts
- log detailed schema errors for bad LLM responses
- expose restart progress in UI components
- translate new `analysisRestarting` message

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68615f197ca0832ba398bebc6de19fe5