### PR TITLE
Implement ownership request threads

### DIFF
--- a/src/app/api/cases/[id]/ownership-request/route.ts
+++ b/src/app/api/cases/[id]/ownership-request/route.ts
@@ -1,8 +1,13 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { NextResponse } from "next/server";
+
 import { withCaseAuthorization } from "@/lib/authz";
-import { addOwnershipRequest, getCase } from "@/lib/caseStore";
+import { addCaseEmail, addOwnershipRequest, getCase } from "@/lib/caseStore";
+import { config } from "@/lib/config";
 import { sendSnailMail } from "@/lib/contactMethods";
 import { ownershipModules } from "@/lib/ownershipModules";
-import { NextResponse } from "next/server";
 
 export const POST = withCaseAuthorization(
   { obj: "cases", act: "update" },
@@ -30,32 +35,50 @@ export const POST = withCaseAuthorization(
     if (!updated) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
-    if (snailMail) {
-      const mod = ownershipModules[moduleId];
-      if (mod?.address) {
-        let attachments: string[] = [];
-        if (mod.generateForms) {
-          const c = getCase(id);
-          if (c) {
-            const info = {
-              plate: c.analysis?.vehicle?.licensePlateNumber ?? "",
-              state: c.analysis?.vehicle?.licensePlateState ?? "",
-              vin: c.vinOverride ?? c.vin ?? undefined,
-            };
-            const result = await mod.generateForms(info);
-            attachments = attachments.concat(
-              Array.isArray(result) ? result : [result],
-            );
-          }
-        }
-        await sendSnailMail({
-          address: mod.address,
-          subject: "Ownership information request",
-          body: `Check number: ${checkNumber ?? ""}`,
-          attachments,
-        });
+    const mod = ownershipModules[moduleId];
+    let attachments: string[] = [];
+    if (mod?.generateForms) {
+      const c = getCase(id);
+      if (c) {
+        const info = {
+          plate: c.analysis?.vehicle?.licensePlateNumber ?? "",
+          state: c.analysis?.vehicle?.licensePlateState ?? "",
+          vin: c.vinOverride ?? c.vin ?? undefined,
+        };
+        const result = await mod.generateForms(info);
+        attachments = attachments.concat(
+          Array.isArray(result) ? result : [result],
+        );
       }
     }
-    return NextResponse.json(updated);
+    if (snailMail && mod?.address) {
+      await sendSnailMail({
+        address: mod.address,
+        subject: "Ownership information request",
+        body: `Check number: ${checkNumber ?? ""}`,
+        attachments,
+      });
+    }
+    const storedAttachments: string[] = [];
+    for (const att of attachments) {
+      if (path.isAbsolute(att)) {
+        const dest = path.join(config.UPLOAD_DIR, path.basename(att));
+        try {
+          fs.copyFileSync(att, dest);
+          storedAttachments.push(path.basename(att));
+        } catch {}
+      } else {
+        storedAttachments.push(att);
+      }
+    }
+    const withEmail = addCaseEmail(id, {
+      to: mod?.address ?? "",
+      subject: "Ownership information request",
+      body: `Check number: ${checkNumber ?? ""}`,
+      attachments: storedAttachments,
+      sentAt: new Date().toISOString(),
+      replyTo: null,
+    });
+    return NextResponse.json({ case: withEmail ?? updated });
   },
 );

--- a/test/e2e/flows.test.ts
+++ b/test/e2e/flows.test.ts
@@ -188,6 +188,10 @@ describe("e2e flows (unauthenticated)", () => {
       body: JSON.stringify({ moduleId: "il", checkNumber: "42" }),
     });
     expect(ownRes.status).toBe(200);
+    const ownData = (await ownRes.json()) as {
+      case: { sentEmails?: unknown[] };
+    };
+    expect(Array.isArray(ownData.case.sentEmails)).toBe(true);
 
     const delCase = await api(`/api/cases/${caseId}`, {
       method: "DELETE",


### PR DESCRIPTION
## Summary
- log ownership request snail mail as a case thread
- redirect to the new thread after requesting ownership info
- expect thread data from ownership request API

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`

------
https://chatgpt.com/codex/tasks/task_e_68668a148ecc832b88c3fa5850557f35