### PR TITLE
Fix e2e photo reanalysis timing

### DIFF
--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -93,7 +93,7 @@ describe("reanalysis", () => {
         { violationType: "parking", details: "d", vehicle: {}, images: {} },
         () => {
           const start = Date.now();
-          while (Date.now() - start < 2000) {}
+          while (Date.now() - start < 5000) {}
           return {
             violationType: "parking",
             details: "d",
@@ -177,18 +177,18 @@ describe("reanalysis", () => {
       });
       expect(rean.status).toBe(200);
 
+      const single = await api(
+        `/api/cases/${caseId}/reanalyze-photo?photo=${encodeURIComponent(photo)}`,
+        { method: "POST" },
+      );
+      expect(single.status).toBe(409);
+
       await poll(
         () => api(`/api/cases/${caseId}/analysis-active`),
         async (r) => (await r.json()).active === true,
         50,
         50,
       );
-
-      const single = await api(
-        `/api/cases/${caseId}/reanalyze-photo?photo=${encodeURIComponent(photo)}`,
-        { method: "POST" },
-      );
-      expect(single.status).toBe(409);
     });
   });
 


### PR DESCRIPTION
## Summary
- stabilize photo reanalysis e2e by waiting less for case analysis to start
- keep case reanalysis running longer so the active check is reliable

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68651b8c8e28832bb0f6ad2b10369bfa