### PR TITLE
Fix ownership page serialization error

### DIFF
--- a/src/app/cases/[id]/ownership/OwnershipEditor.tsx
+++ b/src/app/cases/[id]/ownership/OwnershipEditor.tsx
@@ -10,7 +10,7 @@ export default function OwnershipEditor({
   module,
 }: {
   caseId: string;
-  module: OwnershipModule;
+  module: Omit<OwnershipModule, "requestVin" | "requestContactInfo">;
 }) {
   const [checkNumber, setCheckNumber] = useState("");
   const [snailMail, setSnailMail] = useState(false);

--- a/src/app/cases/[id]/ownership/page.tsx
+++ b/src/app/cases/[id]/ownership/page.tsx
@@ -1,6 +1,7 @@
 import { initI18n } from "@/i18n.server";
 import { getAuthorizedCase } from "@/lib/caseAccess";
 import { ownershipModules } from "@/lib/ownershipModules";
+import type { OwnershipModule } from "@/lib/ownershipModules";
 import { notFound } from "next/navigation";
 import OwnershipEditor from "./OwnershipEditor";
 
@@ -24,5 +25,13 @@ export default async function OwnershipPage({
       <div className="p-8">{t("noOwnershipModule", { label, supported })}</div>
     );
   }
-  return <OwnershipEditor caseId={id} module={mod} />;
+  const { requestVin: _rv, requestContactInfo: _rc, ...clientMod } = mod;
+  return (
+    <OwnershipEditor
+      caseId={id}
+      module={
+        clientMod as Omit<OwnershipModule, "requestVin" | "requestContactInfo">
+      }
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- avoid sending functions to the client by sanitizing the ownership module
- narrow OwnershipEditor props to exclude server-only handlers

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6865513bcbcc832b86ea68d2a5bfa4e2