### PR TITLE
Fix typecheck errors

### DIFF
--- a/src/app/cases/__tests__/publicViewBanner.test.tsx
+++ b/src/app/cases/__tests__/publicViewBanner.test.tsx
@@ -1,6 +1,7 @@
 import { CaseProvider } from "@/app/cases/[id]/CaseContext";
 import PublicViewBanner from "@/app/cases/[id]/components/PublicViewBanner";
 import queryClient from "@/app/queryClient";
+import type { Case } from "@/lib/caseStore";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { render, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -39,7 +40,7 @@ vi.stubGlobal(
   },
 );
 
-const caseData = {
+const caseData: Case = {
   id: "1",
   photos: [],
   photoTimes: {},

--- a/test/e2e/publicVisibility.test.ts
+++ b/test/e2e/publicVisibility.test.ts
@@ -83,7 +83,9 @@ describe("case visibility @smoke", () => {
     const page = await api(`/public/cases/${caseId}`).then((r) => r.text());
     const dom = new JSDOM(page);
     const chatButton = Array.from(
-      dom.window.document.querySelectorAll("button"),
+      dom.window.document.querySelectorAll(
+        "button",
+      ) as NodeListOf<HTMLButtonElement>,
     ).find((b) => b.textContent?.trim() === "Chat");
     expect(chatButton).toBeUndefined();
   });


### PR DESCRIPTION
## Summary
- import `Case` type in `PublicViewBanner` tests
- use that type for `caseData`
- specify button node type in public visibility e2e tests

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6861a8ba7388832b8ae7ffaa7a06f3c7