### PR TITLE
Allow anonymous translation on public cases

### DIFF
--- a/src/app/api/cases/[id]/translate/route.ts
+++ b/src/app/api/cases/[id]/translate/route.ts
@@ -1,4 +1,5 @@
-import { withCaseAuthorization } from "@/lib/authz";
+import { getAnonymousSessionId } from "@/lib/anonymousSession";
+import { authorize, loadAuthContext } from "@/lib/authz";
 import { getCase, setCaseTranslation } from "@/lib/caseStore";
 import { getLlm } from "@/lib/llm";
 import { NextResponse } from "next/server";
@@ -26,41 +27,58 @@ function getValueByPath(obj: unknown, path: string): unknown {
   return current;
 }
 
-export const POST = withCaseAuthorization(
-  { obj: "cases", act: "update" },
-  async (req: Request, { params }: { params: Promise<{ id: string }> }) => {
-    const { id } = await params;
-    const { path, lang } = (await req.json()) as { path: string; lang: string };
-    const c = getCase(id);
-    if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
-    const value = getValueByPath(c, path);
-    if (!value)
-      return NextResponse.json({ error: "Invalid path" }, { status: 400 });
-    const text =
-      typeof value === "string"
-        ? value
-        : typeof value === "object" && value !== null
-          ? ((value as Record<string, string>).en ??
-            Object.values(value as Record<string, string>)[0] ??
-            "")
-          : "";
-    if (!text) return NextResponse.json({ error: "No text" }, { status: 400 });
-    const { client, model } = getLlm("draft_email");
-    const res = await client.chat.completions.create({
-      model,
-      messages: [
-        {
-          role: "system",
-          content: `You translate text. Reply only with the translation in ${lang}.`,
-        },
-        { role: "user", content: text },
-      ],
-    });
-    const translation = res.choices[0]?.message?.content?.trim() ?? "";
-    const updated = setCaseTranslation(id, path, lang, translation);
-    if (!updated)
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
-    const layered = getCase(id);
-    return NextResponse.json(layered);
+export async function POST(
+  req: Request,
+  {
+    params,
+    session,
+  }: {
+    params: Promise<{ id: string }>;
+    session?: { user?: { id?: string; role?: string } };
   },
-);
+) {
+  const { id } = await params;
+  const { path, lang } = (await req.json()) as { path: string; lang: string };
+  const c = getCase(id);
+  if (!c) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const { role, userId } = await loadAuthContext({ session }, "anonymous");
+  const anonId = getAnonymousSessionId(req);
+  const sessionMatch = anonId && c.sessionId && c.sessionId === anonId;
+  const authRole = sessionMatch ? "user" : role;
+  const authorized = await authorize(authRole, "cases", "update", {
+    caseId: id,
+    userId,
+  });
+  if (!authorized && !c.public) {
+    return new Response(null, { status: 403 });
+  }
+  const value = getValueByPath(c, path);
+  if (!value)
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+  const text =
+    typeof value === "string"
+      ? value
+      : typeof value === "object" && value !== null
+        ? ((value as Record<string, string>).en ??
+          Object.values(value as Record<string, string>)[0] ??
+          "")
+        : "";
+  if (!text) return NextResponse.json({ error: "No text" }, { status: 400 });
+  const { client, model } = getLlm("draft_email");
+  const res = await client.chat.completions.create({
+    model,
+    messages: [
+      {
+        role: "system",
+        content: `You translate text. Reply only with the translation in ${lang}.`,
+      },
+      { role: "user", content: text },
+    ],
+  });
+  const translation = res.choices[0]?.message?.content?.trim() ?? "";
+  const updated = setCaseTranslation(id, path, lang, translation);
+  if (!updated)
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const layered = getCase(id);
+  return NextResponse.json(layered);
+}

--- a/test/e2e/translate.test.ts
+++ b/test/e2e/translate.test.ts
@@ -32,6 +32,18 @@ async function signIn(email: string) {
   );
 }
 
+async function signOut() {
+  const csrf = await api("/api/auth/csrf").then((r) => r.json());
+  await api("/api/auth/signout", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      csrfToken: csrf.csrfToken,
+      callbackUrl: server.url,
+    }),
+  });
+}
+
 async function createCase(): Promise<string> {
   const file = createPhoto("a");
   const form = new FormData();
@@ -93,5 +105,37 @@ describe("translate api", () => {
     };
     expect(updated.analysis.details.es).toBe("hola");
     expect(stub.requests.length).toBeGreaterThan(1);
+  });
+
+  it("allows anonymous translation on public cases", async () => {
+    const id = await createCase();
+    const res = await poll(
+      () => api(`/api/cases/${id}`),
+      async (r) => {
+        if (r.status !== 200) return false;
+        const j = await r.clone().json();
+        return j.analysis !== null;
+      },
+      20,
+    );
+    const base = (await res.json()) as { analysis?: { details?: unknown } };
+    expect(base.analysis).toBeTruthy();
+    const pub = await api(`/api/cases/${id}/public`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ public: true }),
+    });
+    expect(pub.status).toBe(200);
+    await signOut();
+    const tr = await api(`/api/cases/${id}/translate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: "analysis.details", lang: "fr" }),
+    });
+    expect(tr.status).toBe(200);
+    const updated = (await tr.json()) as {
+      analysis: { details: Record<string, string> };
+    };
+    expect(updated.analysis.details.fr).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- relax translation API auth to permit updates when a case is public
- add e2e test for anonymous translation on public cases

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686188a6d068832b89854248ac9d5d99