### PR TITLE
Refactor admin page into modular components

### DIFF
--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -1,67 +1,15 @@
 "use client";
-import { apiFetch } from "@/apiClient";
 import { useSession } from "@/app/useSession";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import AppConfigurationTab from "./AppConfigurationTab";
-
-const policyOptions = {
-  anonymous: { public_cases: ["read"] },
-  user: {
-    upload: ["create"],
-    cases: ["read", "update", "delete"],
-    snail_mail_providers: ["read"],
-    vin_sources: ["read"],
-  },
-  admin: {
-    admin: ["read", "update"],
-    users: ["create", "read", "update", "delete"],
-    cases: ["update", "delete"],
-    snail_mail_providers: ["update"],
-    vin_sources: ["update"],
-  },
-  superadmin: { superadmin: ["read", "update"] },
-} as const;
-
-const groupOptions = {
-  admin: ["user"],
-  superadmin: ["admin"],
-} as const;
-
-function normalizeRule(rule: RuleInput): RuleInput {
-  if (rule.ptype === "p") {
-    const v0s = Object.keys(policyOptions) as Array<keyof typeof policyOptions>;
-    if (!rule.v0 || !v0s.includes(rule.v0 as keyof typeof policyOptions))
-      rule.v0 = v0s[0];
-    const v1s = Object.keys(
-      policyOptions[rule.v0 as keyof typeof policyOptions],
-    ) as Array<keyof (typeof policyOptions)[keyof typeof policyOptions]>;
-    if (
-      !rule.v1 ||
-      !v1s.includes(
-        rule.v1 as keyof (typeof policyOptions)[keyof typeof policyOptions],
-      )
-    )
-      rule.v1 = v1s[0];
-    const v2s = policyOptions[rule.v0 as keyof typeof policyOptions][
-      rule.v1 as keyof (typeof policyOptions)[keyof typeof policyOptions]
-    ] as readonly string[];
-    if (!rule.v2 || !v2s.includes(rule.v2)) rule.v2 = v2s[0];
-  } else {
-    const v0s = Object.keys(groupOptions) as Array<keyof typeof groupOptions>;
-    if (!rule.v0 || !v0s.includes(rule.v0 as keyof typeof groupOptions))
-      rule.v0 = v0s[0];
-    const v1s = groupOptions[
-      rule.v0 as keyof typeof groupOptions
-    ] as readonly string[];
-    if (!rule.v1 || !v1s.includes(rule.v1)) rule.v1 = v1s[0];
-    rule.v2 = null;
-  }
-  return rule;
-}
+import InviteUserForm from "./components/InviteUserForm";
+import RulesTable from "./components/RulesTable";
+import UsersTable from "./components/UsersTable";
+import { useCasbinRules } from "./hooks/useCasbinRules";
+import { useUsers } from "./hooks/useUsers";
 
 export interface UserRecord {
   id: string;
@@ -83,8 +31,6 @@ export interface CasbinRule {
 
 export type RuleInput = Omit<CasbinRule, "id">;
 
-const USERS_QUERY_KEY = ["/api/users"] as const;
-
 export default function AdminPageClient({
   initialUsers,
   initialRules,
@@ -94,129 +40,17 @@ export default function AdminPageClient({
   initialRules: RuleInput[];
   initialTab?: "users" | "config";
 }) {
-  const queryClient = useQueryClient();
-  const { data: users = [] } = useQuery<UserRecord[]>({
-    queryKey: USERS_QUERY_KEY,
-    initialData: initialUsers,
-  });
-  const [rules, setRules] = useState(() =>
-    initialRules.map((r) => ({ ...normalizeRule(r), id: crypto.randomUUID() })),
-  );
   const router = useRouter();
   const [tab, setTab] = useState<"users" | "config">(initialTab);
-  const [inviteEmail, setInviteEmail] = useState("");
   const { data: session } = useSession();
-  const isSuperadmin = session?.user?.role === "superadmin";
 
-  const inviteMutation = useMutation({
-    async mutationFn() {
-      await apiFetch("/api/users/invite", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: inviteEmail }),
-      });
-    },
-    onSuccess() {
-      setInviteEmail("");
-      queryClient.invalidateQueries({ queryKey: USERS_QUERY_KEY });
-    },
-  });
-
-  const disableMutation = useMutation({
-    async mutationFn(id: string) {
-      await apiFetch(`/api/users/${id}/disable`, { method: "PUT" });
-    },
-    onSuccess() {
-      queryClient.invalidateQueries({ queryKey: USERS_QUERY_KEY });
-    },
-  });
-
-  const changeRoleMutation = useMutation({
-    async mutationFn({ id, role }: { id: string; role: string }) {
-      await apiFetch(`/api/users/${id}/role`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ role }),
-      });
-    },
-    onSuccess() {
-      queryClient.invalidateQueries({ queryKey: USERS_QUERY_KEY });
-    },
-  });
-
-  const removeMutation = useMutation({
-    async mutationFn(id: string) {
-      await apiFetch(`/api/users/${id}`, { method: "DELETE" });
-    },
-    onSuccess() {
-      queryClient.invalidateQueries({ queryKey: USERS_QUERY_KEY });
-    },
-  });
-
-  function updateRule(
-    id: string,
-    field: keyof Omit<CasbinRule, "id">,
-    value: string,
-  ) {
-    setRules((curr) =>
-      curr.map((r) =>
-        r.id === id
-          ? { ...normalizeRule({ ...r, [field]: value }), id: r.id }
-          : r,
-      ),
-    );
-  }
-
-  function addRule() {
-    const base = normalizeRule({ ptype: "p" });
-    setRules((curr) => [...curr, { ...base, id: crypto.randomUUID() }]);
-  }
-
-  function removeRule(id: string) {
-    setRules((curr) => curr.filter((r) => r.id !== id));
-  }
-
-  const saveRulesMutation = useMutation({
-    async mutationFn() {
-      if (!isSuperadmin) return;
-      const cleaned = rules.map((r) => ({
-        ptype: r.ptype,
-        v0: r.v0 || null,
-        v1: r.v1 || null,
-        v2: r.v2 || null,
-        v3: r.v3 || null,
-        v4: r.v4 || null,
-        v5: r.v5 || null,
-      }));
-      const hasEdit = cleaned.some(
-        (r) =>
-          r.ptype === "p" &&
-          r.v0 === "superadmin" &&
-          r.v1 === "superadmin" &&
-          r.v2 === "update",
-      );
-      if (!hasEdit) {
-        const confirmed = window.confirm(
-          "These changes will remove your ability to edit Casbin rules. Continue?",
-        );
-        if (!confirmed) return;
-      }
-      const res = await apiFetch("/api/casbin-rules", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(cleaned),
-      });
-      if (res.ok)
-        setRules(
-          (await res.json()).map((r: RuleInput) => ({
-            ...r,
-            id: crypto.randomUUID(),
-          })),
-        );
-    },
-  });
-
+  const userHooks = useUsers(initialUsers);
+  const ruleHooks = useCasbinRules(
+    initialRules,
+    session?.user?.role === "superadmin",
+  );
   const { t } = useTranslation();
