### PR TITLE
fix: sticky header offset

### DIFF
--- a/docs/i18n-hydration.md
+++ b/docs/i18n-hydration.md
@@ -1,7 +1,15 @@
 # i18n Hydration Issue
 
-We noticed intermittent hydration warnings in production whenever the `I18nProvider` loaded resources asynchronously. The component sometimes returned `null` on the client until `i18n` finished initializing, which left the initial markup mismatched with the server render.
+We noticed intermittent hydration warnings in production whenever the
+`I18nProvider` loaded resources asynchronously. The component sometimes
+returned `null` on the client until `i18n` finished initializing, which left the
+initial markup mismatched with the server render.
 
-The fix is to load translations synchronously using `initImmediate: false` and to always render the provider on the client. `src/i18n.ts` creates an instance immediately and calls `initReactI18next` on first use. `I18nProvider` now initializes on every render if needed and never returns `null`.
+The fix is to load translations synchronously using `initImmediate: false` and to
+always render the provider on the client. `src/i18n.ts` creates an instance
+immediately and calls `initReactI18next` on first use. `I18nProvider` now
+initializes on every render if needed and never returns `null`.
 
-A hydration test was added (`src/app/__tests__/hydration-i18n.test.tsx`) to ensure `hydrateRoot` completes without console errors when wrapping the tree with `I18nProvider`.
+A hydration test was added (`src/app/__tests__/hydration-i18n.test.tsx`) to
+ensure `hydrateRoot` completes without console errors when wrapping the tree with
+`I18nProvider`.

--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -96,8 +96,8 @@ export default function ClientThreadPage({
   );
 
   return (
-    <div className="p-8 flex flex-col gap-4">
-      <div className="sticky top-14 bg-white dark:bg-gray-900 flex justify-between items-center border-b pb-2">
+    <div className="flex flex-col">
+      <div className="sticky top-14 bg-white dark:bg-gray-900 flex justify-between items-center border-b pb-2 px-8 pt-8">
         <div className="flex items-center gap-2">
           <Link
             href={`/cases/${caseId}`}
@@ -127,67 +127,69 @@ export default function ClientThreadPage({
           </Link>
         </div>
       </div>
-      <ul className="flex flex-col gap-4">
-        {thread.map((mail) => (
-          <li key={mail.sentAt} className="border p-2 rounded">
-            <div className="text-sm text-gray-500 dark:text-gray-400">
-              {new Date(mail.sentAt).toLocaleString()} - To: {mail.to}
-            </div>
-            <div className="font-semibold">{mail.subject}</div>
-            <pre className="whitespace-pre-wrap text-sm">{mail.body}</pre>
-          </li>
-        ))}
-        {images.map((img) => (
-          <li key={img.id} className="border p-2 rounded flex gap-2">
-            <ThumbnailImage
-              src={getThumbnailUrl(img.url, 256)}
-              alt="scan"
-              width={150}
-              height={100}
-              className="cursor-pointer"
-              imgClassName="object-contain"
-              onClick={() => setViewImage(`/uploads/${img.url}`)}
-            />
-            <div className="flex flex-col gap-2 flex-1">
-              <button
-                type="button"
-                onClick={() => attachEvidence(img.url)}
-                className="self-start bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded"
-              >
-                {t("addAsEvidence")}
-              </button>
-              {img.ocrText ? (
-                <pre className="whitespace-pre-wrap text-sm bg-gray-100 dark:bg-gray-800 p-2 rounded">
-                  {img.ocrText}
-                </pre>
-              ) : null}
-            </div>
-          </li>
-        ))}
-      </ul>
-      {viewImage ? (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-modal">
-          <div className="bg-white dark:bg-gray-900 rounded shadow max-w-3xl w-full">
-            <div className="relative w-full h-[80vh]">
-              <img
-                src={viewImage}
-                alt="scan full size"
-                className="object-contain absolute inset-0 w-full h-full"
-                loading="lazy"
+      <div className="p-8 flex flex-col gap-4">
+        <ul className="flex flex-col gap-4">
+          {thread.map((mail) => (
+            <li key={mail.sentAt} className="border p-2 rounded">
+              <div className="text-sm text-gray-500 dark:text-gray-400">
+                {new Date(mail.sentAt).toLocaleString()} - To: {mail.to}
+              </div>
+              <div className="font-semibold">{mail.subject}</div>
+              <pre className="whitespace-pre-wrap text-sm">{mail.body}</pre>
+            </li>
+          ))}
+          {images.map((img) => (
+            <li key={img.id} className="border p-2 rounded flex gap-2">
+              <ThumbnailImage
+                src={getThumbnailUrl(img.url, 256)}
+                alt="scan"
+                width={150}
+                height={100}
+                className="cursor-pointer"
+                imgClassName="object-contain"
+                onClick={() => setViewImage(`/uploads/${img.url}`)}
               />
-            </div>
-            <div className="flex justify-end p-2">
-              <button
-                type="button"
-                onClick={() => setViewImage(null)}
-                className="bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded"
-              >
-                {t("close")}
-              </button>
+              <div className="flex flex-col gap-2 flex-1">
+                <button
+                  type="button"
+                  onClick={() => attachEvidence(img.url)}
+                  className="self-start bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded"
+                >
+                  {t("addAsEvidence")}
+                </button>
+                {img.ocrText ? (
+                  <pre className="whitespace-pre-wrap text-sm bg-gray-100 dark:bg-gray-800 p-2 rounded">
+                    {img.ocrText}
+                  </pre>
+                ) : null}
+              </div>
+            </li>
+          ))}
+        </ul>
+        {viewImage ? (
+          <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-modal">
+            <div className="bg-white dark:bg-gray-900 rounded shadow max-w-3xl w-full">
+              <div className="relative w-full h-[80vh]">
+                <img
+                  src={viewImage}
+                  alt="scan full size"
+                  className="object-contain absolute inset-0 w-full h-full"
+                  loading="lazy"
+                />
+              </div>
+              <div className="flex justify-end p-2">
+                <button
+                  type="button"
+                  onClick={() => setViewImage(null)}
+                  className="bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded"
+                >
+                  {t("close")}
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-      ) : null}
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/app/components/CaseLayout.tsx
+++ b/src/app/components/CaseLayout.tsx
@@ -12,15 +12,17 @@ export default function CaseLayout({
   children?: ReactNode;
 }) {
   return (
-    <div className="p-8 flex flex-col gap-4">
-      <div className="sticky top-14 bg-white dark:bg-gray-900 z-sticky">
+    <div className="flex flex-col">
+      <div className="sticky top-14 bg-white dark:bg-gray-900 z-sticky px-8 py-8">
         {header}
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-[35%_65%] lg:grid-cols-[30%_70%] gap-4 md:gap-6">
-        <div>{left}</div>
-        <div className="flex flex-col gap-4">{right}</div>
+      <div className="p-8 flex flex-col gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-[35%_65%] lg:grid-cols-[30%_70%] gap-4 md:gap-6">
+          <div>{left}</div>
+          <div className="flex flex-col gap-4">{right}</div>
+        </div>
+        {children}
       </div>
-      {children}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove padding gap from sticky header containers
- reorganize thread page layout to keep header flush under nav bar
- fix markdown lint error

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke` *(fails: process hangs)*

------
https://chatgpt.com/codex/tasks/task_e_6861668dce50832b8e570c20c22ca68f