### PR TITLE
Fix e2e translation test

### DIFF
--- a/test/e2e/followup.test.ts
+++ b/test/e2e/followup.test.ts
@@ -44,7 +44,7 @@ beforeAll(async () => {
       vehicle: {},
       images: {},
     },
-    { subject: { en: "s" }, body: { en: "b" } },
+    { subject: "s", body: "b" },
   ]);
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-"));
   const env = {

--- a/test/e2e/translate.test.ts
+++ b/test/e2e/translate.test.ts
@@ -63,6 +63,13 @@ beforeAll(async () => {
       images: {},
     },
     "hola",
+    {
+      violationType: "parking",
+      details: { en: "hello" },
+      vehicle: {},
+      images: {},
+    },
+    "bonjour",
   ]);
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-translate-"));
   server = await startServer(3032, {


### PR DESCRIPTION
## Summary
- correct OpenAI stub responses in translation and followup e2e tests

## Testing
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68651b4f611c832ba04f9f1424a3b005