### PR TITLE
Display filled ownership request PDF

### DIFF
--- a/src/app/api/cases/[id]/ownership-form/route.ts
+++ b/src/app/api/cases/[id]/ownership-form/route.ts
@@ -1,0 +1,32 @@
+import fs from "node:fs";
+
+import { withCaseAuthorization } from "@/lib/authz";
+import { getCase } from "@/lib/caseStore";
+import {
+  getCasePlateNumber,
+  getCasePlateState,
+  getCaseVin,
+} from "@/lib/caseUtils";
+import { fillIlForm } from "@/lib/ownershipModules";
+
+export const GET = withCaseAuthorization(
+  { obj: "cases" },
+  async (_req: Request, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const c = getCase(id);
+    if (!c) return new Response(null, { status: 404 });
+    const state = getCasePlateState(c)?.toLowerCase();
+    if (state !== "il") {
+      return new Response("Unsupported", { status: 400 });
+    }
+    const pdfPath = await fillIlForm({
+      plate: getCasePlateNumber(c) ?? "",
+      state: state.toUpperCase(),
+      vin: getCaseVin(c),
+    });
+    const bytes = fs.readFileSync(pdfPath);
+    return new Response(bytes, {
+      headers: { "Content-Type": "application/pdf" },
+    });
+  },
+);

--- a/src/app/cases/[id]/ownership/OwnershipEditor.tsx
+++ b/src/app/cases/[id]/ownership/OwnershipEditor.tsx
@@ -8,9 +8,11 @@ import { useNotify } from "../../../components/NotificationProvider";
 export default function OwnershipEditor({
   caseId,
   module,
+  pdfUrl,
 }: {
   caseId: string;
   module: Omit<OwnershipModule, "requestVin" | "requestContactInfo">;
+  pdfUrl?: string;
 }) {
   const [checkNumber, setCheckNumber] = useState("");
   const [snailMail, setSnailMail] = useState(false);
@@ -64,6 +66,13 @@ export default function OwnershipEditor({
       >
         {t("markRequested")}
       </button>
+      {pdfUrl ? (
+        <iframe
+          src={pdfUrl}
+          className="w-full h-[600px] border"
+          title="Ownership Request PDF"
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/app/cases/[id]/ownership/page.tsx
+++ b/src/app/cases/[id]/ownership/page.tsx
@@ -25,12 +25,15 @@ export default async function OwnershipPage({
       <div className="p-8">{t("noOwnershipModule", { label, supported })}</div>
     );
   }
-  const { requestVin: _rv, requestContactInfo: _rc, ...clientMod } = mod;
+  const { requestVin: _rv, requestContactInfo, ...clientMod } = mod;
   return (
     <OwnershipEditor
       caseId={id}
       module={
         clientMod as Omit<OwnershipModule, "requestVin" | "requestContactInfo">
+      }
+      pdfUrl={
+        requestContactInfo ? `/api/cases/${id}/ownership-form` : undefined
       }
     />
   );


### PR DESCRIPTION
## Summary
- add API route to generate IL ownership request PDF
- allow `OwnershipEditor` to show an iframe with the filled PDF
- show PDF viewer on case ownership page when contact info module exists

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686571dd8080832b8e5fafc1b9fd6419