### PR TITLE
Fix: hide chat button on public case page

### DIFF
--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -119,17 +119,19 @@ function ClientCasePage({
           {t("dropToAddPhotos")}
         </div>
       )}
-      <div
-        className={
-          chatExpanded ? "md:col-span-1 h-full overflow-y-auto" : undefined
-        }
-      >
-        <CaseChat
-          caseId={caseId}
-          expanded={chatExpanded}
-          onExpandChange={setChatExpanded}
-        />
-      </div>
+      {readOnly ? null : (
+        <div
+          className={
+            chatExpanded ? "md:col-span-1 h-full overflow-y-auto" : undefined
+          }
+        >
+          <CaseChat
+            caseId={caseId}
+            expanded={chatExpanded}
+            onExpandChange={setChatExpanded}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -66,4 +66,25 @@ describe("case visibility @smoke", () => {
     const toggle = getByTestId(dom.window.document, "toggle-public-button");
     expect(toggle).toBeTruthy();
   });
+
+  it("hides chat button on public page", async () => {
+    await signIn("user@example.com");
+    const file = createPhoto("a");
+    const form = new FormData();
+    form.append("photo", file);
+    const upload = await api("/api/upload", { method: "POST", body: form });
+    const { caseId } = (await upload.json()) as { caseId: string };
+    await api(`/api/cases/${caseId}/public`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ public: true }),
+    });
+
+    const page = await api(`/public/cases/${caseId}`).then((r) => r.text());
+    const dom = new JSDOM(page);
+    const chatButton = Array.from(
+      dom.window.document.querySelectorAll("button"),
+    ).find((b) => b.textContent?.trim() === "Chat");
+    expect(chatButton).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- hide CaseChat when `readOnly` prop is true
- verify public case page has no chat button

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68618e50df44832b88d21f82b968b928