### PR TITLE
fix: mark credit routes as dynamic

### DIFF
--- a/src/app/api/credits/add/route.ts
+++ b/src/app/api/credits/add/route.ts
@@ -3,6 +3,8 @@ import { getCreditSettings } from "@/lib/creditSettings";
 import { addCredits } from "@/lib/credits";
 import { NextResponse } from "next/server";
 
+export const dynamic = "force-dynamic";
+
 export const POST = withAuthorization(
   { obj: "credits", act: "update" },
   async (

--- a/src/app/api/credits/balance/route.ts
+++ b/src/app/api/credits/balance/route.ts
@@ -2,6 +2,8 @@ import { withAuthorization } from "@/lib/authz";
 import { getCreditBalance } from "@/lib/credits";
 import { NextResponse } from "next/server";
 
+export const dynamic = "force-dynamic";
+
 export const GET = withAuthorization(
   { obj: "credits" },
   async (


### PR DESCRIPTION
## Summary
- mark credits add and balance API routes as dynamic

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke` *(fails: expected null to be truthy)*

------
https://chatgpt.com/codex/tasks/task_e_686212ed1ef4832b98e59d02587348ad