### PR TITLE
Limit hero image overlay text

### DIFF
--- a/src/app/cases/[id]/components/PhotoViewer.tsx
+++ b/src/app/cases/[id]/components/PhotoViewer.tsx
@@ -110,7 +110,7 @@ export default function PhotoViewer({
           </details>
         )}
         {caseData.analysis ? (
-          <div className="group absolute bottom-0 left-0 right-0 bg-black/60 text-white p-2 text-sm overflow-hidden max-h-20 group-hover:overflow-visible">
+          <div className="group absolute bottom-0 left-0 right-0 bg-black/60 text-white p-2 text-sm overflow-hidden max-h-20 hover:overflow-visible">
             <div className="space-y-1 line-clamp-4 group-hover:line-clamp-none">
               <ImageHighlights
                 analysis={caseData.analysis}


### PR DESCRIPTION
## Summary
- clamp hero image overlay text to four lines with ellipsis
- reveal full text on hover without obscuring the image

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68618ffd1fe4832b897776b46c455781