### PR TITLE
Fix case list links for logged out users

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -231,7 +231,7 @@ export default function ClientCasesPage({
               }`}
             >
               <Link
-                href={`/cases/${c.id}`}
+                href={session ? `/cases/${c.id}` : `/public/cases/${c.id}`}
                 onClick={(e) => {
                   if (e.shiftKey) {
                     e.preventDefault();


### PR DESCRIPTION
## Summary
- when showing the case list to logged out users, link each case to the public case page instead of the private one

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6861880ae9e8832b8b23fc126e66648c