### PR TITLE
Display ownership request form

### DIFF
--- a/src/app/api/cases/[id]/ownership-form/route.ts
+++ b/src/app/api/cases/[id]/ownership-form/route.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import { withCaseAuthorization } from "@/lib/authz";
+import { getCase } from "@/lib/caseStore";
+import { fillIlForm } from "@/lib/ownershipModules";
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const GET = withCaseAuthorization(
+  { obj: "cases" },
+  async (_req: Request, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const c = getCase(id);
+    if (!c) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const state = c.analysis?.vehicle?.licensePlateState?.toLowerCase();
+    if (state !== "il") {
+      return NextResponse.json({ error: "unsupported" }, { status: 400 });
+    }
+    const info = {
+      plate: c.analysis?.vehicle?.licensePlateNumber ?? "",
+      state: c.analysis?.vehicle?.licensePlateState ?? "",
+      vin: c.vinOverride ?? c.vin ?? undefined,
+    };
+    const pdfPath = await fillIlForm(info);
+    const data = fs.readFileSync(pdfPath);
+    fs.rmSync(pdfPath);
+    return new NextResponse(data, {
+      headers: { "Content-Type": "application/pdf" },
+    });
+  },
+);

--- a/src/app/cases/[id]/ownership/OwnershipEditor.tsx
+++ b/src/app/cases/[id]/ownership/OwnershipEditor.tsx
@@ -8,9 +8,11 @@ import { useNotify } from "../../../components/NotificationProvider";
 export default function OwnershipEditor({
   caseId,
   module,
+  showPdf = false,
 }: {
   caseId: string;
   module: Omit<OwnershipModule, "requestVin" | "requestContactInfo">;
+  showPdf?: boolean;
 }) {
   const [checkNumber, setCheckNumber] = useState("");
   const [snailMail, setSnailMail] = useState(false);
@@ -40,6 +42,13 @@ export default function OwnershipEditor({
       <pre className="bg-gray-100 dark:bg-gray-800 p-2 whitespace-pre-wrap">
         {module.address}
       </pre>
+      {showPdf ? (
+        <iframe
+          src={`/api/cases/${caseId}/ownership-form`}
+          className="w-full h-96 border"
+          title="Ownership form"
+        />
+      ) : null}
       <label className="flex flex-col">
         {t("checkNumberLabel")}
         <input

--- a/src/app/cases/[id]/ownership/page.tsx
+++ b/src/app/cases/[id]/ownership/page.tsx
@@ -25,13 +25,14 @@ export default async function OwnershipPage({
       <div className="p-8">{t("noOwnershipModule", { label, supported })}</div>
     );
   }
-  const { requestVin: _rv, requestContactInfo: _rc, ...clientMod } = mod;
+  const { requestVin: _rv, requestContactInfo: rc, ...clientMod } = mod;
   return (
     <OwnershipEditor
       caseId={id}
       module={
         clientMod as Omit<OwnershipModule, "requestVin" | "requestContactInfo">
       }
+      showPdf={Boolean(rc)}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add route to generate Illinois request PDF
- show the PDF on the ownership page when the module supports contact info request

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke` *(fails: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_686571dd8080832b8e5fafc1b9fd6419