### PR TITLE
feat: enable server source maps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN npm run build && npm prune --production
 FROM node:20-bookworm AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+ENV NODE_OPTIONS=--enable-source-maps
 ENV PORT=3000
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,9 @@ const assetPrefix = basePath ? `${basePath}/` : undefined;
 const nextConfig: NextConfig = {
   basePath,
   assetPrefix,
+  experimental: {
+    serverSourceMaps: true,
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary
- enable source maps in Next.js for server bundles
- allow Node to read source maps at runtime

## Testing
- `npm test`
- `npm run e2e:smoke`

------
https://chatgpt.com/codex/tasks/task_e_68632cc2becc832ba8289097ae47b591