### PR TITLE
Fix case chat dynamic height

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -45,11 +45,10 @@ function CaseChatInner({ caseId }: { caseId: string }) {
       {open ? (
         <div
           className={`bg-white dark:bg-gray-900 shadow-lg rounded flex flex-col ${
-            expanded ? "w-full h-full" : "w-screen sm:w-80 sm:max-h-[400px]"
+            expanded
+              ? "w-full h-full"
+              : "w-screen sm:w-80 sm:max-h-[400px] [height:var(--visual-viewport-height)] sm:[height:calc(var(--visual-viewport-height)-1rem)] sm:mt-4"
           }`}
-          style={
-            expanded ? undefined : { height: "var(--visual-viewport-height)" }
-          }
         >
           <ChatHeader />
           <ChatMessages caseId={caseId} />


### PR DESCRIPTION
## Summary
- adjust case chat dynamic height so the top isn't clipped when the viewport height shrinks on desktop

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6861711f4f10832ba465b92d542d433b