### PR TITLE
fix: prevent body consumed in e2e poll

### DIFF
--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -198,7 +198,7 @@ describe("reanalysis", () => {
 
       const activeRes = await poll(
         () => api(`/api/cases/${caseId}/analysis-active`),
-        async (r) => (await r.json()).active === true,
+        async (r) => (await r.clone().json()).active === true,
         50,
         50,
       );


### PR DESCRIPTION
## Summary
- ensure `poll` does not consume the response body when checking analysis status

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e:smoke` *(fails: blocked or timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6865287db06c832b942321b0bcc9d43a