### PR TITLE
Fix admin page searchParams type

### DIFF
--- a/src/app/admin/__tests__/AdminPage.test.tsx
+++ b/src/app/admin/__tests__/AdminPage.test.tsx
@@ -20,6 +20,8 @@ it("returns 403 for non-admin", async () => {
   ).mockResolvedValue({
     user: { role: "user" },
   });
-  const res = (await AdminPage({ searchParams: {} })) as Response;
+  const res = (await AdminPage({
+    searchParams: Promise.resolve({}),
+  })) as Response;
   expect(res.status).toBe(403);
 });

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -12,7 +12,7 @@ const handler = withAuthorization<
   {
     params: Promise<Record<string, string>>;
     session?: { user?: { role?: string } };
-    searchParams?: { tab?: string };
+    searchParams?: Promise<{ tab?: string }>;
   },
   Response | ReactElement
 >(
@@ -24,7 +24,7 @@ const handler = withAuthorization<
       searchParams,
     }: {
       session?: { user?: { role?: string } };
-      searchParams?: { tab?: string };
+      searchParams?: Promise<{ tab?: string }>;
     },
   ) => {
     const s = session ?? (await getServerSession(authOptions));
@@ -34,12 +34,13 @@ const handler = withAuthorization<
     }
     const users = listUsers();
     const rules = getCasbinRules();
-    const tab = searchParams?.tab === "config" ? "config" : "users";
+    const { tab } = (await searchParams) ?? {};
+    const t = tab === "config" ? "config" : "users";
     return (
       <AdminPageClient
         initialUsers={users}
         initialRules={rules}
-        initialTab={tab}
+        initialTab={t}
       />
     );
   },
@@ -48,7 +49,7 @@ const handler = withAuthorization<
 export default async function AdminPage({
   searchParams,
 }: {
-  searchParams?: { tab?: string };
+  searchParams?: Promise<{ tab?: string }>;
 }) {
   const session = await getServerSession(authOptions);
   return handler(new Request("http://localhost"), {


### PR DESCRIPTION
## Summary
- update admin page searchParams typing to use Promise
- adjust admin page tests for new typing

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68657a9fc1d0832b83dd25cc4fb46579