### PR TITLE
Enable auto-linking for Google sign-in

### DIFF
--- a/docs/i18n-hydration.md
+++ b/docs/i18n-hydration.md
@@ -1,7 +1,12 @@
 # i18n Hydration Issue
 
-We noticed intermittent hydration warnings in production whenever the `I18nProvider` loaded resources asynchronously. The component sometimes returned `null` on the client until `i18n` finished initializing, which left the initial markup mismatched with the server render.
+We noticed intermittent hydration warnings in production whenever the `I18nProvider` loaded resources
+asynchronously. The component sometimes returned `null` on the client until `i18n` finished initializing,
+which left the initial markup mismatched with the server render.
 
-The fix is to load translations synchronously using `initImmediate: false` and to always render the provider on the client. `src/i18n.ts` creates an instance immediately and calls `initReactI18next` on first use. `I18nProvider` now initializes on every render if needed and never returns `null`.
+The fix is to load translations synchronously using `initImmediate: false` and to always render the provider on
+the client. `src/i18n.ts` creates an instance immediately and calls `initReactI18next` on first use.
+`I18nProvider` now initializes on every render if needed and never returns `null`.
 
-A hydration test was added (`src/app/__tests__/hydration-i18n.test.tsx`) to ensure `hydrateRoot` completes without console errors when wrapping the tree with `I18nProvider`.
+A hydration test was added (`src/app/__tests__/hydration-i18n.test.tsx`) to ensure `hydrateRoot` completes
+without console errors when wrapping the tree with `I18nProvider`.

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -36,6 +36,7 @@ export const authOptions: NextAuthOptions = {
     GoogleProvider({
       clientId: config.GOOGLE_CLIENT_ID ?? "",
       clientSecret: config.GOOGLE_CLIENT_SECRET ?? "",
+      allowDangerousEmailAccountLinking: true,
     }),
   ],
   pages: { signIn: "/signin" },


### PR DESCRIPTION
## Summary
- allow automatic account linking for Google provider
- wrap long lines in docs to satisfy lint

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6861688f6034832b838c0ee084e13e11