### PR TITLE
Fix MapPageClient imports

### DIFF
--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -7,8 +7,6 @@ import { osm } from "pigeon-maps/providers";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
 
-import "@/app/globals.css";
-
 function MarkerIcon() {
   return (
     <svg


### PR DESCRIPTION
## Summary
- remove unused globals.css import from MapPageClient so global styles come from layout

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke` *(fails: Command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6862def7ff90832b9668e9a2ec28e322