### PR TITLE
feat: banner for non-public view link

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -81,6 +81,10 @@
     "signIn": "Sign In",
     "dismiss": "Dismiss"
   },
+  "publicViewBanner": {
+    "message": "You are viewing the public read-only version of this case. If you need to make edits, use the non-public view.",
+    "link": "Open non-public view"
+  },
   "admin": {
     "userManagement": "User Management",
     "appConfiguration": "App Configuration",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -81,6 +81,10 @@
     "signIn": "Iniciar sesión",
     "dismiss": "Descartar"
   },
+  "publicViewBanner": {
+    "message": "Estás viendo la versión pública de este caso en modo de solo lectura. Si necesitas editarlo, usa la vista no pública.",
+    "link": "Abrir vista no pública"
+  },
   "admin": {
     "userManagement": "Gestión de usuarios",
     "appConfiguration": "Configuración de la app",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -81,6 +81,10 @@
     "signIn": "Connexion",
     "dismiss": "Fermer"
   },
+  "publicViewBanner": {
+    "message": "Vous consultez la version publique de ce dossier en lecture seule. Pour le modifier, utilisez la vue non publique.",
+    "link": "Ouvrir la vue non publique"
+  },
   "admin": {
     "userManagement": "Gestion des utilisateurs",
     "appConfiguration": "Configuration de l'application",

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -15,6 +15,7 @@ import CaseExtraInfo from "./components/CaseExtraInfo";
 import CaseHeader from "./components/CaseHeader";
 import ClaimBanner from "./components/ClaimBanner";
 import PhotoSection from "./components/PhotoSection";
+import PublicViewBanner from "./components/PublicViewBanner";
 
 function ClientCasePage({
   caseId,
@@ -92,6 +93,11 @@ function ClientCasePage({
       <ClaimBanner
         show={showClaimBanner}
         onDismiss={() => setHideClaimBanner(true)}
+        className={chatExpanded ? "md:col-span-2" : undefined}
+      />
+      <PublicViewBanner
+        caseId={caseId}
+        show={readOnly}
         className={chatExpanded ? "md:col-span-2" : undefined}
       />
       <div

--- a/src/app/cases/[id]/components/PublicViewBanner.tsx
+++ b/src/app/cases/[id]/components/PublicViewBanner.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useSession } from "@/app/useSession";
+import Link from "next/link";
+import { useTranslation } from "react-i18next";
+import { useCaseContext } from "../CaseContext";
+
+export default function PublicViewBanner({
+  caseId,
+  show = true,
+  className,
+}: {
+  caseId: string;
+  show?: boolean;
+  className?: string;
+}) {
+  const { members } = useCaseContext();
+  const { data: session } = useSession();
+  const { t } = useTranslation();
+  const isMember = members.some((m) => m.userId === session?.user?.id);
+  if (!show || !isMember) return null;
+  return (
+    <div
+      className={`bg-blue-100 border border-blue-300 text-blue-800 p-2 flex items-center justify-between ${className ?? ""}`}
+    >
+      <span>{t("publicViewBanner.message")}</span>
+      <Link href={`/cases/${caseId}`} className="underline">
+        {t("publicViewBanner.link")}
+      </Link>
+    </div>
+  );
+}

--- a/src/app/cases/__tests__/publicViewBanner.test.tsx
+++ b/src/app/cases/__tests__/publicViewBanner.test.tsx
@@ -1,0 +1,65 @@
+import { CaseProvider } from "@/app/cases/[id]/CaseContext";
+import PublicViewBanner from "@/app/cases/[id]/components/PublicViewBanner";
+import queryClient from "@/app/queryClient";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/useSession", () => ({
+  useSession: () => ({ data: { user: { id: "u1" } } }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async (input: RequestInfo) => ({
+    ok: true,
+    json: async () =>
+      String(input).includes("/members")
+        ? [
+            {
+              userId: "u1",
+              role: "owner",
+              name: "User",
+              email: "user@example.com",
+            },
+          ]
+        : caseData,
+  })),
+);
+
+vi.stubGlobal(
+  "EventSource",
+  class {
+    onmessage: ((e: MessageEvent) => void) | null = null;
+    close() {}
+  },
+);
+
+const caseData = {
+  id: "1",
+  photos: [],
+  photoTimes: {},
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  analysisStatus: "pending",
+  public: true,
+};
+
+describe("PublicViewBanner", () => {
+  it("renders for case members", async () => {
+    const { getByText } = render(
+      <QueryClientProvider client={queryClient}>
+        <CaseProvider initialCase={caseData} caseId="1">
+          <PublicViewBanner caseId="1" show />
+        </CaseProvider>
+      </QueryClientProvider>,
+    );
+    await waitFor(() =>
+      expect(getByText(/Open non-public view/i)).toBeTruthy(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- show PublicViewBanner for members viewing public cases
- add translations for banner message in English, Spanish and French
- test PublicViewBanner functionality

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68618e7a14b4832bab78bacfbf9c4326