### PR TITLE
Fix hydration warning from nested buttons

### DIFF
--- a/docs/i18n-hydration.md
+++ b/docs/i18n-hydration.md
@@ -1,7 +1,12 @@
 # i18n Hydration Issue
 
-We noticed intermittent hydration warnings in production whenever the `I18nProvider` loaded resources asynchronously. The component sometimes returned `null` on the client until `i18n` finished initializing, which left the initial markup mismatched with the server render.
+We noticed intermittent hydration warnings in production whenever the `I18nProvider` loaded resources
+asynchronously. The component sometimes returned `null` on the client until `i18n` finished initializing,
+which left the initial markup mismatched with the server render.
 
-The fix is to load translations synchronously using `initImmediate: false` and to always render the provider on the client. `src/i18n.ts` creates an instance immediately and calls `initReactI18next` on first use. `I18nProvider` now initializes on every render if needed and never returns `null`.
+The fix is to load translations synchronously using `initImmediate: false` and to always render the
+provider on the client. `src/i18n.ts` creates an instance immediately and calls `initReactI18next` on first
+use. `I18nProvider` now initializes on every render if needed and never returns `null`.
 
-A hydration test was added (`src/app/__tests__/hydration-i18n.test.tsx`) to ensure `hydrateRoot` completes without console errors when wrapping the tree with `I18nProvider`.
+A hydration test was added (`src/app/__tests__/hydration-i18n.test.tsx`) to ensure `hydrateRoot` completes
+without console errors when wrapping the tree with `I18nProvider`.

--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -7,6 +7,7 @@ import type { Case } from "@/lib/caseStore";
 import { getOfficialCaseGps, getRepresentativePhoto } from "@/lib/caseUtils";
 import { distanceBetween } from "@/lib/distance";
 import { useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -229,14 +230,13 @@ export default function ClientCasesPage({
                     : "ring-1 ring-transparent"
               }`}
             >
-              <button
-                type="button"
+              <Link
+                href={`/cases/${c.id}`}
                 onClick={(e) => {
                   if (e.shiftKey) {
+                    e.preventDefault();
                     const ids = Array.from(new Set([...selectedIds, c.id]));
                     router.push(`/cases?ids=${ids.join(",")}`);
-                  } else {
-                    router.push(`/cases/${c.id}`);
                   }
                 }}
                 className="flex flex-wrap lg:flex-nowrap items-start gap-4 w-full text-left"
@@ -296,7 +296,7 @@ export default function ClientCasesPage({
                     </span>
                   )}
                 </div>
-              </button>
+              </Link>
             </li>
           ))}
       </ul>


### PR DESCRIPTION
## Summary
- avoid nested buttons in the cases list by linking directly with `<Link>`
- rewrap long lines in docs so markdown lint passes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68616c9979b8832b8010da0e8b738e21