### PR TITLE
feat: persist admin tab selection in url

### DIFF
--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -3,6 +3,7 @@ import { apiFetch } from "@/apiClient";
 import { useSession } from "@/app/useSession";
 import { getPublicEnv } from "@/publicEnv";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import AppConfigurationTab from "./AppConfigurationTab";
@@ -87,9 +88,11 @@ const USERS_QUERY_KEY = ["/api/users"] as const;
 export default function AdminPageClient({
   initialUsers,
   initialRules,
+  initialTab = "users",
 }: {
   initialUsers: UserRecord[];
   initialRules: RuleInput[];
+  initialTab?: "users" | "config";
 }) {
   const queryClient = useQueryClient();
   const { data: users = [] } = useQuery<UserRecord[]>({
@@ -99,7 +102,8 @@ export default function AdminPageClient({
   const [rules, setRules] = useState(() =>
     initialRules.map((r) => ({ ...normalizeRule(r), id: crypto.randomUUID() })),
   );
-  const [tab, setTab] = useState<"users" | "config">("users");
+  const router = useRouter();
+  const [tab, setTab] = useState<"users" | "config">(initialTab);
   const [inviteEmail, setInviteEmail] = useState("");
   const { data: session } = useSession();
   const isSuperadmin = session?.user?.role === "superadmin";
@@ -220,18 +224,32 @@ export default function AdminPageClient({
   } = getPublicEnv();
   return (
     <div className="p-8">
-      <div className="flex gap-4 mb-4">
+      <div className="flex gap-4 mb-4 border-b">
         <button
           type="button"
-          onClick={() => setTab("users")}
-          className={tab === "users" ? "font-bold underline" : ""}
+          onClick={() => {
+            setTab("users");
+            router.replace("?tab=users");
+          }}
+          className={`px-3 py-1 border-b-2 rounded-t ${
+            tab === "users"
+              ? "border-blue-600 text-blue-600 font-bold"
+              : "border-transparent"
+          }`}
         >
           {t("admin.userManagement")}
         </button>
         <button
           type="button"
-          onClick={() => setTab("config")}
-          className={tab === "config" ? "font-bold underline" : ""}
+          onClick={() => {
+            setTab("config");
+            router.replace("?tab=config");
+          }}
+          className={`px-3 py-1 border-b-2 rounded-t ${
+            tab === "config"
+              ? "border-blue-600 text-blue-600 font-bold"
+              : "border-transparent"
+          }`}
         >
           {t("admin.appConfiguration")}
         </button>

--- a/src/app/admin/__tests__/AdminPage.test.tsx
+++ b/src/app/admin/__tests__/AdminPage.test.tsx
@@ -20,6 +20,6 @@ it("returns 403 for non-admin", async () => {
   ).mockResolvedValue({
     user: { role: "user" },
   });
-  const res = (await AdminPage()) as Response;
+  const res = (await AdminPage({ searchParams: {} })) as Response;
   expect(res.status).toBe(403);
 });

--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -15,6 +15,11 @@ vi.mock("@/app/useSession", () => ({
 
 import { useSession } from "@/app/useSession";
 
+const mockReplace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
 vi.mock("@/apiClient", () => ({
   apiFetch: vi.fn(),
 }));
@@ -47,6 +52,20 @@ describe("AdminPageClient", () => {
     expect(screen.getAllByDisplayValue("admin")[0]).toBeInTheDocument();
     expect(screen.getByDisplayValue("users")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /save rules/i })).toBeDisabled();
+  });
+
+  it("updates url when tab changes", () => {
+    vi.mocked(apiFetch).mockResolvedValue({
+      ok: true,
+      json: async () => users,
+    } as Response);
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AdminPageClient initialUsers={users} initialRules={rules} />
+      </QueryClientProvider>,
+    );
+    fireEvent.click(screen.getByText(/app configuration/i));
+    expect(mockReplace).toHaveBeenCalledWith("?tab=config");
   });
 
   it("enables saving for superadmins", async () => {


### PR DESCRIPTION
## Summary
- preserve selected admin tab in URL
- style admin page tabs with a visible indicator
- pass URL tab to admin page on initial load
- test tab URL persistence

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686551df1fd8832bae0afeaa199a95b8