### PR TITLE
Fix admin deployment info hydration

### DIFF
--- a/src/app/admin/AdminDeploymentInfo.tsx
+++ b/src/app/admin/AdminDeploymentInfo.tsx
@@ -1,0 +1,45 @@
+import { initI18n } from "@/i18n.server";
+import { config } from "@/lib/config";
+import { cookies, headers } from "next/headers";
+
+export default async function AdminDeploymentInfo() {
+  const cookieStore = await cookies();
+  let lang = cookieStore.get("language")?.value;
+  if (!lang) {
+    const accept = (await headers()).get("accept-language") ?? "";
+    const supported = ["en", "es", "fr"];
+    for (const part of accept.split(",")) {
+      const code = part.split(";")[0].trim().toLowerCase().split("-")[0];
+      if (supported.includes(code)) {
+        lang = code;
+        break;
+      }
+    }
+    lang = lang ?? "en";
+  }
+  const { t } = await initI18n(lang);
+  const {
+    NEXT_PUBLIC_DEPLOY_TIME,
+    NEXT_PUBLIC_APP_COMMIT,
+    NEXT_PUBLIC_APP_VERSION,
+  } = config;
+  return (
+    <div className="mt-4 text-sm text-gray-600 dark:text-gray-400 space-y-1">
+      <p>
+        {t("admin.deployedAt", {
+          date: NEXT_PUBLIC_DEPLOY_TIME ?? t("unknown"),
+        })}
+      </p>
+      <p>
+        {t("admin.deployCommit", {
+          commit: NEXT_PUBLIC_APP_COMMIT ?? t("unknown"),
+        })}
+      </p>
+      <p>
+        {t("admin.deployVersion", {
+          version: NEXT_PUBLIC_APP_VERSION ?? t("unknown"),
+        })}
+      </p>
+    </div>
+  );
+}

--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -2,7 +2,6 @@
 import { apiFetch } from "@/apiClient";
 import { useSession } from "@/app/useSession";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { getPublicEnv } from "@/publicEnv";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -218,268 +217,225 @@ export default function AdminPageClient({
   });
 
   const { t } = useTranslation();
