### PR TITLE
Add more tests to smoke suite

### DIFF
--- a/test/e2e/analysisQueue.test.ts
+++ b/test/e2e/analysisQueue.test.ts
@@ -83,7 +83,7 @@ afterAll(async () => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-describe("analysis queue", () => {
+describe("analysis queue @smoke", () => {
   it("processes additional photos sequentially", async () => {
     const file = await createPhoto("a");
     const form = new FormData();

--- a/test/e2e/chat.test.ts
+++ b/test/e2e/chat.test.ts
@@ -34,7 +34,7 @@ afterAll(async () => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-describe("chat api", () => {
+describe("chat api @smoke", () => {
   async function createCase(): Promise<string> {
     const file = createPhoto("a");
     const form = new FormData();

--- a/test/e2e/email.test.ts
+++ b/test/e2e/email.test.ts
@@ -58,7 +58,7 @@ afterAll(async () => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-describe("email sending", () => {
+describe("email sending @smoke", () => {
   async function createCase(): Promise<string> {
     const file = createPhoto("a");
     const form = new FormData();

--- a/test/e2e/publicAccess.test.ts
+++ b/test/e2e/publicAccess.test.ts
@@ -72,7 +72,7 @@ afterAll(async () => {
   await stub.close();
 });
 
-describe("anonymous access", () => {
+describe("anonymous access @smoke", () => {
   it("allows access to public case", async () => {
     await signIn("user@example.com");
     const id = await createCase();

--- a/test/e2e/snailmail.test.ts
+++ b/test/e2e/snailmail.test.ts
@@ -108,7 +108,7 @@ afterAll(async () => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-describe("snail mail providers", () => {
+describe("snail mail providers @smoke", () => {
   async function createCase(): Promise<string> {
     const file = createPhoto("a");
     const form = new FormData();

--- a/test/e2e/translate.test.ts
+++ b/test/e2e/translate.test.ts
@@ -80,7 +80,7 @@ afterAll(async () => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-describe("translate api", () => {
+describe("translate api @smoke", () => {
   it("translates analysis details", async () => {
     const id = await createCase();
     const res = await poll(
@@ -90,7 +90,7 @@ describe("translate api", () => {
         const j = await r.clone().json();
         return j.analysis !== null;
       },
-      20,
+      40,
     );
     const base = (await res.json()) as { analysis?: { details?: unknown } };
     expect(base.analysis).toBeTruthy();
@@ -116,7 +116,7 @@ describe("translate api", () => {
         const j = await r.clone().json();
         return j.analysis !== null;
       },
-      20,
+      40,
     );
     const base = (await res.json()) as { analysis?: { details?: unknown } };
     expect(base.analysis).toBeTruthy();


### PR DESCRIPTION
## Summary
- mark several E2E tests with the `@smoke` tag
- increase polling attempts in translation tests so they pass consistently

## Testing
- `npm test`
- `npm run e2e:smoke` *(fails: process hung, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_6861ae3e392c832b9e8860f11df48afb