### PR TITLE
Fix translate e2e flakiness

### DIFF
--- a/test/e2e/translate.test.ts
+++ b/test/e2e/translate.test.ts
@@ -13,7 +13,7 @@ let api: (path: string, opts?: RequestInit) => Promise<Response>;
 let stub: OpenAIStub;
 let tmpDir: string;
 
-vi.setConfig({ testTimeout: 60000 });
+vi.setConfig({ testTimeout: 60000, hookTimeout: 60000 });
 
 async function signIn(email: string) {
   const csrf = await api("/api/auth/csrf").then((r) => r.json());
@@ -56,6 +56,13 @@ async function createCase(): Promise<string> {
 
 beforeAll(async () => {
   stub = await startOpenAIStub([
+    {
+      violationType: "parking",
+      details: { en: "hello" },
+      vehicle: {},
+      images: {},
+    },
+    "hola",
     {
       violationType: "parking",
       details: { en: "hello" },


### PR DESCRIPTION
## Summary
- extend vitest hook timeout for translate tests
- ensure OpenAI stub has responses for both tests

## Testing
- `npm test`
- `npx vitest run -c vitest.e2e.config.ts test/e2e/translate.test.ts --reporter dot` *(fails to run due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_6862d65629fc832bbcf9a557c2dbe32d