### PR TITLE
fix: lazy init credits db

### DIFF
--- a/src/lib/credits.ts
+++ b/src/lib/credits.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import type Database from "better-sqlite3";
 import { db } from "./db";
 
 export interface CreditTransaction {
@@ -8,31 +9,37 @@ export interface CreditTransaction {
   createdAt: string;
 }
 
-const insertTx = db.prepare(
-  "INSERT INTO credit_transactions (id, user_id, amount, created_at) VALUES (?, ?, ?, ?)",
-);
-const updateBalance = db.prepare(
-  "UPDATE user SET credits = credits + ? WHERE id = ?",
-);
-const selectBalance = db.prepare("SELECT credits FROM user WHERE id = ?");
+let insertTx!: Database.Statement;
+let updateBalance!: Database.Statement;
+let selectBalance!: Database.Statement;
+let txAdd!: (userId: string, amount: number) => number;
 
-const txAdd = db.transaction(((userId: string, amount: number) => {
-  const id = crypto.randomUUID();
-  const createdAt = new Date().toISOString();
-  insertTx.run(id, userId, amount, createdAt);
-  updateBalance.run(amount, userId);
-  const row = selectBalance.get(userId) as { credits: number } | undefined;
-  return row?.credits ?? 0;
-}) as (userId: string, amount: number) => unknown) as (
-  userId: string,
-  amount: number,
-) => number;
+function initStatements(): void {
+  if (txAdd) return;
+  insertTx = db.prepare(
+    "INSERT INTO credit_transactions (id, user_id, amount, created_at) VALUES (?, ?, ?, ?)",
+  );
+  updateBalance = db.prepare(
+    "UPDATE user SET credits = credits + ? WHERE id = ?",
+  );
+  selectBalance = db.prepare("SELECT credits FROM user WHERE id = ?");
+  txAdd = db.transaction((userId: string, amount: number) => {
+    const id = crypto.randomUUID();
+    const createdAt = new Date().toISOString();
+    insertTx.run(id, userId, amount, createdAt);
+    updateBalance.run(amount, userId);
+    const row = selectBalance.get(userId) as { credits: number } | undefined;
+    return row?.credits ?? 0;
+  }) as (userId: string, amount: number) => number;
+}
 
 export function addCredits(userId: string, amount: number): number {
+  initStatements();
   return txAdd(userId, amount);
 }
 
 export function getCreditBalance(userId: string): number {
+  initStatements();
   const row = selectBalance.get(userId) as { credits: number } | undefined;
   return row?.credits ?? 0;
 }


### PR DESCRIPTION
## Summary
- avoid preparing statements when `credits` module is imported

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862cbdd2100832bacf87564d205e28b