### PR TITLE
Centralize zod openapi setup

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,7 @@
 import { createServer } from "node:http";
 import next from "next";
 import { type WebSocket, WebSocketServer } from "ws";
+import "./src/lib/init";
 import { caseEvents } from "./src/lib/caseEvents";
 import { migrationsReady } from "./src/lib/db";
 import { jobEvents } from "./src/lib/jobEvents";

--- a/src/lib/caseChat.ts
+++ b/src/lib/caseChat.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import "./zod-setup";
 import { localizedTextSchema, rawLocalizedTextSchema } from "./openai";
 
 export type CaseChatAction =

--- a/src/lib/caseReport.ts
+++ b/src/lib/caseReport.ts
@@ -9,7 +9,6 @@ import { log } from "./logger";
 import { localizedTextSchema } from "./openai";
 import type { ReportModule } from "./reportModules";
 import { getViolationCode } from "./violationCodes";
-import "./zod-setup";
 
 function logBadResponse(
   attempt: number,

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -1,0 +1,3 @@
+import { setupZodOpenApi } from "./zod-setup";
+
+setupZodOpenApi();

--- a/src/lib/llmUtils.ts
+++ b/src/lib/llmUtils.ts
@@ -6,7 +6,6 @@ import type {
   ChatCompletionMessageParam,
 } from "openai/resources/chat/completions";
 import type { ZodSchema } from "zod";
-import "./zod-setup";
 
 export type LlmProgress =
   | {

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -6,7 +6,6 @@ import type {
   ChatCompletionMessageParam,
 } from "openai/resources/chat/completions";
 import { z } from "zod";
-import "./zod-setup";
 import { getLlm } from "./llm";
 import { normalizeLocalizedText } from "./localizedText";
 import { US_STATES } from "./usStates";

--- a/src/lib/snailMail.ts
+++ b/src/lib/snailMail.ts
@@ -2,7 +2,6 @@ import docsmitProvider from "./docsmitProvider";
 import fileProvider from "./fileSnailMailProvider";
 import { runJob } from "./jobScheduler";
 import { log } from "./logger";
-import "./zod-setup";
 
 export interface MailingAddress {
   name?: string;

--- a/src/lib/zod-setup.ts
+++ b/src/lib/zod-setup.ts
@@ -1,4 +1,11 @@
 import { extendZodWithOpenApi } from "@anatine/zod-openapi";
 import { z } from "zod";
 
-extendZodWithOpenApi(z);
+let extended = false;
+
+export function setupZodOpenApi(): void {
+  if (!extended) {
+    extendZodWithOpenApi(z);
+    extended = true;
+  }
+}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import React, { type ImgHTMLAttributes } from "react";
 import { type TestContext, afterEach, beforeAll, beforeEach, vi } from "vitest";
 import { initI18n } from "./src/i18n";
+import "./src/lib/init";
 
 if (typeof window !== "undefined" && !("ResizeObserver" in window)) {
   class ResizeObserver {


### PR DESCRIPTION
## Summary
- expose `setupZodOpenApi` and guard against duplicate calls
- create `init.ts` and run zod setup once
- load `init` from `server.ts` and the vitest setup
- drop scattered `import "./zod-setup"` statements

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6862df013d38832bb802b916dd6ee11e