### PR TITLE
fix: mobile page scroll after chat close

### DIFF
--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -31,7 +31,7 @@ export default function CaseChat(props: {
 
 function CaseChatInner({ caseId }: { caseId: string }) {
   const { open, expanded, handleOpen } = useCaseChat();
-  useVisualViewportHeight();
+  useVisualViewportHeight(open);
   return (
     <div
       className={`${

--- a/src/app/hooks/useVisualViewportHeight.ts
+++ b/src/app/hooks/useVisualViewportHeight.ts
@@ -1,8 +1,9 @@
 "use client";
 import { useEffect } from "react";
 
-export default function useVisualViewportHeight() {
+export default function useVisualViewportHeight(active = true) {
   useEffect(() => {
+    if (!active) return;
     const setHeight = () => {
       const height = window.visualViewport
         ? window.visualViewport.height
@@ -21,5 +22,5 @@ export default function useVisualViewportHeight() {
       window.visualViewport?.removeEventListener("resize", setHeight);
       window.removeEventListener("resize", setHeight);
     };
-  }, []);
+  }, [active]);
 }


### PR DESCRIPTION
## Summary
- stop useVisualViewportHeight hook when case chat is closed

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6861886516fc832b8b532f84d39db590