### PR TITLE
Fix NextAuth route handler types

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,14 +1,6 @@
 import { getAuthOptions } from "@/lib/authOptions";
 import NextAuth from "next-auth";
-import type { NextRequest } from "next/server";
 
-export function GET(req: NextRequest, ctx: { params: { nextauth: string[] } }) {
-  return NextAuth(req, ctx, getAuthOptions());
-}
+const handler = NextAuth(getAuthOptions());
 
-export function POST(
-  req: NextRequest,
-  ctx: { params: { nextauth: string[] } },
-) {
-  return NextAuth(req, ctx, getAuthOptions());
-}
+export { handler as GET, handler as POST };


### PR DESCRIPTION
## Summary
- simplify NextAuth route handler to use recommended syntax

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68622f3d9414832b802f47e0411d8f0a