### PR TITLE
fix: stabilize reanalyze e2e test

### DIFF
--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -172,6 +172,9 @@ describe("reanalysis", () => {
       const photo = json.photos[0] as string;
       photoName = path.basename(photo);
 
+      // warm up analysis-active route to avoid compilation delay
+      await api(`/api/cases/${caseId}/analysis-active`);
+
       const rean = await api(`/api/cases/${caseId}/reanalyze`, {
         method: "POST",
       });


### PR DESCRIPTION
## Summary
- warm up analysis-active endpoint before running reanalyze test

## Testing
- `npm test`
- `npm run e2e:smoke`
- `npx vitest run -c vitest.e2e.config.ts test/e2e/reanalyze.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6861b2ebe73c832bbdafbb41822efada