### PR TITLE
fix: skip runtime checks during build

### DIFF
--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -11,7 +11,10 @@ import { config } from "./config";
 import { sendEmail } from "./email";
 import { log } from "./logger";
 
-if (!config.NEXTAUTH_SECRET) {
+if (
+  process.env.NEXT_PHASE !== "phase-production-build" &&
+  !config.NEXTAUTH_SECRET
+) {
   console.error(
     "NEXTAUTH_SECRET environment variable must be set to preserve sessions",
   );

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -12,4 +12,7 @@ fs.mkdirSync(path.dirname(dbFile), { recursive: true });
 
 export const db = new Database(dbFile);
 
-export const migrationsReady = runMigrations(db);
+export const migrationsReady: Promise<void> =
+  process.env.NEXT_PHASE === "phase-production-build"
+    ? Promise.resolve()
+    : Promise.resolve(runMigrations(db));


### PR DESCRIPTION
## Summary
- avoid running DB migrations during `next build`
- skip NEXTAUTH_SECRET warning at build time

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68620bbb9dec832ba77cac951583986b