### PR TITLE
Remove heavy tests from smoke suite

### DIFF
--- a/test/e2e/analysisQueue.test.ts
+++ b/test/e2e/analysisQueue.test.ts
@@ -83,7 +83,7 @@ afterAll(async () => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-describe("analysis queue @smoke", () => {
+describe("analysis queue", () => {
   it("processes additional photos sequentially", async () => {
     const file = await createPhoto("a");
     const form = new FormData();

--- a/test/e2e/email.test.ts
+++ b/test/e2e/email.test.ts
@@ -58,7 +58,7 @@ afterAll(async () => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-describe("email sending @smoke", () => {
+describe("email sending", () => {
   async function createCase(): Promise<string> {
     const file = createPhoto("a");
     const form = new FormData();

--- a/test/e2e/snailmail.test.ts
+++ b/test/e2e/snailmail.test.ts
@@ -108,7 +108,7 @@ afterAll(async () => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-describe("snail mail providers @smoke", () => {
+describe("snail mail providers", () => {
   async function createCase(): Promise<string> {
     const file = createPhoto("a");
     const form = new FormData();

--- a/test/e2e/translate.test.ts
+++ b/test/e2e/translate.test.ts
@@ -80,7 +80,7 @@ afterAll(async () => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-describe("translate api @smoke", () => {
+describe("translate api", () => {
   it("translates analysis details", async () => {
     const id = await createCase();
     const res = await poll(


### PR DESCRIPTION
## Summary
- demote long-running email and translation tests from `@smoke`

## Testing
- `npm test`
- `npm run e2e:smoke`

------
https://chatgpt.com/codex/tasks/task_e_6862d5e4ff28832b80ce52949a840a47