### PR TITLE
Add user dropdown with public profile

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -18,7 +18,8 @@
     "userSettings": "User Settings",
     "profile": "Profile",
     "signOut": "Sign Out",
-    "signIn": "Sign In"
+    "signIn": "Sign In",
+    "publicProfile": "Public Profile"
   },
   "addImage": "+ add image",
   "uploadImage": "Upload Image",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -18,7 +18,8 @@
     "userSettings": "Configuración de usuario",
     "profile": "Perfil",
     "signOut": "Cerrar sesión",
-    "signIn": "Iniciar sesión"
+    "signIn": "Iniciar sesión",
+    "publicProfile": "Perfil público"
   },
   "addImage": "+ agregar imagen",
   "uploadImage": "Subir imagen",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -18,7 +18,8 @@
     "userSettings": "Paramètres utilisateur",
     "profile": "Profil",
     "signOut": "Déconnexion",
-    "signIn": "Connexion"
+    "signIn": "Connexion",
+    "publicProfile": "Profil public"
   },
   "addImage": "+ ajouter image",
   "uploadImage": "Téléverser une image",

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FaBars } from "react-icons/fa";
+import { FaBars, FaUserCircle } from "react-icons/fa";
 import LanguageSwitcher from "./LanguageSwitcher";
 
 export default function NavBar() {
@@ -87,41 +87,49 @@ export default function NavBar() {
           {t("nav.systemStatus")}
         </Link>
       ) : null}
-      {session ? (
-        <>
-          <Link
-            href="/settings"
-            className="hover:text-gray-600 dark:hover:text-gray-300"
-            onClick={() => setMenuOpen(false)}
-          >
-            {t("nav.userSettings")}
-          </Link>
-        </>
-      ) : null}
-      {session ? (
-        <button
-          type="button"
-          onClick={() => {
-            setMenuOpen(false);
-            signOut();
-          }}
-          className="hover:text-gray-600 dark:hover:text-gray-300"
-        >
-          {t("nav.signOut")}
-        </button>
-      ) : (
-        <button
-          type="button"
-          onClick={() => {
-            setMenuOpen(false);
-            signIn();
-          }}
-          className="hover:text-gray-600 dark:hover:text-gray-300"
-        >
-          {t("nav.signIn")}
-        </button>
-      )}
     </>
+  );
+
+  const [userMenuOpen, setUserMenuOpen] = useState(false);
+
+  const userMenu = session ? (
+    <>
+      <Link
+        href={`/public/users/${session.user?.id}`}
+        className="hover:text-gray-600 dark:hover:text-gray-300"
+        onClick={() => setUserMenuOpen(false)}
+      >
+        {t("nav.publicProfile")}
+      </Link>
+      <Link
+        href="/settings"
+        className="hover:text-gray-600 dark:hover:text-gray-300"
+        onClick={() => setUserMenuOpen(false)}
+      >
+        {t("nav.userSettings")}
+      </Link>
+      <button
+        type="button"
+        onClick={() => {
+          setUserMenuOpen(false);
+          signOut();
+        }}
+        className="hover:text-gray-600 dark:hover:text-gray-300"
+      >
+        {t("nav.signOut")}
+      </button>
+    </>
+  ) : (
+    <button
+      type="button"
+      onClick={() => {
+        setUserMenuOpen(false);
+        signIn();
+      }}
+      className="hover:text-gray-600 dark:hover:text-gray-300"
+    >
+      {t("nav.signIn")}
+    </button>
   );
 
   return (
@@ -143,6 +151,33 @@ export default function NavBar() {
       <div className="hidden sm:flex gap-4 sm:gap-6 md:gap-8 text-sm items-center">
         {navLinks}
         <LanguageSwitcher />
+        <Popover.Root open={userMenuOpen} onOpenChange={setUserMenuOpen}>
+          <Popover.Trigger asChild>
+            <button
+              type="button"
+              className="text-xl p-1 rounded-full overflow-hidden flex items-center justify-center"
+            >
+              {session?.user?.image ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={session.user.image}
+                  alt=""
+                  className="w-6 h-6 rounded-full object-cover"
+                />
+              ) : (
+                <FaUserCircle />
+              )}
+            </button>
+          </Popover.Trigger>
+          <Popover.Portal>
+            <Popover.Content
+              sideOffset={4}
+              className="flex flex-col gap-2 text-sm bg-gray-100 dark:bg-gray-900 border rounded shadow p-4"
+            >
+              {userMenu}
+            </Popover.Content>
+          </Popover.Portal>
+        </Popover.Root>
       </div>
       <Popover.Root open={menuOpen} onOpenChange={setMenuOpen}>
         <Popover.Trigger asChild>
@@ -161,6 +196,7 @@ export default function NavBar() {
           >
             {navLinks}
             <LanguageSwitcher />
+            <div className="border-t pt-2 mt-2">{userMenu}</div>
           </Popover.Content>
         </Popover.Portal>
       </Popover.Root>

--- a/src/app/public/users/[id]/page.tsx
+++ b/src/app/public/users/[id]/page.tsx
@@ -1,0 +1,70 @@
+import { initI18n } from "@/i18n.server";
+import { getUser } from "@/lib/userStore";
+import { cookies, headers } from "next/headers";
+import { notFound } from "next/navigation";
+import { FaUserCircle } from "react-icons/fa";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export default async function PublicUserProfilePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const cookieStore = await cookies();
+  let lang = cookieStore.get("language")?.value;
+  if (!lang) {
+    const accept = (await headers()).get("accept-language") ?? "";
+    const supported = ["en", "es", "fr"];
+    for (const part of accept.split(",")) {
+      const code = part.split(";")[0].trim().toLowerCase().split("-")[0];
+      if (supported.includes(code)) {
+        lang = code;
+        break;
+      }
+    }
+    lang = lang ?? "en";
+  }
+  const { t } = await initI18n(lang);
+  const user = getUser(id);
+  if (!user) notFound();
+  return (
+    <div className="p-8 max-w-2xl mx-auto">
+      <div className="flex items-center gap-4 mb-4">
+        {user.image ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={user.image}
+            alt=""
+            className="w-24 h-24 rounded-full object-cover"
+          />
+        ) : (
+          <FaUserCircle className="w-24 h-24" />
+        )}
+        <h1 className="text-2xl font-bold">{user.name ?? t("unknown")}</h1>
+      </div>
+      {user.profileStatus === "published" ? (
+        <>
+          {user.bio ? (
+            <p className="mb-4 whitespace-pre-line">{user.bio}</p>
+          ) : null}
+          {user.socialLinks ? (
+            <ul className="list-disc pl-5 space-y-1">
+              {user.socialLinks.split(/\r?\n/).map((link) => (
+                <li key={link}>
+                  <a href={link} className="text-blue-600 underline break-all">
+                    {link}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </>
+      ) : (
+        <p className="text-gray-600">{t("profileStatusUnderReview")}</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- move session links to user dropdown with avatar button
- implement new public profile page
- translate "Public Profile" in supported languages

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6866a8f52774832b83b263fd0c68c1b5