### PR TITLE
fix: adjust case chat viewport height

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -48,7 +48,12 @@ function CaseChatInner({ caseId }: { caseId: string }) {
             expanded ? "w-full h-full" : "w-screen sm:w-80 sm:max-h-[400px]"
           }`}
           style={
-            expanded ? undefined : { height: "var(--visual-viewport-height)" }
+            expanded
+              ? undefined
+              : {
+                  height: "calc(var(--visual-viewport-height) - 1rem)",
+                  marginTop: "1rem",
+                }
           }
         >
           <ChatHeader />


### PR DESCRIPTION
## Summary
- adjust CaseChat viewport height and give top margin

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6861711f4f10832ba465b92d542d433b