-  const {
-    NEXT_PUBLIC_APP_COMMIT,
-    NEXT_PUBLIC_APP_VERSION,
-    NEXT_PUBLIC_DEPLOY_TIME,
-  } = getPublicEnv();
   return (
-    <div className="p-8">
-      <Tabs
-        value={tab}
-        onValueChange={(v) => {
-          setTab(v as "users" | "config");
-          router.replace(`?tab=${v}`);
-        }}
-      >
-        <TabsList className="mb-4 flex gap-4 border-b">
-          <TabsTrigger value="users">{t("admin.userManagement")}</TabsTrigger>
-          <TabsTrigger value="config">
-            {t("admin.appConfiguration")}
-          </TabsTrigger>
-        </TabsList>
-        <TabsContent value="users">
-          <>
-            <h1 className="text-xl font-bold mb-4">{t("admin.users")}</h1>
-            <div className="mb-4 flex gap-2">
-              <input
-                type="email"
-                value={inviteEmail}
-                onChange={(e) => setInviteEmail(e.target.value)}
-                className="border rounded p-1 bg-white dark:bg-gray-900"
-              />
-              <button
-                type="button"
-                onClick={() => inviteMutation.mutate()}
-                className="bg-blue-600 text-white px-2 py-1 rounded"
-              >
-                {t("admin.invite")}
-              </button>
-            </div>
-            <ul className="grid gap-2">
-              {users.map((u) => (
-                <li key={u.id} className="flex items-center gap-2">
-                  <span className="flex-1">{u.email ?? u.id}</span>
-                  <select
-                    value={u.role}
-                    onChange={(e) =>
-                      changeRoleMutation.mutate({
-                        id: u.id,
-                        role: e.target.value,
-                      })
-                    }
-                    className="border rounded p-1 bg-white dark:bg-gray-900"
-                  >
-                    <option value="user">user</option>
-                    <option value="admin">admin</option>
-                    <option value="superadmin">superadmin</option>
-                    <option value="disabled">disabled</option>
-                  </select>
-                  {u.role !== "disabled" && (
-                    <button
-                      type="button"
-                      onClick={() => disableMutation.mutate(u.id)}
-                      className="bg-yellow-500 text-white px-2 py-1 rounded"
-                    >
-                      {t("admin.disable")}
-                    </button>
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => removeMutation.mutate(u.id)}
-                    className="bg-red-500 text-white px-2 py-1 rounded"
-                  >
-                    {t("admin.delete")}
-                  </button>
-                </li>
-              ))}
-            </ul>
-            <h1 className="text-xl font-bold my-4">{t("admin.casbinRules")}</h1>
-            <table className="mb-2 border-collapse w-full">
-              <thead>
-                <tr>
-                  <th className="border px-1">ptype</th>
-                  <th className="border px-1">v0</th>
-                  <th className="border px-1">v1</th>
-                  <th className="border px-1">v2</th>
-                  <th className="border px-1">v3</th>
-                  <th className="border px-1">v4</th>
-                  <th className="border px-1">v5</th>
-                  <th className="border px-1" />
-                </tr>
-              </thead>
-              <tbody>
-                {rules.map((r) => {
-                  const ptypeOptions = ["p", "g"];
-                  const v0Options =
-                    r.ptype === "p"
-                      ? Object.keys(policyOptions)
-                      : Object.keys(groupOptions);
-                  const v1Options =
-                    r.ptype === "p"
-                      ? r.v0
-                        ? Object.keys(
-                            policyOptions[r.v0 as keyof typeof policyOptions] ??
-                              {},
-                          )
-                        : []
-                      : r.v0
-                        ? (groupOptions[r.v0 as keyof typeof groupOptions] ??
-                          [])
-                        : [];
-                  const v2Options =
-                    r.ptype === "p" && r.v0 && r.v1
-                      ? (policyOptions[r.v0 as keyof typeof policyOptions][
-                          r.v1 as keyof (typeof policyOptions)[keyof typeof policyOptions]
-                        ] ?? [])
-                      : [];
-                  return (
-                    <tr key={r.id}>
-                      <td className="border">
-                        <select
-                          value={r.ptype}
-                          onChange={(e) =>
-                            updateRule(r.id, "ptype", e.target.value)
-                          }
-                          className="w-full p-1 bg-white dark:bg-gray-900"
-                        >
-                          {ptypeOptions.map((o) => (
-                            <option key={o} value={o}>
-                              {o}
-                            </option>
-                          ))}
-                        </select>
-                      </td>
-                      <td className="border">
-                        <select
-                          value={r.v0 ?? ""}
-                          onChange={(e) =>
-                            updateRule(r.id, "v0", e.target.value)
-                          }
-                          className="w-full p-1 bg-white dark:bg-gray-900"
-                        >
-                          {v0Options.map((o) => (
-                            <option key={o} value={o}>
-                              {o}
-                            </option>
-                          ))}
-                        </select>
-                      </td>
-                      <td className="border">
-                        <select
-                          value={r.v1 ?? ""}
-                          onChange={(e) =>
-                            updateRule(r.id, "v1", e.target.value)
-                          }
-                          className="w-full p-1 bg-white dark:bg-gray-900"
-                        >
-                          {v1Options.map((o) => (
-                            <option key={o} value={o}>
-                              {o}
-                            </option>
-                          ))}
-                        </select>
-                      </td>
-                      <td className="border">
-                        <select
-                          value={r.v2 ?? ""}
-                          onChange={(e) =>
-                            updateRule(r.id, "v2", e.target.value)
-                          }
-                          className="w-full p-1 bg-white dark:bg-gray-900"
-                        >
-                          {v2Options.map((o) => (
-                            <option key={o} value={o}>
-                              {o}
-                            </option>
-                          ))}
-                        </select>
-                      </td>
-                      <td className="border">
-                        <input
-                          value={r.v3 ?? ""}
-                          onChange={(e) =>
-                            updateRule(r.id, "v3", e.target.value)
-                          }
-                          className="w-full p-1 bg-white dark:bg-gray-900"
-                        />
-                      </td>
-                      <td className="border">
-                        <input
-                          value={r.v4 ?? ""}
-                          onChange={(e) =>
-                            updateRule(r.id, "v4", e.target.value)
-                          }
-                          className="w-full p-1 bg-white dark:bg-gray-900"
-                        />
-                      </td>
-                      <td className="border">
-                        <input
-                          value={r.v5 ?? ""}
-                          onChange={(e) =>
-                            updateRule(r.id, "v5", e.target.value)
-                          }
-                          className="w-full p-1 bg-white dark:bg-gray-900"
-                        />
-                      </td>
-                      <td className="border">
-                        <button
-                          type="button"
-                          onClick={() => removeRule(r.id)}
-                          className="bg-red-500 text-white px-2 py-1 rounded"
-                        >
-                          Delete
-                        </button>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-            <div className="flex gap-2 mb-2">
-              <button
-                type="button"
-                onClick={addRule}
-                className="bg-green-600 text-white px-2 py-1 rounded"
-              >
-                {t("admin.addRule")}
-              </button>
-            </div>
+    <Tabs
+      value={tab}
+      onValueChange={(v) => {
+        setTab(v as "users" | "config");
+        router.replace(`?tab=${v}`);
+      }}
+    >
+      <TabsList className="mb-4 flex gap-4 border-b">
+        <TabsTrigger value="users">{t("admin.userManagement")}</TabsTrigger>
+        <TabsTrigger value="config">{t("admin.appConfiguration")}</TabsTrigger>
+      </TabsList>
+      <TabsContent value="users">
+        <>
+          <h1 className="text-xl font-bold mb-4">{t("admin.users")}</h1>
+          <div className="mb-4 flex gap-2">
+            <input
+              type="email"
+              value={inviteEmail}
+              onChange={(e) => setInviteEmail(e.target.value)}
+              className="border rounded p-1 bg-white dark:bg-gray-900"
+            />
             <button
               type="button"
-              onClick={() => saveRulesMutation.mutate()}
-              disabled={!isSuperadmin}
-              className="bg-blue-600 text-white px-2 py-1 rounded disabled:opacity-50"
+              onClick={() => inviteMutation.mutate()}
+              className="bg-blue-600 text-white px-2 py-1 rounded"
             >
-              {t("admin.saveRules")}
+              {t("admin.invite")}
             </button>
-          </>
-        </TabsContent>
-        <TabsContent value="config">
-          <AppConfigurationTab />
-        </TabsContent>
-      </Tabs>
-      {isSuperadmin && (
-        <div className="mt-4 text-sm text-gray-600 dark:text-gray-400 space-y-1">
-          <p>
-            {t("admin.deployedAt", {
-              date: NEXT_PUBLIC_DEPLOY_TIME
-                ? new Date(NEXT_PUBLIC_DEPLOY_TIME).toLocaleString()
-                : t("unknown"),
-            })}
-          </p>
-          <p>
-            {t("admin.deployCommit", {
-              commit: NEXT_PUBLIC_APP_COMMIT ?? t("unknown"),
-            })}
-          </p>
-          <p>
-            {t("admin.deployVersion", {
-              version: NEXT_PUBLIC_APP_VERSION ?? t("unknown"),
-            })}
-          </p>
-        </div>
-      )}
-    </div>
+          </div>
+          <ul className="grid gap-2">
+            {users.map((u) => (
+              <li key={u.id} className="flex items-center gap-2">
+                <span className="flex-1">{u.email ?? u.id}</span>
+                <select
+                  value={u.role}
+                  onChange={(e) =>
+                    changeRoleMutation.mutate({
+                      id: u.id,
+                      role: e.target.value,
+                    })
+                  }
+                  className="border rounded p-1 bg-white dark:bg-gray-900"
+                >
+                  <option value="user">user</option>
+                  <option value="admin">admin</option>
+                  <option value="superadmin">superadmin</option>
+                  <option value="disabled">disabled</option>
+                </select>
+                {u.role !== "disabled" && (
+                  <button
+                    type="button"
+                    onClick={() => disableMutation.mutate(u.id)}
+                    className="bg-yellow-500 text-white px-2 py-1 rounded"
+                  >
+                    {t("admin.disable")}
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => removeMutation.mutate(u.id)}
+                  className="bg-red-500 text-white px-2 py-1 rounded"
+                >
+                  {t("admin.delete")}
+                </button>
+              </li>
+            ))}
+          </ul>
+          <h1 className="text-xl font-bold my-4">{t("admin.casbinRules")}</h1>
+          <table className="mb-2 border-collapse w-full">
+            <thead>
+              <tr>
+                <th className="border px-1">ptype</th>
+                <th className="border px-1">v0</th>
+                <th className="border px-1">v1</th>
+                <th className="border px-1">v2</th>
+                <th className="border px-1">v3</th>
+                <th className="border px-1">v4</th>
+                <th className="border px-1">v5</th>
+                <th className="border px-1" />
+              </tr>
+            </thead>
+            <tbody>
+              {rules.map((r) => {
+                const ptypeOptions = ["p", "g"];
+                const v0Options =
+                  r.ptype === "p"
+                    ? Object.keys(policyOptions)
+                    : Object.keys(groupOptions);
+                const v1Options =
+                  r.ptype === "p"
+                    ? r.v0
+                      ? Object.keys(
+                          policyOptions[r.v0 as keyof typeof policyOptions] ??
+                            {},
+                        )
+                      : []
+                    : r.v0
+                      ? (groupOptions[r.v0 as keyof typeof groupOptions] ?? [])
+                      : [];
+                const v2Options =
+                  r.ptype === "p" && r.v0 && r.v1
+                    ? (policyOptions[r.v0 as keyof typeof policyOptions][
+                        r.v1 as keyof (typeof policyOptions)[keyof typeof policyOptions]
+                      ] ?? [])
+                    : [];
+                return (
+                  <tr key={r.id}>
+                    <td className="border">
+                      <select
+                        value={r.ptype}
+                        onChange={(e) =>
+                          updateRule(r.id, "ptype", e.target.value)
+                        }
+                        className="w-full p-1 bg-white dark:bg-gray-900"
+                      >
+                        {ptypeOptions.map((o) => (
+                          <option key={o} value={o}>
+                            {o}
+                          </option>
+                        ))}
+                      </select>
+                    </td>
+                    <td className="border">
+                      <select
+                        value={r.v0 ?? ""}
+                        onChange={(e) => updateRule(r.id, "v0", e.target.value)}
+                        className="w-full p-1 bg-white dark:bg-gray-900"
+                      >
+                        {v0Options.map((o) => (
+                          <option key={o} value={o}>
+                            {o}
+                          </option>
+                        ))}
+                      </select>
+                    </td>
+                    <td className="border">
+                      <select
+                        value={r.v1 ?? ""}
+                        onChange={(e) => updateRule(r.id, "v1", e.target.value)}
+                        className="w-full p-1 bg-white dark:bg-gray-900"
+                      >
+                        {v1Options.map((o) => (
+                          <option key={o} value={o}>
+                            {o}
+                          </option>
+                        ))}
+                      </select>
+                    </td>
+                    <td className="border">
+                      <select
+                        value={r.v2 ?? ""}
+                        onChange={(e) => updateRule(r.id, "v2", e.target.value)}
+                        className="w-full p-1 bg-white dark:bg-gray-900"
+                      >
+                        {v2Options.map((o) => (
+                          <option key={o} value={o}>
+                            {o}
+                          </option>
+                        ))}
+                      </select>
+                    </td>
+                    <td className="border">
+                      <input
+                        value={r.v3 ?? ""}
+                        onChange={(e) => updateRule(r.id, "v3", e.target.value)}
+                        className="w-full p-1 bg-white dark:bg-gray-900"
+                      />
+                    </td>
+                    <td className="border">
+                      <input
+                        value={r.v4 ?? ""}
+                        onChange={(e) => updateRule(r.id, "v4", e.target.value)}
+                        className="w-full p-1 bg-white dark:bg-gray-900"
+                      />
+                    </td>
+                    <td className="border">
+                      <input
+                        value={r.v5 ?? ""}
+                        onChange={(e) => updateRule(r.id, "v5", e.target.value)}
+                        className="w-full p-1 bg-white dark:bg-gray-900"
+                      />
+                    </td>
+                    <td className="border">
+                      <button
+                        type="button"
+                        onClick={() => removeRule(r.id)}
+                        className="bg-red-500 text-white px-2 py-1 rounded"
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          <div className="flex gap-2 mb-2">
+            <button
+              type="button"
+              onClick={addRule}
+              className="bg-green-600 text-white px-2 py-1 rounded"
+            >
+              {t("admin.addRule")}
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => saveRulesMutation.mutate()}
+            disabled={!isSuperadmin}
+            className="bg-blue-600 text-white px-2 py-1 rounded disabled:opacity-50"
+          >
+            {t("admin.saveRules")}
+          </button>
+        </>
+      </TabsContent>
+      <TabsContent value="config">
+        <AppConfigurationTab />
+      </TabsContent>
+    </Tabs>
   );
 }

--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -86,32 +86,6 @@ describe("AdminPageClient", () => {
     ).not.toBeDisabled();
   });
 
-  it("shows deployment info for superadmins", () => {
-    vi.mocked(useSession).mockReturnValueOnce({
-      data: { user: { role: "superadmin" }, expires: "0" },
-    } as unknown as ReturnType<typeof useSessionFn>);
-    vi.mocked(apiFetch).mockResolvedValue({
-      ok: true,
-      json: async () => users,
-    } as Response);
-    const deployTime = "2024-01-01T00:00:00Z";
-    (window as unknown as { PUBLIC_ENV?: unknown }).PUBLIC_ENV = {
-      NEXT_PUBLIC_APP_COMMIT: "abc123",
-      NEXT_PUBLIC_APP_VERSION: "1.0.0",
-      NEXT_PUBLIC_DEPLOY_TIME: deployTime,
-    };
-    render(
-      <QueryClientProvider client={queryClient}>
-        <AdminPageClient initialUsers={users} initialRules={rules} />
-      </QueryClientProvider>,
-    );
-    expect(screen.getByText(/abc123/)).toBeInTheDocument();
-    expect(screen.getByText(/1.0.0/)).toBeInTheDocument();
-    const expectedDate = new Date(deployTime).toLocaleString();
-    const escaped = expectedDate.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    expect(screen.getByText(new RegExp(escaped))).toBeInTheDocument();
-  });
-
   it("updates user role without reload", async () => {
     vi.mocked(apiFetch).mockReset();
     vi.mocked(apiFetch).mockResolvedValueOnce({

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -4,6 +4,7 @@ import { withAuthorization } from "@/lib/authz";
 import { log } from "@/lib/logger";
 import { getServerSession } from "next-auth/next";
 import type { ReactElement } from "react";
+import AdminDeploymentInfo from "./AdminDeploymentInfo";
 import AdminPageClient from "./AdminPageClient";
 
 export const dynamic = "force-dynamic";
@@ -36,12 +37,16 @@ const handler = withAuthorization<
     const rules = getCasbinRules();
     const { tab } = (await searchParams) ?? {};
     const t = tab === "config" ? "config" : "users";
+    const isSuperadmin = s?.user?.role === "superadmin";
     return (
-      <AdminPageClient
-        initialUsers={users}
-        initialRules={rules}
-        initialTab={t}
-      />
+      <div className="p-8">
+        <AdminPageClient
+          initialUsers={users}
+          initialRules={rules}
+          initialTab={t}
+        />
+        {isSuperadmin && <AdminDeploymentInfo />}
+      </div>
     );
   },
 );


### PR DESCRIPTION
## Summary
- render deployment metadata with a new `AdminDeploymentInfo` server component
- place deployment info component below the tabs in admin page
- remove client-side deployment info and related test

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68668a976168832bbe5b5c8cd80bc379