### PR TITLE
Fix WebSocket dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ This stack is designed for performance, type safety, and complete control over h
 
 ## Getting Started
 
-Install dependencies and start the development server:
+Install dependencies and start the development server (using the custom
+WebSocket-enabled server):
 
 ```bash
 npm install

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "npm@10.5.0",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "ts-node --transpile-only server.ts",
     "build:jobs": "node scripts/compileJobs.mjs",
     "build": "npm run build:jobs && next build",
     "start": "ts-node --transpile-only server.ts",

--- a/test/e2e/startServer.ts
+++ b/test/e2e/startServer.ts
@@ -23,12 +23,12 @@ export async function startServer(
   port = 3002,
   env: Partial<NodeJS.ProcessEnv> = {},
 ): Promise<TestServer> {
-  const nextBin = path.join("node_modules", ".bin", "next");
+  const tsNodeBin = path.join("node_modules", ".bin", "ts-node");
   // Using EMAIL_FILE activates the mock email store defined in src/lib/email.ts
   // so no real messages are sent during tests.
   const emailFile =
     env.EMAIL_FILE ?? path.join(os.tmpdir(), `e2e-emails-${port}.json`);
-  const proc = spawn(nextBin, ["dev", "-p", String(port), "--turbo"], {
+  const proc = spawn(tsNodeBin, ["--transpile-only", "server.ts"], {
     env: {
       ...process.env,
       NEXT_TELEMETRY_DISABLED: "1",
@@ -45,6 +45,7 @@ export async function startServer(
       SMTP_FROM: "",
       EMAIL_FILE: emailFile,
       MOCK_EMAIL_TO: "",
+      PORT: String(port),
       ...env,
       CI: "1",
     },


### PR DESCRIPTION
## Summary
- run the custom server in `npm run dev`
- document that the dev server uses WebSockets
- start the dev server with `ts-node` in e2e tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke` *(fails: ENETUNREACH to OpenAI, port already in use)*

------
https://chatgpt.com/codex/tasks/task_e_6861b7efb954832ba0fe36376ceae7af