### PR TITLE
fix case chat height

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -45,7 +45,7 @@ function CaseChatInner({ caseId }: { caseId: string }) {
       {open ? (
         <div
           className={`bg-white dark:bg-gray-900 shadow-lg rounded flex flex-col ${
-            expanded ? "w-full h-full" : "w-screen sm:w-80 sm:h-96"
+            expanded ? "w-full h-full" : "w-screen sm:w-80 sm:max-h-[400px]"
           }`}
           style={
             expanded ? undefined : { height: "var(--visual-viewport-height)" }


### PR DESCRIPTION
## Summary
- keep the case chat popup under 400px high on larger screens

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68615b7d062c832b884eb669f975b39b