### PR TITLE
Add superadmin OAuth provider policy

### DIFF
--- a/migrations/0021_superadmin_oauth_provider_read.sql
+++ b/migrations/0021_superadmin_oauth_provider_read.sql
@@ -1,0 +1,2 @@
+INSERT INTO casbin_rules (ptype, v0, v1, v2) VALUES
+  ('p', 'superadmin', 'oauth_providers', 'read');

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,8 +3,8 @@ import { authOptions } from "@/lib/authOptions";
 import { withAuthorization } from "@/lib/authz";
 import { log } from "@/lib/logger";
 import { getServerSession } from "next-auth/next";
-import AdminPageClient from "./AdminPageClient";
 import type { ReactElement } from "react";
+import AdminPageClient from "./AdminPageClient";
 
 export const dynamic = "force-dynamic";
 

--- a/test/oauthProviders.test.ts
+++ b/test/oauthProviders.test.ts
@@ -58,4 +58,13 @@ describe("oauth provider API authorization", () => {
     });
     expect(res.status).toBe(403);
   });
+
+  it("allows listing with superadmin role", async () => {
+    const mod = await import("@/app/api/oauth-providers/route");
+    const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({}) as Promise<Record<string, string>>,
+      session: { user: { role: "superadmin" } },
+    });
+    expect(res.status).toBe(200);
+  });
 });


### PR DESCRIPTION
## Summary
- add DB migration to permit superadmins to read OAuth providers
- allow OAuth providers list API with superadmin role
- fix lint ordering in admin page

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686555c9e4ec832bbcac821d3cb78df7