### PR TITLE
fix: adjust short desktop case chat height

### DIFF
--- a/src/app/cases/[id]/CaseChat.module.css
+++ b/src/app/cases/[id]/CaseChat.module.css
@@ -80,3 +80,10 @@
   width: 0;
   animation: typing-ellipsis 1s steps(4, end) infinite;
 }
+
+@media (min-width: 640px) {
+  .desktopShort {
+    height: calc(var(--visual-viewport-height) - 1rem);
+    margin-top: 1rem;
+  }
+}

--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -1,6 +1,7 @@
 "use client";
 import type { CaseChatReply } from "@/lib/caseChat";
 import useVisualViewportHeight from "../../hooks/useVisualViewportHeight";
+import styles from "./CaseChat.module.css";
 import {
   CaseChatProvider,
   type ChatResponse,
@@ -46,7 +47,7 @@ function CaseChatInner({ caseId }: { caseId: string }) {
         <div
           className={`bg-white dark:bg-gray-900 shadow-lg rounded flex flex-col ${
             expanded ? "w-full h-full" : "w-screen sm:w-80 sm:max-h-[400px]"
-          }`}
+          }${expanded ? "" : ` ${styles.desktopShort}`}`}
           style={
             expanded ? undefined : { height: "var(--visual-viewport-height)" }
           }


### PR DESCRIPTION
## Summary
- ensure case chat height accounts for desktop bottom margin
- add `desktopShort` class to CSS for dynamic height adjustment

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6861711f4f10832ba465b92d542d433b