### PR TITLE
Fix reanalysis e2e race

### DIFF
--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -172,6 +172,25 @@ describe("reanalysis", () => {
       const photo = json.photos[0] as string;
       photoName = path.basename(photo);
 
+      // Warm up the reanalyze-photo route to avoid dev server compile delays
+      await api(`/api/cases/${caseId}/reanalyze-photo?photo=warmup`, {
+        method: "POST",
+      }).catch(() => {
+        /* ignore errors */
+      });
+
+      // Warm up the reanalyze route for the same reason
+      await api(`/api/cases/${caseId}/reanalyze`, { method: "POST" }).catch(
+        () => {
+          /* ignore errors */
+        },
+      );
+
+      // Warm up analysis-active route
+      await api(`/api/cases/${caseId}/analysis-active`).catch(() => {
+        /* ignore errors */
+      });
+
       const rean = await api(`/api/cases/${caseId}/reanalyze`, {
         method: "POST",
       });


### PR DESCRIPTION
## Summary
- warm up reanalysis API routes in the photo reanalysis test

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68651b8c8e28832bb0f6ad2b10369bfa