### PR TITLE
Add Facebook auth provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,8 @@ NEXTAUTH_SECRET=
 NEXTAUTH_URL=
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+FACEBOOK_CLIENT_ID=
+FACEBOOK_CLIENT_SECRET=
 
 # SQLite database locations
 # Default case store is data/cases.sqlite

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ terraform init
 terraform apply
 ```
 
+To enable Facebook sign-in, set `FACEBOOK_CLIENT_ID` and
+`FACEBOOK_CLIENT_SECRET` in your environment. Facebook does not have a
+Terraform module here, so create an app in the Facebook developer console and
+copy the credentials into `.env.local`.
+
 Copy the outputs into `.env.local` for the production deployment.
 
 ## Generating Zod Schemas

--- a/src/app/signin/__tests__/SignInPage.test.tsx
+++ b/src/app/signin/__tests__/SignInPage.test.tsx
@@ -50,4 +50,12 @@ describe("SignInPage", () => {
     fireEvent.click(btn);
     expect(signIn).toHaveBeenCalledWith("google", { callbackUrl: "/" });
   });
+
+  it("allows signing in with Facebook", () => {
+    mockGet.mockReturnValueOnce(null);
+    render(<SignInPage />);
+    const btn = screen.getByRole("button", { name: /sign in with facebook/i });
+    fireEvent.click(btn);
+    expect(signIn).toHaveBeenCalledWith("facebook", { callbackUrl: "/" });
+  });
 });

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -52,6 +52,13 @@ export default function SignInPage() {
         >
           Sign in with Google
         </button>
+        <button
+          type="button"
+          onClick={() => signIn("facebook", { callbackUrl: withBasePath("/") })}
+          className="bg-blue-600 text-white px-4 py-2 mt-2"
+        >
+          Sign in with Facebook
+        </button>
       </form>
       <a href={MARKETING_URL} className="underline mt-2">
         Learn more about Photo to Citation

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { NextAuthOptions, Session, User } from "next-auth";
 import type { Adapter } from "next-auth/adapters";
 import EmailProvider from "next-auth/providers/email";
+import FacebookProvider from "next-auth/providers/facebook";
 import GoogleProvider from "next-auth/providers/google";
 import { authAdapter, seedSuperAdmin } from "./auth";
 import { config } from "./config";
@@ -36,6 +37,11 @@ export const authOptions: NextAuthOptions = {
     GoogleProvider({
       clientId: config.GOOGLE_CLIENT_ID ?? "",
       clientSecret: config.GOOGLE_CLIENT_SECRET ?? "",
+      allowDangerousEmailAccountLinking: true,
+    }),
+    FacebookProvider({
+      clientId: config.FACEBOOK_CLIENT_ID ?? "",
+      clientSecret: config.FACEBOOK_CLIENT_SECRET ?? "",
       allowDangerousEmailAccountLinking: true,
     }),
   ],

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -32,6 +32,8 @@ const envSchema = z
     NEXTAUTH_URL: z.string().optional(),
     GOOGLE_CLIENT_ID: z.string().optional(),
     GOOGLE_CLIENT_SECRET: z.string().optional(),
+    FACEBOOK_CLIENT_ID: z.string().optional(),
+    FACEBOOK_CLIENT_SECRET: z.string().optional(),
     CASE_STORE_FILE: z.string().optional(),
     VIN_SOURCE_FILE: z.string().optional(),
     SNAIL_MAIL_FILE: z.string().optional(),


### PR DESCRIPTION
## Summary
- include `FACEBOOK_CLIENT_ID` and `FACEBOOK_CLIENT_SECRET` in the config
- support Facebook sign‑in via NextAuth
- add Facebook button to the sign‑in page
- document new environment variables
- test Facebook sign‑in

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68616e5367f8832b8a3e620e47d8a539