### PR TITLE
fix date assertion in admin page test

### DIFF
--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -94,10 +94,11 @@ describe("AdminPageClient", () => {
       ok: true,
       json: async () => users,
     } as Response);
+    const deployTime = "2024-01-01T00:00:00Z";
     (window as unknown as { PUBLIC_ENV?: unknown }).PUBLIC_ENV = {
       NEXT_PUBLIC_APP_COMMIT: "abc123",
       NEXT_PUBLIC_APP_VERSION: "1.0.0",
-      NEXT_PUBLIC_DEPLOY_TIME: "2024-01-01T00:00:00Z",
+      NEXT_PUBLIC_DEPLOY_TIME: deployTime,
     };
     render(
       <QueryClientProvider client={queryClient}>
@@ -106,7 +107,9 @@ describe("AdminPageClient", () => {
     );
     expect(screen.getByText(/abc123/)).toBeInTheDocument();
     expect(screen.getByText(/1.0.0/)).toBeInTheDocument();
-    expect(screen.getByText(/2024/)).toBeInTheDocument();
+    const expectedDate = new Date(deployTime).toLocaleString();
+    const escaped = expectedDate.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    expect(screen.getByText(new RegExp(escaped))).toBeInTheDocument();
   });
 
   it("updates user role without reload", async () => {

--- a/src/lib/ownershipModules.ts
+++ b/src/lib/ownershipModules.ts
@@ -63,11 +63,7 @@ async function mailPdf(address: string, pdfPath: string): Promise<void> {
 }
 
 export async function fillIlForm(info: OwnershipRequestInfo): Promise<string> {
-  const formPath = path.resolve(path.join(
-    "forms",
-    "il",
-    "vsd375.pdf",
-  ));
+  const formPath = path.resolve(path.join("forms", "il", "vsd375.pdf"));
   const bytes = fs.readFileSync(formPath);
   const pdf = await PDFDocument.load(new Uint8Array(bytes));
   const form = pdf.getForm();


### PR DESCRIPTION
## Summary
- fix AdminPageClient test to account for timezone by formatting the expected date
- format ownershipModules

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68659e33ccac832b9fe008afb1315efe