### PR TITLE
Fix CaseChat dynamic height

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -38,7 +38,7 @@ function CaseChatInner({ caseId }: { caseId: string }) {
         expanded
           ? "relative h-full"
           : open
-            ? "fixed inset-0 sm:bottom-4 sm:right-4 sm:inset-auto z-chat"
+            ? "fixed inset-0 sm:bottom-4 sm:right-4 sm:inset-auto z-chat sm:[--case-chat-offset:1rem]"
             : "fixed bottom-4 right-4 z-chat"
       } text-sm`}
     >
@@ -48,7 +48,13 @@ function CaseChatInner({ caseId }: { caseId: string }) {
             expanded ? "w-full h-full" : "w-screen sm:w-80 sm:max-h-[400px]"
           }`}
           style={
-            expanded ? undefined : { height: "var(--visual-viewport-height)" }
+            expanded
+              ? undefined
+              : {
+                  height:
+                    "calc(var(--visual-viewport-height) - var(--case-chat-offset,0px))",
+                  marginTop: "var(--case-chat-offset,0px)",
+                }
           }
         >
           <ChatHeader />


### PR DESCRIPTION
## Summary
- subtract offset when using dynamic viewport height so CaseChat doesn't clip
- add variable to offset the container margin

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6861711f4f10832ba465b92d542d433b