### PR TITLE
fix openai leak in e2e

### DIFF
--- a/test/e2e/startServer.ts
+++ b/test/e2e/startServer.ts
@@ -46,6 +46,8 @@ export async function startServer(
       EMAIL_FILE: emailFile,
       MOCK_EMAIL_TO: "",
       PORT: String(port),
+      OPENAI_API_KEY: "test",
+      OPENAI_BASE_URL: "http://127.0.0.1:65535",
       ...env,
       CI: "1",
     },


### PR DESCRIPTION
## Summary
- prevent accidental network calls to OpenAI when tests start the server without providing a stub

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6862e1d7c344832bb75dabe892357454