### PR TITLE
Add Facebook auth support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,8 @@ NEXTAUTH_SECRET=
 NEXTAUTH_URL=
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+FACEBOOK_CLIENT_ID=
+FACEBOOK_CLIENT_SECRET=
 
 # SQLite database locations
 # Default case store is data/cases.sqlite

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ terraform apply
 
 Copy the outputs into `.env.local` for the production deployment.
 
+To enable Facebook sign‑in, set `FACEBOOK_CLIENT_ID` and
+`FACEBOOK_CLIENT_SECRET` from the Facebook developer console.
+
 ## Generating Zod Schemas
 
 When interfaces in `src/lib` change, update the runtime schemas and verify the output with:

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { NextAuthOptions, Session, User } from "next-auth";
 import type { Adapter } from "next-auth/adapters";
 import EmailProvider from "next-auth/providers/email";
+import FacebookProvider from "next-auth/providers/facebook";
 import GoogleProvider from "next-auth/providers/google";
 import { authAdapter, seedSuperAdmin } from "./auth";
 import { config } from "./config";
@@ -36,6 +37,11 @@ export const authOptions: NextAuthOptions = {
     GoogleProvider({
       clientId: config.GOOGLE_CLIENT_ID ?? "",
       clientSecret: config.GOOGLE_CLIENT_SECRET ?? "",
+      allowDangerousEmailAccountLinking: true,
+    }),
+    FacebookProvider({
+      clientId: config.FACEBOOK_CLIENT_ID ?? "",
+      clientSecret: config.FACEBOOK_CLIENT_SECRET ?? "",
       allowDangerousEmailAccountLinking: true,
     }),
   ],

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -32,6 +32,8 @@ const envSchema = z
     NEXTAUTH_URL: z.string().optional(),
     GOOGLE_CLIENT_ID: z.string().optional(),
     GOOGLE_CLIENT_SECRET: z.string().optional(),
+    FACEBOOK_CLIENT_ID: z.string().optional(),
+    FACEBOOK_CLIENT_SECRET: z.string().optional(),
     CASE_STORE_FILE: z.string().optional(),
     VIN_SOURCE_FILE: z.string().optional(),
     SNAIL_MAIL_FILE: z.string().optional(),


### PR DESCRIPTION
## Summary
- configure NextAuth to use Facebook
- document Facebook sign-in env vars
- add Facebook settings in example env file
- parse Facebook env vars in config

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68616e5367f8832b8a3e620e47d8a539