### PR TITLE
feat: centralize SSE handling

### DIFF
--- a/src/app/components/CaseJobList.tsx
+++ b/src/app/components/CaseJobList.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { apiEventSource } from "@/apiClient";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import useEventSource from "../hooks/useEventSource";
 
 interface JobInfo {
   id: number;
@@ -27,19 +27,14 @@ export default function CaseJobList({
   const [updatedAt, setUpdatedAt] = useState<number>(0);
   const { t } = useTranslation();
 
-  useEffect(() => {
-    const base = isPublic ? "/api/public/cases" : "/api/cases";
-    const es = apiEventSource(
-      `${base}/${encodeURIComponent(caseId)}/jobs/stream`,
-    );
-    es.onmessage = (e) => {
-      const data: JobResponse = JSON.parse(e.data);
+  useEventSource<JobResponse>(
+    `${isPublic ? "/api/public/cases" : "/api/cases"}/${encodeURIComponent(caseId)}/jobs/stream`,
+    (data) => {
       setJobs(data.jobs);
       setAuditedAt(data.auditedAt);
       setUpdatedAt(data.updatedAt);
-    };
-    return () => es.close();
-  }, [caseId, isPublic]);
+    },
+  );
 
   if (jobs.length === 0) {
     return null;

--- a/src/app/hooks/useEventSource.ts
+++ b/src/app/hooks/useEventSource.ts
@@ -1,0 +1,25 @@
+import { apiEventSource } from "@/apiClient";
+import { useCallback, useEffect } from "react";
+
+export default function useEventSource<T>(
+  url: string | null,
+  onData: (data: T) => void,
+) {
+  const handleMessage = useCallback(
+    (e: MessageEvent<string>) => {
+      try {
+        onData(JSON.parse(e.data) as T);
+      } catch {
+        // ignore invalid JSON
+      }
+    },
+    [onData],
+  );
+
+  useEffect(() => {
+    if (!url) return;
+    const es = apiEventSource(url);
+    es.onmessage = handleMessage;
+    return () => es.close();
+  }, [url, handleMessage]);
+}

--- a/src/app/system-status/SystemStatusClient.tsx
+++ b/src/app/system-status/SystemStatusClient.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { apiEventSource } from "@/apiClient";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import useEventSource from "../hooks/useEventSource";
 
 interface JobInfo {
   id: number;
@@ -23,20 +23,16 @@ export default function SystemStatusClient() {
   const [filter, setFilter] = useState<string>("");
   const { t } = useTranslation();
 
-  useEffect(() => {
-    const url =
-      filter !== ""
-        ? `/api/system/jobs/stream?type=${encodeURIComponent(filter)}`
-        : "/api/system/jobs/stream";
-    const es = apiEventSource(url);
-    es.onmessage = (e) => {
-      const data: JobResponse = JSON.parse(e.data);
+  useEventSource<JobResponse>(
+    filter !== ""
+      ? `/api/system/jobs/stream?type=${encodeURIComponent(filter)}`
+      : "/api/system/jobs/stream",
+    (data) => {
       setJobs(data.jobs);
       setAuditedAt(data.auditedAt);
       setUpdatedAt(data.updatedAt);
-    };
-    return () => es.close();
-  }, [filter]);
+    },
+  );
 
   const types = Array.from(new Set(jobs.map((j) => j.type)));
 


### PR DESCRIPTION
## Summary
- add `useEventSource` hook for consistent SSE logic
- refactor SSE listeners in client components

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68668aceec8c832b8f10cc04416776a9