### PR TITLE
Skip migrations during build

### DIFF
--- a/scripts/cleanupAnonymousCases.ts
+++ b/scripts/cleanupAnonymousCases.ts
@@ -2,7 +2,7 @@ import { deleteAnonymousCasesOlderThan } from "../src/lib/caseStore";
 import { migrationsReady } from "../src/lib/db";
 
 async function run() {
-  await migrationsReady;
+  await migrationsReady();
   const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
   const count = deleteAnonymousCasesOlderThan(cutoff);
   console.log(

--- a/scripts/migrateAnalysisImages.ts
+++ b/scripts/migrateAnalysisImages.ts
@@ -6,7 +6,7 @@ import { orm } from "../src/lib/orm";
 import { casePhotoAnalysis, casePhotos } from "../src/lib/schema";
 
 async function run() {
-  await migrationsReady;
+  await migrationsReady();
   const cases = db.prepare("SELECT id, data FROM cases").all() as Array<{
     id: string;
     data: string;

--- a/scripts/scanInbox.ts
+++ b/scripts/scanInbox.ts
@@ -2,7 +2,7 @@ import { migrationsReady } from "../src/lib/db";
 import { scanInbox } from "../src/lib/inboxScanner";
 
 async function run() {
-  await migrationsReady;
+  await migrationsReady();
   await scanInbox();
 }
 

--- a/scripts/updateMissingAnalysis.ts
+++ b/scripts/updateMissingAnalysis.ts
@@ -3,7 +3,7 @@ import { getCases } from "../src/lib/caseStore";
 import { migrationsReady } from "../src/lib/db";
 
 async function run() {
-  await migrationsReady;
+  await migrationsReady();
   const cases = getCases();
   for (const c of cases) {
     const status = c.analysisStatusCode;

--- a/src/app/__tests__/hydration-i18n.test.tsx
+++ b/src/app/__tests__/hydration-i18n.test.tsx
@@ -3,7 +3,12 @@ import I18nProvider from "@/app/i18n-provider";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
 import { renderToString } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
+
+beforeAll(async () => {
+  const db = await import("@/lib/db");
+  await db.migrationsReady();
+});
 
 describe("i18n hydration smoke test", () => {
   it("hydrates LoggedOutLanding with I18nProvider without errors", async () => {

--- a/src/app/__tests__/hydration.test.tsx
+++ b/src/app/__tests__/hydration.test.tsx
@@ -2,7 +2,12 @@ import LoggedOutLanding from "@/app/LoggedOutLanding";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
 import { renderToString } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
+
+beforeAll(async () => {
+  const db = await import("@/lib/db");
+  await db.migrationsReady();
+});
 
 describe("hydration smoke test", () => {
   it("hydrates LoggedOutLanding without errors", async () => {

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -9,7 +9,7 @@ vi.mock("next/headers", () => ({
 vi.mock("next-auth/next", () => ({
   getServerSession: vi.fn(),
 }));
-vi.mock("@/lib/authOptions", () => ({ authOptions: {} }));
+vi.mock("@/lib/authOptions", () => ({ getAuthOptions: () => ({}) }));
 
 describe("Home page", () => {
   it("redirects mobile users to /point when signed in", async () => {

--- a/src/app/admin/__tests__/AdminPage.test.tsx
+++ b/src/app/admin/__tests__/AdminPage.test.tsx
@@ -7,7 +7,7 @@ vi.mock("next-auth/next", () => ({
 }));
 
 vi.mock("@/lib/authOptions", () => ({
-  authOptions: {},
+  getAuthOptions: () => ({}),
 }));
 
 vi.mock("@/lib/authz", () => ({

--- a/src/app/admin/__tests__/changeRoleRoute.test.ts
+++ b/src/app/admin/__tests__/changeRoleRoute.test.ts
@@ -13,7 +13,7 @@ beforeEach(async () => {
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   ({ orm } = await import("@/lib/orm"));
   schema = await import("@/lib/schema");
   ({ eq } = await import("drizzle-orm"));

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,5 @@
 import { getCasbinRules, listUsers } from "@/lib/adminStore";
-import { authOptions } from "@/lib/authOptions";
+import { getAuthOptions } from "@/lib/authOptions";
 import { withAuthorization } from "@/lib/authz";
 import { log } from "@/lib/logger";
 import { getServerSession } from "next-auth/next";
@@ -13,7 +13,7 @@ const handler = withAuthorization(
     _req: Request,
     { session }: { session?: { user?: { role?: string } } },
   ) => {
-    const s = session ?? (await getServerSession(authOptions));
+    const s = session ?? (await getServerSession(getAuthOptions()));
     log("admin page session", s?.user?.role);
     if (s?.user?.role !== "admin" && s?.user?.role !== "superadmin") {
       return new Response(null, { status: 403 });
@@ -25,7 +25,7 @@ const handler = withAuthorization(
 );
 
 export default async function AdminPage() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession(getAuthOptions());
   return handler(new Request("http://localhost"), {
     params: Promise.resolve({}),
     session: session ?? undefined,

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,10 @@
-import { authOptions } from "@/lib/authOptions";
+import { getAuthOptions } from "@/lib/authOptions";
 import NextAuth from "next-auth";
 
-const handler = NextAuth(authOptions);
-export { handler as GET, handler as POST };
+export function GET(req: Request, ctx: { params: { nextauth: string[] } }) {
+  return NextAuth(req, ctx, getAuthOptions());
+}
+
+export function POST(req: Request, ctx: { params: { nextauth: string[] } }) {
+  return NextAuth(req, ctx, getAuthOptions());
+}

--- a/src/app/cases/[id]/draft/page.tsx
+++ b/src/app/cases/[id]/draft/page.tsx
@@ -1,4 +1,4 @@
-import { authOptions } from "@/lib/authOptions";
+import { getAuthOptions } from "@/lib/authOptions";
 import { getAuthorizedCase } from "@/lib/caseAccess";
 import { draftEmail } from "@/lib/caseReport";
 import { reportModules } from "@/lib/reportModules";
@@ -16,7 +16,7 @@ export default async function DraftPage({
   const c = await getAuthorizedCase(id);
   if (!c) notFound();
   const reportModule = reportModules["oak-park"];
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession(getAuthOptions());
   const sender = session?.user
     ? { name: session.user.name ?? null, email: session.user.email ?? null }
     : undefined;

--- a/src/app/cases/layout.tsx
+++ b/src/app/cases/layout.tsx
@@ -1,4 +1,4 @@
-import { authOptions } from "@/lib/authOptions";
+import { getAuthOptions } from "@/lib/authOptions";
 import { getCases } from "@/lib/caseStore";
 import { getServerSession } from "next-auth/next";
 import type { ReactNode } from "react";
@@ -14,7 +14,7 @@ export default async function CasesLayout({
   params: Promise<{ id?: string }>;
 }) {
   await params;
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession(getAuthOptions());
   const list = getCases();
   const cases = session ? list : list.filter((c) => c.public);
   return <CasesLayoutClient initialCases={cases}>{children}</CasesLayoutClient>;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { authOptions } from "@/lib/authOptions";
+import { getAuthOptions } from "@/lib/authOptions";
 import { config } from "@/lib/config";
 import type { Metadata, Viewport } from "next";
 import { getServerSession } from "next-auth";
@@ -29,7 +29,7 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession(getAuthOptions());
   const cookieStore = await cookies();
   // Prefer the language cookie but fall back to Accept-Language
   let storedLang = cookieStore.get("language")?.value;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 export { dynamic } from "./cases/page";
 import { withBasePath } from "@/basePath";
-import { authOptions } from "@/lib/authOptions";
+import { getAuthOptions } from "@/lib/authOptions";
 import { log } from "@/lib/logger";
 import isMobile from "is-mobile";
 import { getServerSession } from "next-auth/next";
@@ -9,7 +9,7 @@ import { redirect } from "next/navigation";
 import LoggedOutLanding from "./LoggedOutLanding";
 
 export default async function Home() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession(getAuthOptions());
   log("home session", !!session);
   const ua = (await headers()).get("user-agent") ?? "";
   const isMobileBrowser = isMobile({ ua });

--- a/src/app/system-status/__tests__/SystemStatusPage.test.tsx
+++ b/src/app/system-status/__tests__/SystemStatusPage.test.tsx
@@ -7,7 +7,7 @@ vi.mock("next-auth/next", () => ({
 }));
 
 vi.mock("@/lib/authOptions", () => ({
-  authOptions: {},
+  getAuthOptions: () => ({}),
 }));
 
 vi.mock("@/lib/authz", () => ({

--- a/src/app/system-status/page.tsx
+++ b/src/app/system-status/page.tsx
@@ -1,4 +1,4 @@
-import { authOptions } from "@/lib/authOptions";
+import { getAuthOptions } from "@/lib/authOptions";
 import { withAuthorization } from "@/lib/authz";
 import { getServerSession } from "next-auth/next";
 import SystemStatusClient from "./SystemStatusClient";
@@ -13,7 +13,7 @@ const handler = withAuthorization(
 );
 
 export default async function SystemStatusPage() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession(getAuthOptions());
   return handler(new Request("http://localhost"), {
     params: Promise.resolve({}),
     session: session ?? undefined,

--- a/src/app/triage/page.tsx
+++ b/src/app/triage/page.tsx
@@ -1,4 +1,4 @@
-import { authOptions } from "@/lib/authOptions";
+import { getAuthOptions } from "@/lib/authOptions";
 import type { Case } from "@/lib/caseStore";
 import { getCases } from "@/lib/caseStore";
 import {
@@ -50,7 +50,7 @@ function nextAction(c: Case): string {
 }
 
 export default async function TriagePage() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession(getAuthOptions());
   const cookieStore = await cookies();
   let lang = cookieStore.get("language")?.value;
   if (!lang) {

--- a/src/jobs/analyzeCase.ts
+++ b/src/jobs/analyzeCase.ts
@@ -4,7 +4,7 @@ import type { Case } from "@/lib/caseStore";
 import { migrationsReady } from "@/lib/db";
 
 (async () => {
-  await migrationsReady;
+  await migrationsReady();
   const { jobData } = workerData as {
     jobData: { caseData: Case; lang: string };
   };

--- a/src/jobs/analyzePhoto.ts
+++ b/src/jobs/analyzePhoto.ts
@@ -4,7 +4,7 @@ import type { Case } from "@/lib/caseStore";
 import { migrationsReady } from "@/lib/db";
 
 (async () => {
-  await migrationsReady;
+  await migrationsReady();
   const { jobData } = workerData as {
     jobData: { caseData: Case; photo: string; lang: string };
   };

--- a/src/jobs/fetchCaseLocation.ts
+++ b/src/jobs/fetchCaseLocation.ts
@@ -4,7 +4,7 @@ import type { Case } from "@/lib/caseStore";
 import { migrationsReady } from "@/lib/db";
 
 (async () => {
-  await migrationsReady;
+  await migrationsReady();
   const { jobData } = workerData as { jobData: Case };
   await fetchCaseLocation(jobData);
   if (parentPort) parentPort.postMessage("done");

--- a/src/jobs/fetchCaseVin.ts
+++ b/src/jobs/fetchCaseVin.ts
@@ -4,7 +4,7 @@ import { migrationsReady } from "@/lib/db";
 import { fetchCaseVin } from "@/lib/vinLookup";
 
 (async () => {
-  await migrationsReady;
+  await migrationsReady();
   const { jobData } = workerData as { jobData: Case };
   await fetchCaseVin(jobData);
   if (parentPort) parentPort.postMessage("done");

--- a/src/lib/__tests__/caseStore.test.ts
+++ b/src/lib/__tests__/caseStore.test.ts
@@ -11,7 +11,7 @@ beforeEach(async () => {
   process.env.CASE_STORE_FILE = path.join(tmpDir, "cases.sqlite");
   vi.resetModules();
   const db = await import("../db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   store = await import("../caseStore");
 });
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -27,7 +27,7 @@ export async function seedSuperAdmin(newUser?: {
   id: string;
   email: string | null;
 }) {
-  await migrationsReady;
+  await migrationsReady();
   const existing = orm
     .select()
     .from(users)

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -11,64 +11,65 @@ import { config } from "./config";
 import { sendEmail } from "./email";
 import { log } from "./logger";
 
-if (!config.NEXTAUTH_SECRET) {
-  console.error(
-    "NEXTAUTH_SECRET environment variable must be set to preserve sessions",
-  );
-}
-
-export const authOptions: NextAuthOptions = {
-  adapter: authAdapter() as Adapter,
-  providers: [
-    EmailProvider({
-      async sendVerificationRequest({ identifier, url }) {
-        log("sendVerificationRequest", identifier);
-        if (config.TEST_APIS) {
-          (global as Record<string, unknown>).verificationUrl = url;
-          const filePath = path.join(os.tmpdir(), "verification-url.txt");
-          await writeFile(filePath, url);
-          return;
+export function getAuthOptions(): NextAuthOptions {
+  if (!config.NEXTAUTH_SECRET) {
+    console.error(
+      "NEXTAUTH_SECRET environment variable must be set to preserve sessions",
+    );
+  }
+  return {
+    adapter: authAdapter() as Adapter,
+    providers: [
+      EmailProvider({
+        async sendVerificationRequest({ identifier, url }) {
+          log("sendVerificationRequest", identifier);
+          if (config.TEST_APIS) {
+            (global as Record<string, unknown>).verificationUrl = url;
+            const filePath = path.join(os.tmpdir(), "verification-url.txt");
+            await writeFile(filePath, url);
+            return;
+          }
+          await sendEmail({ to: identifier, subject: "Sign in", body: url });
+          log("Verification email sent", identifier);
+        },
+        from: config.SMTP_FROM,
+      }),
+      GoogleProvider({
+        clientId: config.GOOGLE_CLIENT_ID ?? "",
+        clientSecret: config.GOOGLE_CLIENT_SECRET ?? "",
+        allowDangerousEmailAccountLinking: true,
+      }),
+      FacebookProvider({
+        clientId: config.FACEBOOK_CLIENT_ID ?? "",
+        clientSecret: config.FACEBOOK_CLIENT_SECRET ?? "",
+        allowDangerousEmailAccountLinking: true,
+      }),
+    ],
+    pages: { signIn: "/signin" },
+    session: { strategy: "database" as const },
+    callbacks: {
+      async session({
+        session,
+        user,
+      }: { session: Session; user: User & { role?: string } }) {
+        log("session callback", user.id);
+        if (session.user) {
+          (session.user as User & { role?: string }).role = user.role;
+          (session.user as User & { id: string }).id = user.id;
         }
-        await sendEmail({ to: identifier, subject: "Sign in", body: url });
-        log("Verification email sent", identifier);
+        return session;
       },
-      from: config.SMTP_FROM,
-    }),
-    GoogleProvider({
-      clientId: config.GOOGLE_CLIENT_ID ?? "",
-      clientSecret: config.GOOGLE_CLIENT_SECRET ?? "",
-      allowDangerousEmailAccountLinking: true,
-    }),
-    FacebookProvider({
-      clientId: config.FACEBOOK_CLIENT_ID ?? "",
-      clientSecret: config.FACEBOOK_CLIENT_SECRET ?? "",
-      allowDangerousEmailAccountLinking: true,
-    }),
-  ],
-  pages: { signIn: "/signin" },
-  session: { strategy: "database" as const },
-  callbacks: {
-    async session({
-      session,
-      user,
-    }: { session: Session; user: User & { role?: string } }) {
-      log("session callback", user.id);
-      if (session.user) {
-        (session.user as User & { role?: string }).role = user.role;
-        (session.user as User & { id: string }).id = user.id;
-      }
-      return session;
     },
-  },
-  events: {
-    async createUser({ user }) {
-      log("new user", user.id);
-      try {
-        await seedSuperAdmin({ id: user.id, email: user.email ?? null });
-      } catch (err) {
-        console.error("Failed to assign super admin role", err);
-      }
+    events: {
+      async createUser({ user }) {
+        log("new user", user.id);
+        try {
+          await seedSuperAdmin({ id: user.id, email: user.email ?? null });
+        } catch (err) {
+          console.error("Failed to assign super admin role", err);
+        }
+      },
     },
-  },
-  secret: config.NEXTAUTH_SECRET,
-};
+    secret: config.NEXTAUTH_SECRET,
+  };
+}

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -1,7 +1,7 @@
 import { type Enforcer, newEnforcer, newModelFromString } from "casbin";
 import { getServerSession } from "next-auth/next";
 import { getAnonymousSessionId } from "./anonymousSession";
-import { authOptions } from "./authOptions";
+import { getAuthOptions } from "./authOptions";
 import { isCaseMember } from "./caseMembers";
 import { getCase } from "./caseStore";
 import { migrationsReady } from "./db";
@@ -13,7 +13,7 @@ let enforcer: Enforcer | undefined;
 
 async function loadEnforcer(): Promise<Enforcer> {
   if (enforcer) return enforcer;
-  await migrationsReady;
+  await migrationsReady();
   log("loading casbin enforcer");
   const model = newModelFromString(`
   [request_definition]
@@ -78,7 +78,7 @@ export async function loadAuthContext(
   const skipSessionLoad = process.env.VITEST && !process.env.TEST_APIS;
   const session = skipSessionLoad
     ? ctx.session
-    : (ctx.session ?? (await getServerSession(authOptions)) ?? undefined);
+    : (ctx.session ?? (await getServerSession(getAuthOptions())) ?? undefined);
   const { role, userId } = getSessionDetails({ session }, defaultRole);
   return { session, role, userId };
 }

--- a/src/lib/caseAccess.ts
+++ b/src/lib/caseAccess.ts
@@ -1,6 +1,6 @@
 import { getServerSession } from "next-auth/next";
 import { cookies } from "next/headers";
-import { authOptions } from "./authOptions";
+import { getAuthOptions } from "./authOptions";
 import { authorize } from "./authz";
 import { isCaseMember } from "./caseMembers";
 import { getCase } from "./caseStore";
@@ -8,7 +8,7 @@ import { getCase } from "./caseStore";
 export async function getAuthorizedCase(id: string) {
   const c = getCase(id);
   if (!c) return null;
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession(getAuthOptions());
   const cookieStore = await cookies();
   const anonId =
     cookieStore.get("anon_session_id")?.value ??

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -12,4 +12,10 @@ fs.mkdirSync(path.dirname(dbFile), { recursive: true });
 
 export const db = new Database(dbFile);
 
-export const migrationsReady = runMigrations(db);
+let migrationPromise: Promise<void> | undefined;
+export function migrationsReady(): Promise<void> {
+  if (!migrationPromise) {
+    migrationPromise = Promise.resolve().then(() => runMigrations(db));
+  }
+  return migrationPromise;
+}

--- a/test/anonymousUpload.test.ts
+++ b/test/anonymousUpload.test.ts
@@ -47,7 +47,7 @@ beforeEach(async () => {
     headers: () => new Headers(),
   }));
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   upload = await import("@/app/api/upload/route");
   caseRoute = await import("@/app/api/cases/[id]/route");
 });

--- a/test/authWrappers.test.ts
+++ b/test/authWrappers.test.ts
@@ -16,7 +16,7 @@ beforeEach(async () => {
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   ({ orm } = await import("@/lib/orm"));
   schema = await import("@/lib/schema");
   caseStore = await import("@/lib/caseStore");

--- a/test/authz.test.ts
+++ b/test/authz.test.ts
@@ -10,7 +10,7 @@ beforeEach(async () => {
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   const { orm } = await import("@/lib/orm");
   const { casbinRules, users } = await import("@/lib/schema");
   orm

--- a/test/casbinRulesRoute.test.ts
+++ b/test/casbinRulesRoute.test.ts
@@ -10,7 +10,7 @@ beforeEach(async () => {
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   const { orm } = await import("@/lib/orm");
   const { casbinRules } = await import("@/lib/schema");
   orm

--- a/test/caseAnalysis.test.ts
+++ b/test/caseAnalysis.test.ts
@@ -12,6 +12,8 @@ vi.mock("@/lib/jobScheduler", () => ({ runJob: runJobMock }));
 describe("analyzeCaseInBackground", () => {
   beforeEach(() => {
     runJobMock.mockClear();
+    const dbPromise = import("@/lib/db");
+    return dbPromise.then((db) => db.migrationsReady());
   });
 
   it("does not start a new worker when analysis is active", async () => {

--- a/test/caseAuthorization.test.ts
+++ b/test/caseAuthorization.test.ts
@@ -11,7 +11,7 @@ beforeEach(async () => {
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   caseStore = await import("@/lib/caseStore");
   const { orm } = await import("@/lib/orm");
   const { users } = await import("@/lib/schema");

--- a/test/caseJobsRoute.test.ts
+++ b/test/caseJobsRoute.test.ts
@@ -16,7 +16,7 @@ beforeEach(async () => {
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   caseStore = await import("@/lib/caseStore");
   jobScheduler = await import("@/lib/jobScheduler");
   jobScheduler.activeJobs.clear();

--- a/test/caseMembers.test.ts
+++ b/test/caseMembers.test.ts
@@ -14,7 +14,7 @@ beforeEach(async () => {
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   ({ orm } = await import("@/lib/orm"));
   schema = await import("@/lib/schema");
   orm

--- a/test/caseStore.test.ts
+++ b/test/caseStore.test.ts
@@ -19,8 +19,8 @@ beforeEach(async () => {
   members = await import("@/lib/caseMembers");
   ({ orm } = await import("@/lib/orm"));
   schema = await import("@/lib/schema");
+  await dbModule.migrationsReady();
   orm.insert(schema.users).values({ id: "u1" }).run();
-  await dbModule.migrationsReady;
 });
 
 afterEach(() => {

--- a/test/profileRoute.test.ts
+++ b/test/profileRoute.test.ts
@@ -10,7 +10,7 @@ beforeEach(async () => {
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   const { orm } = await import("@/lib/orm");
   const { users } = await import("@/lib/schema");
   orm

--- a/test/protectedRoutes.test.ts
+++ b/test/protectedRoutes.test.ts
@@ -42,7 +42,7 @@ beforeEach(async () => {
     }),
   }));
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
 });
 
 afterEach(() => {

--- a/test/publicCases.test.ts
+++ b/test/publicCases.test.ts
@@ -11,7 +11,7 @@ beforeEach(async () => {
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   caseStore = await import("@/lib/caseStore");
 });
 

--- a/test/snailMailProviders.test.ts
+++ b/test/snailMailProviders.test.ts
@@ -11,7 +11,7 @@ beforeEach(async () => {
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   const { snailMailProviders } = await import("@/lib/snailMail");
   const statuses = Object.keys(snailMailProviders).map((id, idx) => ({
     id,

--- a/test/systemJobsRoute.test.ts
+++ b/test/systemJobsRoute.test.ts
@@ -16,7 +16,7 @@ beforeEach(async () => {
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   ({ orm } = await import("@/lib/orm"));
   schema = await import("@/lib/schema");
   orm

--- a/test/uploadRoute.test.ts
+++ b/test/uploadRoute.test.ts
@@ -59,7 +59,7 @@ beforeEach(async () => {
     headers: () => new Headers(),
   }));
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   caseStore = await import("@/lib/caseStore");
   caseAnalysis = await import("@/lib/caseAnalysis");
   cancelSpy = vi.spyOn(caseAnalysis, "cancelCaseAnalysis");

--- a/test/uploadsAccess.test.ts
+++ b/test/uploadsAccess.test.ts
@@ -15,7 +15,7 @@ beforeEach(async () => {
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   store = await import("@/lib/caseStore");
   const { orm } = await import("@/lib/orm");
   const { users } = await import("@/lib/schema");

--- a/test/vinLookup.test.ts
+++ b/test/vinLookup.test.ts
@@ -19,7 +19,7 @@ beforeEach(async () => {
   fs.writeFileSync(process.env.VIN_SOURCE_FILE, JSON.stringify(statuses));
   vi.resetModules();
   const dbModule = await import("@/lib/db");
-  await dbModule.migrationsReady;
+  await dbModule.migrationsReady();
 });
 
 afterEach(() => {

--- a/test/vinSources.test.ts
+++ b/test/vinSources.test.ts
@@ -11,7 +11,7 @@ beforeEach(async () => {
   process.env.CASE_STORE_FILE = path.join(dataDir, "cases.sqlite");
   vi.resetModules();
   const db = await import("@/lib/db");
-  await db.migrationsReady;
+  await db.migrationsReady();
   const { defaultVinSources } = await import("@/lib/vinSources");
   const statuses = defaultVinSources.map((s: { id: string }) => ({
     id: s.id,


### PR DESCRIPTION
## Summary
- skip automatic DB migrations in Docker build
- expose `migrationsReady()` to run migrations on demand
- check NextAuth secret only when building auth options
- document docker compose usage

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npx vitest run -c vitest.e2e.config.ts --testNamePattern "@smoke"` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68620bbb9dec832ba77cac951583986b