### PR TITLE
fix: preserve analysis on photo note update

### DIFF
--- a/src/lib/caseStore.ts
+++ b/src/lib/caseStore.ts
@@ -455,8 +455,11 @@ export function setPhotoNote(
   current.photoNotes[photo] = note;
   current.updatedAt = new Date().toISOString();
   saveCase(current);
-  caseEvents.emit("update", current);
-  return current;
+  const layered = getCase(id);
+  if (layered) {
+    caseEvents.emit("update", layered);
+  }
+  return layered;
 }
 
 export function setCaseTranslation(


### PR DESCRIPTION
## Summary
- keep analysis data when updating photo notes

## Testing
- `npm test`
- `npm run e2e:smoke` *(fails: Dev Server start hung)*

------
https://chatgpt.com/codex/tasks/task_e_6861ba8d5558832b97ac90a35fd78491