### PR TITLE
Fix followup e2e test

### DIFF
--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -44,7 +44,7 @@ beforeAll(async () => {
       vehicle: {},
       images: {},
     },
-    { subject: { en: "s" }, body: { en: "b" } },
+    { subject: "s", body: "b" },
   ]);
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   const env = {


### PR DESCRIPTION
## Summary
- correct response format for OpenAI stub in followup e2e test

## Testing
- `npm test`
- `npx vitest run -c vitest.e2e.config.ts --testNamePattern "@smoke"`

------
https://chatgpt.com/codex/tasks/task_e_68651ba5316c832b9309e09d2800557b