### PR TITLE
Adjust case chat noop instruction

### DIFF
--- a/docs/i18n-hydration.md
+++ b/docs/i18n-hydration.md
@@ -1,7 +1,15 @@
 # i18n Hydration Issue
 
-We noticed intermittent hydration warnings in production whenever the `I18nProvider` loaded resources asynchronously. The component sometimes returned `null` on the client until `i18n` finished initializing, which left the initial markup mismatched with the server render.
+We noticed intermittent hydration warnings in production whenever the
+`I18nProvider` loaded resources asynchronously. The component sometimes returned
+`null` on the client until `i18n` finished initializing, which left the initial
+markup mismatched with the server render.
 
-The fix is to load translations synchronously using `initImmediate: false` and to always render the provider on the client. `src/i18n.ts` creates an instance immediately and calls `initReactI18next` on first use. `I18nProvider` now initializes on every render if needed and never returns `null`.
+The fix is to load translations synchronously using `initImmediate: false` and to
+always render the provider on the client. `src/i18n.ts` creates an instance
+immediately and calls `initReactI18next` on first use. `I18nProvider` now
+initializes on every render if needed and never returns `null`.
 
-A hydration test was added (`src/app/__tests__/hydration-i18n.test.tsx`) to ensure `hydrateRoot` completes without console errors when wrapping the tree with `I18nProvider`.
+A hydration test was added (`src/app/__tests__/hydration-i18n.test.tsx`) to ensure
+`hydrateRoot` completes without console errors when wrapping the tree with
+`I18nProvider`.

--- a/src/app/api/cases/[id]/chat/route.ts
+++ b/src/app/api/cases/[id]/chat/route.ts
@@ -59,7 +59,7 @@ export const POST = withCaseAuthorization(
       `Number of photos: ${c.photos.length}.`,
       contextLines ? `Image contexts:\n${contextLines}` : "",
       "When there is no user question yet, decide if you should proactively suggest a next action or useful observation.",
-      "If you have nothing helpful, set response to [noop].",
+      "Only set response to [noop] if you truly have nothing helpful to add after careful consideration. Otherwise include at least a brief reply.",
       `Reply in JSON matching this schema: ${schemaDesc}`,
       "Use {id: ID} objects for case actions.",
       "Use {field: FIELD, value: VALUE} to edit the case (fields: vin, plate, state, note).",


### PR DESCRIPTION
## Summary
- wrap lines in the i18n hydration guide
- clarify the system prompt so Case Chat only sets `noop` when it truly has nothing to add

## Testing
- `npm run format`
- `npm run lint`
- `npm run lint:md`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68616bf8f774832bafa7dae73407ff23