### PR TITLE
fix: respect runtime email override

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -66,7 +66,9 @@ const envSchema = z
 
 export type Config = z.infer<typeof envSchema>;
 export function getConfig(): Config {
-  return envSchema.parse(process.env);
+  const cfg = envSchema.parse(process.env);
+  if (cfg.MOCK_EMAIL_TO === "") cfg.MOCK_EMAIL_TO = undefined;
+  return cfg;
 }
 // For NEXT_PUBLIC_* variables we must reference them directly so Next.js can
 // inline them for client-side usage. When using the dev server a full page


### PR DESCRIPTION
## Summary
- ignore empty `MOCK_EMAIL_TO` env var in config

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`
- `npx vitest run -c vitest.e2e.config.ts test/e2e/email.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_686628cf91f4832badf1cb7a9f743aa4