### PR TITLE
Fix Docker runtime missing server.ts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/tsconfig.generated.json ./tsconfig.generated.json
 COPY --from=builder /app/migrations ./migrations
+COPY --from=builder /app/server.ts ./server.ts
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/dist/jobs ./dist/jobs
 COPY --from=builder /app/src/lib ./src/lib


### PR DESCRIPTION
## Summary
- copy `server.ts` into the runtime Docker image so `npm start` works

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6862dc03d7c8832b94825a00db3622ee