+
   return (
     <Tabs
       value={tab}
@@ -232,205 +66,10 @@ export default function AdminPageClient({
       <TabsContent value="users">
         <>
           <h1 className="text-xl font-bold mb-4">{t("admin.users")}</h1>
-          <div className="mb-4 flex gap-2">
-            <input
-              type="email"
-              value={inviteEmail}
-              onChange={(e) => setInviteEmail(e.target.value)}
-              className="border rounded p-1 bg-white dark:bg-gray-900"
-            />
-            <button
-              type="button"
-              onClick={() => inviteMutation.mutate()}
-              className="bg-blue-600 text-white px-2 py-1 rounded"
-            >
-              {t("admin.invite")}
-            </button>
-          </div>
-          <ul className="grid gap-2">
-            {users.map((u) => (
-              <li key={u.id} className="flex items-center gap-2">
-                <span className="flex-1">{u.email ?? u.id}</span>
-                <select
-                  value={u.role}
-                  onChange={(e) =>
-                    changeRoleMutation.mutate({
-                      id: u.id,
-                      role: e.target.value,
-                    })
-                  }
-                  className="border rounded p-1 bg-white dark:bg-gray-900"
-                >
-                  <option value="user">user</option>
-                  <option value="admin">admin</option>
-                  <option value="superadmin">superadmin</option>
-                  <option value="disabled">disabled</option>
-                </select>
-                {u.role !== "disabled" && (
-                  <button
-                    type="button"
-                    onClick={() => disableMutation.mutate(u.id)}
-                    className="bg-yellow-500 text-white px-2 py-1 rounded"
-                  >
-                    {t("admin.disable")}
-                  </button>
-                )}
-                <button
-                  type="button"
-                  onClick={() => removeMutation.mutate(u.id)}
-                  className="bg-red-500 text-white px-2 py-1 rounded"
-                >
-                  {t("admin.delete")}
-                </button>
-              </li>
-            ))}
-          </ul>
+          <InviteUserForm hooks={userHooks} />
+          <UsersTable hooks={userHooks} />
           <h1 className="text-xl font-bold my-4">{t("admin.casbinRules")}</h1>
-          <table className="mb-2 border-collapse w-full">
-            <thead>
-              <tr>
-                <th className="border px-1">ptype</th>
-                <th className="border px-1">v0</th>
-                <th className="border px-1">v1</th>
-                <th className="border px-1">v2</th>
-                <th className="border px-1">v3</th>
-                <th className="border px-1">v4</th>
-                <th className="border px-1">v5</th>
-                <th className="border px-1" />
-              </tr>
-            </thead>
-            <tbody>
-              {rules.map((r) => {
-                const ptypeOptions = ["p", "g"];
-                const v0Options =
-                  r.ptype === "p"
-                    ? Object.keys(policyOptions)
-                    : Object.keys(groupOptions);
-                const v1Options =
-                  r.ptype === "p"
-                    ? r.v0
-                      ? Object.keys(
-                          policyOptions[r.v0 as keyof typeof policyOptions] ??
-                            {},
-                        )
-                      : []
-                    : r.v0
-                      ? (groupOptions[r.v0 as keyof typeof groupOptions] ?? [])
-                      : [];
-                const v2Options =
-                  r.ptype === "p" && r.v0 && r.v1
-                    ? (policyOptions[r.v0 as keyof typeof policyOptions][
-                        r.v1 as keyof (typeof policyOptions)[keyof typeof policyOptions]
-                      ] ?? [])
-                    : [];
-                return (
-                  <tr key={r.id}>
-                    <td className="border">
-                      <select
-                        value={r.ptype}
-                        onChange={(e) =>
-                          updateRule(r.id, "ptype", e.target.value)
-                        }
-                        className="w-full p-1 bg-white dark:bg-gray-900"
-                      >
-                        {ptypeOptions.map((o) => (
-                          <option key={o} value={o}>
-                            {o}
-                          </option>
-                        ))}
-                      </select>
-                    </td>
-                    <td className="border">
-                      <select
-                        value={r.v0 ?? ""}
-                        onChange={(e) => updateRule(r.id, "v0", e.target.value)}
-                        className="w-full p-1 bg-white dark:bg-gray-900"
-                      >
-                        {v0Options.map((o) => (
-                          <option key={o} value={o}>
-                            {o}
-                          </option>
-                        ))}
-                      </select>
-                    </td>
-                    <td className="border">
-                      <select
-                        value={r.v1 ?? ""}
-                        onChange={(e) => updateRule(r.id, "v1", e.target.value)}
-                        className="w-full p-1 bg-white dark:bg-gray-900"
-                      >
-                        {v1Options.map((o) => (
-                          <option key={o} value={o}>
-                            {o}
-                          </option>
-                        ))}
-                      </select>
-                    </td>
-                    <td className="border">
-                      <select
-                        value={r.v2 ?? ""}
-                        onChange={(e) => updateRule(r.id, "v2", e.target.value)}
-                        className="w-full p-1 bg-white dark:bg-gray-900"
-                      >
-                        {v2Options.map((o) => (
-                          <option key={o} value={o}>
-                            {o}
-                          </option>
-                        ))}
-                      </select>
-                    </td>
-                    <td className="border">
-                      <input
-                        value={r.v3 ?? ""}
-                        onChange={(e) => updateRule(r.id, "v3", e.target.value)}
-                        className="w-full p-1 bg-white dark:bg-gray-900"
-                      />
-                    </td>
-                    <td className="border">
-                      <input
-                        value={r.v4 ?? ""}
-                        onChange={(e) => updateRule(r.id, "v4", e.target.value)}
-                        className="w-full p-1 bg-white dark:bg-gray-900"
-                      />
-                    </td>
-                    <td className="border">
-                      <input
-                        value={r.v5 ?? ""}
-                        onChange={(e) => updateRule(r.id, "v5", e.target.value)}
-                        className="w-full p-1 bg-white dark:bg-gray-900"
-                      />
-                    </td>
-                    <td className="border">
-                      <button
-                        type="button"
-                        onClick={() => removeRule(r.id)}
-                        className="bg-red-500 text-white px-2 py-1 rounded"
-                      >
-                        Delete
-                      </button>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-          <div className="flex gap-2 mb-2">
-            <button
-              type="button"
-              onClick={addRule}
-              className="bg-green-600 text-white px-2 py-1 rounded"
-            >
-              {t("admin.addRule")}
-            </button>
-          </div>
-          <button
-            type="button"
-            onClick={() => saveRulesMutation.mutate()}
-            disabled={!isSuperadmin}
-            className="bg-blue-600 text-white px-2 py-1 rounded disabled:opacity-50"
-          >
-            {t("admin.saveRules")}
-          </button>
+          <RulesTable hooks={ruleHooks} />
         </>
       </TabsContent>
       <TabsContent value="config">

--- a/src/app/admin/components/InviteUserForm.tsx
+++ b/src/app/admin/components/InviteUserForm.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { type FormEvent, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { useUsers } from "../hooks/useUsers";
+
+export default function InviteUserForm({
+  hooks,
+}: { hooks: ReturnType<typeof useUsers> }) {
+  const { invite } = hooks;
+  const [inviteEmail, setInviteEmail] = useState("");
+  const { t } = useTranslation();
+
+  function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    invite.mutate(inviteEmail);
+    setInviteEmail("");
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="mb-4 flex gap-2">
+      <input
+        type="email"
+        value={inviteEmail}
+        onChange={(e) => setInviteEmail(e.target.value)}
+        className="border rounded p-1 bg-white dark:bg-gray-900"
+      />
+      <button
+        type="submit"
+        className="bg-blue-600 text-white px-2 py-1 rounded"
+      >
+        {t("admin.invite")}
+      </button>
+    </form>
+  );
+}

--- a/src/app/admin/components/RuleRow.tsx
+++ b/src/app/admin/components/RuleRow.tsx
@@ -1,0 +1,120 @@
+"use client";
+import type { CasbinRule } from "../AdminPageClient";
+import { groupOptions, policyOptions } from "../hooks/useCasbinRules";
+
+export default function RuleRow({
+  rule,
+  onChange,
+  onRemove,
+}: {
+  rule: CasbinRule;
+  onChange: (field: keyof Omit<CasbinRule, "id">, value: string) => void;
+  onRemove: () => void;
+}) {
+  const ptypeOptions = ["p", "g"];
+  const v0Options =
+    rule.ptype === "p" ? Object.keys(policyOptions) : Object.keys(groupOptions);
+  const v1Options =
+    rule.ptype === "p"
+      ? rule.v0
+        ? Object.keys(
+            policyOptions[rule.v0 as keyof typeof policyOptions] ?? {},
+          )
+        : []
+      : rule.v0
+        ? (groupOptions[rule.v0 as keyof typeof groupOptions] ?? [])
+        : [];
+  const v2Options =
+    rule.ptype === "p" && rule.v0 && rule.v1
+      ? (policyOptions[rule.v0 as keyof typeof policyOptions][
+          rule.v1 as keyof (typeof policyOptions)[keyof typeof policyOptions]
+        ] ?? [])
+      : [];
+
+  return (
+    <tr>
+      <td className="border">
+        <select
+          value={rule.ptype}
+          onChange={(e) => onChange("ptype", e.target.value)}
+          className="w-full p-1 bg-white dark:bg-gray-900"
+        >
+          {ptypeOptions.map((o) => (
+            <option key={o} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td className="border">
+        <select
+          value={rule.v0 ?? ""}
+          onChange={(e) => onChange("v0", e.target.value)}
+          className="w-full p-1 bg-white dark:bg-gray-900"
+        >
+          {v0Options.map((o) => (
+            <option key={o} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td className="border">
+        <select
+          value={rule.v1 ?? ""}
+          onChange={(e) => onChange("v1", e.target.value)}
+          className="w-full p-1 bg-white dark:bg-gray-900"
+        >
+          {v1Options.map((o) => (
+            <option key={o} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td className="border">
+        <select
+          value={rule.v2 ?? ""}
+          onChange={(e) => onChange("v2", e.target.value)}
+          className="w-full p-1 bg-white dark:bg-gray-900"
+        >
+          {v2Options.map((o) => (
+            <option key={o} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td className="border">
+        <input
+          value={rule.v3 ?? ""}
+          onChange={(e) => onChange("v3", e.target.value)}
+          className="w-full p-1 bg-white dark:bg-gray-900"
+        />
+      </td>
+      <td className="border">
+        <input
+          value={rule.v4 ?? ""}
+          onChange={(e) => onChange("v4", e.target.value)}
+          className="w-full p-1 bg-white dark:bg-gray-900"
+        />
+      </td>
+      <td className="border">
+        <input
+          value={rule.v5 ?? ""}
+          onChange={(e) => onChange("v5", e.target.value)}
+          className="w-full p-1 bg-white dark:bg-gray-900"
+        />
+      </td>
+      <td className="border">
+        <button
+          type="button"
+          onClick={onRemove}
+          className="bg-red-500 text-white px-2 py-1 rounded"
+        >
+          Delete
+        </button>
+      </td>
+    </tr>
+  );
+}

--- a/src/app/admin/components/RulesTable.tsx
+++ b/src/app/admin/components/RulesTable.tsx
@@ -1,0 +1,63 @@
+"use client";
+import { useTranslation } from "react-i18next";
+import type { useCasbinRules } from "../hooks/useCasbinRules";
+import RuleRow from "./RuleRow";
+
+export default function RulesTable({
+  hooks,
+}: { hooks: ReturnType<typeof useCasbinRules> }) {
+  const {
+    rules,
+    updateRule,
+    addRule,
+    removeRule,
+    saveRulesMutation,
+    isSuperadmin,
+  } = hooks;
+  const { t } = useTranslation();
+  return (
+    <div>
+      <table className="mb-2 border-collapse w-full">
+        <thead>
+          <tr>
+            <th className="border px-1">ptype</th>
+            <th className="border px-1">v0</th>
+            <th className="border px-1">v1</th>
+            <th className="border px-1">v2</th>
+            <th className="border px-1">v3</th>
+            <th className="border px-1">v4</th>
+            <th className="border px-1">v5</th>
+            <th className="border px-1" />
+          </tr>
+        </thead>
+        <tbody>
+          {rules.map((r) => (
+            <RuleRow
+              key={r.id}
+              rule={r}
+              onChange={(field, value) => updateRule(r.id, field, value)}
+              onRemove={() => removeRule(r.id)}
+            />
+          ))}
+        </tbody>
+      </table>
+      <div className="flex gap-2 mb-2">
+        <button
+          type="button"
+          onClick={addRule}
+          className="bg-green-600 text-white px-2 py-1 rounded"
+        >
+          {t("admin.addRule")}
+        </button>
+      </div>
+      <button
+        type="button"
+        onClick={() => saveRulesMutation.mutate()}
+        disabled={!isSuperadmin}
+        className="bg-blue-600 text-white px-2 py-1 rounded disabled:opacity-50"
+      >
+        {t("admin.saveRules")}
+      </button>
+    </div>
+  );
+}

--- a/src/app/admin/components/UsersTable.tsx
+++ b/src/app/admin/components/UsersTable.tsx
@@ -1,0 +1,49 @@
+"use client";
+import { useTranslation } from "react-i18next";
+import type { UserRecord } from "../AdminPageClient";
+import type { useUsers } from "../hooks/useUsers";
+
+export default function UsersTable({
+  hooks,
+}: { hooks: ReturnType<typeof useUsers> }) {
+  const { usersQuery, disable, changeRole, remove } = hooks;
+  const users = usersQuery.data ?? [];
+  const { t } = useTranslation();
+  return (
+    <ul className="grid gap-2">
+      {users.map((u: UserRecord) => (
+        <li key={u.id} className="flex items-center gap-2">
+          <span className="flex-1">{u.email ?? u.id}</span>
+          <select
+            value={u.role}
+            onChange={(e) =>
+              changeRole.mutate({ id: u.id, role: e.target.value })
+            }
+            className="border rounded p-1 bg-white dark:bg-gray-900"
+          >
+            <option value="user">user</option>
+            <option value="admin">admin</option>
+            <option value="superadmin">superadmin</option>
+            <option value="disabled">disabled</option>
+          </select>
+          {u.role !== "disabled" && (
+            <button
+              type="button"
+              onClick={() => disable.mutate(u.id)}
+              className="bg-yellow-500 text-white px-2 py-1 rounded"
+            >
+              {t("admin.disable")}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => remove.mutate(u.id)}
+            className="bg-red-500 text-white px-2 py-1 rounded"
+          >
+            {t("admin.delete")}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/app/admin/hooks/useCasbinRules.ts
+++ b/src/app/admin/hooks/useCasbinRules.ts
@@ -1,0 +1,142 @@
+import { apiFetch } from "@/apiClient";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import type { CasbinRule, RuleInput } from "../AdminPageClient";
+
+const policyOptions = {
+  anonymous: { public_cases: ["read"] },
+  user: {
+    upload: ["create"],
+    cases: ["read", "update", "delete"],
+    snail_mail_providers: ["read"],
+    vin_sources: ["read"],
+  },
+  admin: {
+    admin: ["read", "update"],
+    users: ["create", "read", "update", "delete"],
+    cases: ["update", "delete"],
+    snail_mail_providers: ["update"],
+    vin_sources: ["update"],
+  },
+  superadmin: { superadmin: ["read", "update"] },
+} as const;
+
+const groupOptions = {
+  admin: ["user"],
+  superadmin: ["admin"],
+} as const;
+
+function normalizeRule(rule: RuleInput): RuleInput {
+  if (rule.ptype === "p") {
+    const v0s = Object.keys(policyOptions) as Array<keyof typeof policyOptions>;
+    if (!rule.v0 || !v0s.includes(rule.v0 as keyof typeof policyOptions))
+      rule.v0 = v0s[0];
+    const v1s = Object.keys(
+      policyOptions[rule.v0 as keyof typeof policyOptions],
+    ) as Array<keyof (typeof policyOptions)[keyof typeof policyOptions]>;
+    if (
+      !rule.v1 ||
+      !v1s.includes(
+        rule.v1 as keyof (typeof policyOptions)[keyof typeof policyOptions],
+      )
+    )
+      rule.v1 = v1s[0];
+    const v2s = policyOptions[rule.v0 as keyof typeof policyOptions][
+      rule.v1 as keyof (typeof policyOptions)[keyof typeof policyOptions]
+    ] as readonly string[];
+    if (!rule.v2 || !v2s.includes(rule.v2)) rule.v2 = v2s[0];
+  } else {
+    const v0s = Object.keys(groupOptions) as Array<keyof typeof groupOptions>;
+    if (!rule.v0 || !v0s.includes(rule.v0 as keyof typeof groupOptions))
+      rule.v0 = v0s[0];
+    const v1s = groupOptions[
+      rule.v0 as keyof typeof groupOptions
+    ] as readonly string[];
+    if (!rule.v1 || !v1s.includes(rule.v1)) rule.v1 = v1s[0];
+    rule.v2 = null;
+  }
+  return rule;
+}
+
+export function useCasbinRules(
+  initialRules: RuleInput[],
+  isSuperadmin: boolean,
+) {
+  const [rules, setRules] = useState(() =>
+    initialRules.map((r) => ({ ...normalizeRule(r), id: crypto.randomUUID() })),
+  );
+
+  function updateRule(
+    id: string,
+    field: keyof Omit<CasbinRule, "id">,
+    value: string,
+  ) {
+    setRules((curr) =>
+      curr.map((r) =>
+        r.id === id
+          ? { ...normalizeRule({ ...r, [field]: value }), id: r.id }
+          : r,
+      ),
+    );
+  }
+
+  function addRule() {
+    const base = normalizeRule({ ptype: "p" });
+    setRules((curr) => [...curr, { ...base, id: crypto.randomUUID() }]);
+  }
+
+  function removeRule(id: string) {
+    setRules((curr) => curr.filter((r) => r.id !== id));
+  }
+
+  const saveRulesMutation = useMutation({
+    async mutationFn() {
+      if (!isSuperadmin) return;
+      const cleaned = rules.map((r) => ({
+        ptype: r.ptype,
+        v0: r.v0 || null,
+        v1: r.v1 || null,
+        v2: r.v2 || null,
+        v3: r.v3 || null,
+        v4: r.v4 || null,
+        v5: r.v5 || null,
+      }));
+      const hasEdit = cleaned.some(
+        (r) =>
+          r.ptype === "p" &&
+          r.v0 === "superadmin" &&
+          r.v1 === "superadmin" &&
+          r.v2 === "update",
+      );
+      if (!hasEdit) {
+        const confirmed = window.confirm(
+          "These changes will remove your ability to edit Casbin rules. Continue?",
+        );
+        if (!confirmed) return;
+      }
+      const res = await apiFetch("/api/casbin-rules", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(cleaned),
+      });
+      if (res.ok)
+        setRules(
+          (await res.json()).map((r: RuleInput) => ({
+            ...r,
+            id: crypto.randomUUID(),
+          })),
+        );
+    },
+  });
+
+  return {
+    rules,
+    updateRule,
+    addRule,
+    removeRule,
+    saveRulesMutation,
+    isSuperadmin,
+  };
+}
+
+export { policyOptions, groupOptions };

--- a/src/app/admin/hooks/useUsers.ts
+++ b/src/app/admin/hooks/useUsers.ts
@@ -1,0 +1,59 @@
+import { apiFetch } from "@/apiClient";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { UserRecord } from "../AdminPageClient";
+
+const USERS_QUERY_KEY = ["/api/users"] as const;
+
+export function useUsers(initialUsers: UserRecord[]) {
+  const queryClient = useQueryClient();
+  const usersQuery = useQuery<UserRecord[]>({
+    queryKey: USERS_QUERY_KEY,
+    initialData: initialUsers,
+  });
+
+  const invite = useMutation({
+    async mutationFn(email: string) {
+      await apiFetch("/api/users/invite", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+    },
+    onSuccess() {
+      queryClient.invalidateQueries({ queryKey: USERS_QUERY_KEY });
+    },
+  });
+
+  const disable = useMutation({
+    async mutationFn(id: string) {
+      await apiFetch(`/api/users/${id}/disable`, { method: "PUT" });
+    },
+    onSuccess() {
+      queryClient.invalidateQueries({ queryKey: USERS_QUERY_KEY });
+    },
+  });
+
+  const changeRole = useMutation({
+    async mutationFn({ id, role }: { id: string; role: string }) {
+      await apiFetch(`/api/users/${id}/role`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role }),
+      });
+    },
+    onSuccess() {
+      queryClient.invalidateQueries({ queryKey: USERS_QUERY_KEY });
+    },
+  });
+
+  const remove = useMutation({
+    async mutationFn(id: string) {
+      await apiFetch(`/api/users/${id}`, { method: "DELETE" });
+    },
+    onSuccess() {
+      queryClient.invalidateQueries({ queryKey: USERS_QUERY_KEY });
+    },
+  });
+
+  return { usersQuery, invite, disable, changeRole, remove };
+}


### PR DESCRIPTION
## Summary
- split large AdminPageClient into smaller components
- add custom hooks for user and casbin rule management
- update imports and typing annotations

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686691f16c18832ba1d2a9521559d67f