### PR TITLE
feat: add public profile and user menu

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -16,6 +16,7 @@
     "admin": "Admin",
     "systemStatus": "System Status",
     "userSettings": "User Settings",
+    "publicProfile": "Public Profile",
     "profile": "Profile",
     "signOut": "Sign Out",
     "signIn": "Sign In"

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -16,6 +16,7 @@
     "admin": "Admin",
     "systemStatus": "Estado del sistema",
     "userSettings": "Configuración de usuario",
+    "publicProfile": "Perfil público",
     "profile": "Perfil",
     "signOut": "Cerrar sesión",
     "signIn": "Iniciar sesión"

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -16,6 +16,7 @@
     "admin": "Admin",
     "systemStatus": "État du système",
     "userSettings": "Paramètres utilisateur",
+    "publicProfile": "Profil public",
     "profile": "Profil",
     "signOut": "Déconnexion",
     "signIn": "Connexion"

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FaBars } from "react-icons/fa";
+import { FaBars, FaUserCircle } from "react-icons/fa";
 import LanguageSwitcher from "./LanguageSwitcher";
 
 export default function NavBar() {
@@ -87,41 +87,57 @@ export default function NavBar() {
           {t("nav.systemStatus")}
         </Link>
       ) : null}
-      {session ? (
-        <>
-          <Link
-            href="/settings"
-            className="hover:text-gray-600 dark:hover:text-gray-300"
-            onClick={() => setMenuOpen(false)}
-          >
-            {t("nav.userSettings")}
-          </Link>
-        </>
-      ) : null}
-      {session ? (
-        <button
-          type="button"
-          onClick={() => {
-            setMenuOpen(false);
-            signOut();
-          }}
-          className="hover:text-gray-600 dark:hover:text-gray-300"
-        >
-          {t("nav.signOut")}
-        </button>
-      ) : (
-        <button
-          type="button"
-          onClick={() => {
-            setMenuOpen(false);
-            signIn();
-          }}
-          className="hover:text-gray-600 dark:hover:text-gray-300"
-        >
-          {t("nav.signIn")}
-        </button>
-      )}
+      {/* user menu items removed from navLinks */}
     </>
+  );
+
+  const userMenu = (
+    <details className="relative" onToggle={() => setMenuOpen(false)}>
+      <summary className="cursor-pointer list-none flex items-center">
+        {session?.user?.image ? (
+          <img
+            src={session.user.image}
+            alt="avatar"
+            className="w-6 h-6 rounded-full object-cover"
+          />
+        ) : (
+          <FaUserCircle className="w-6 h-6" />
+        )}
+      </summary>
+      <div className="absolute right-0 mt-1 bg-white dark:bg-gray-900 border rounded shadow text-sm">
+        {session ? (
+          <>
+            <Link
+              href="/settings"
+              className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              {t("nav.userSettings")}
+            </Link>
+            <Link
+              href={`/public/users/${session.user?.id}`}
+              className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              {t("nav.publicProfile")}
+            </Link>
+            <button
+              type="button"
+              onClick={() => signOut()}
+              className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+            >
+              {t("nav.signOut")}
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            onClick={() => signIn()}
+            className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+          >
+            {t("nav.signIn")}
+          </button>
+        )}
+      </div>
+    </details>
   );
 
   return (
@@ -143,27 +159,31 @@ export default function NavBar() {
       <div className="hidden sm:flex gap-4 sm:gap-6 md:gap-8 text-sm items-center">
         {navLinks}
         <LanguageSwitcher />
+        {userMenu}
       </div>
-      <Popover.Root open={menuOpen} onOpenChange={setMenuOpen}>
-        <Popover.Trigger asChild>
-          <button
-            type="button"
-            className="sm:hidden text-xl p-2 hover:text-gray-600 dark:hover:text-gray-300"
-            aria-label={t("menu")}
-          >
-            <FaBars />
-          </button>
-        </Popover.Trigger>
-        <Popover.Portal>
-          <Popover.Content
-            sideOffset={4}
-            className="sm:hidden flex flex-col gap-2 text-sm bg-gray-100 dark:bg-gray-900 border rounded shadow p-4"
-          >
-            {navLinks}
-            <LanguageSwitcher />
-          </Popover.Content>
-        </Popover.Portal>
-      </Popover.Root>
+      <div className="sm:hidden flex items-center gap-2">
+        <Popover.Root open={menuOpen} onOpenChange={setMenuOpen}>
+          <Popover.Trigger asChild>
+            <button
+              type="button"
+              className="sm:hidden text-xl p-2 hover:text-gray-600 dark:hover:text-gray-300"
+              aria-label={t("menu")}
+            >
+              <FaBars />
+            </button>
+          </Popover.Trigger>
+          <Popover.Portal>
+            <Popover.Content
+              sideOffset={4}
+              className="sm:hidden flex flex-col gap-2 text-sm bg-gray-100 dark:bg-gray-900 border rounded shadow p-4"
+            >
+              {navLinks}
+              <LanguageSwitcher />
+            </Popover.Content>
+          </Popover.Portal>
+        </Popover.Root>
+        {userMenu}
+      </div>
     </nav>
   );
 }

--- a/src/app/public/users/[id]/PublicProfileClient.tsx
+++ b/src/app/public/users/[id]/PublicProfileClient.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { useTranslation } from "react-i18next";
+import { FaUserCircle } from "react-icons/fa";
+
+export interface PublicUser {
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  bio: string | null;
+  socialLinks: string | null;
+  profileStatus: string;
+  profileReviewNotes: string | null;
+  role: string;
+}
+
+export default function PublicProfileClient({
+  user,
+}: {
+  user: PublicUser;
+}) {
+  const { t } = useTranslation();
+  const links = user.socialLinks?.split(/\n+/).filter(Boolean) ?? [];
+  return (
+    <div className="p-8 flex flex-col items-center gap-4 text-center">
+      {user.image ? (
+        <img
+          src={user.image}
+          alt="avatar"
+          className="w-24 h-24 rounded-full object-cover"
+        />
+      ) : (
+        <FaUserCircle className="w-24 h-24" />
+      )}
+      <h1 className="text-2xl font-bold">{user.name ?? t("unknown")}</h1>
+      {user.profileStatus === "published" ? (
+        user.bio ? (
+          <p className="max-w-prose whitespace-pre-line">{user.bio}</p>
+        ) : null
+      ) : (
+        <p className="text-sm text-gray-600">{t("profileStatusUnderReview")}</p>
+      )}
+      {links.length ? (
+        <div className="flex flex-col gap-1">
+          {links.map((l) => (
+            <a
+              key={l}
+              href={l}
+              className="text-blue-600 underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {l}
+            </a>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/public/users/[id]/page.tsx
+++ b/src/app/public/users/[id]/page.tsx
@@ -1,0 +1,19 @@
+import { getUser } from "@/lib/userStore";
+import { notFound } from "next/navigation";
+import PublicProfileClient from "./PublicProfileClient";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export default async function PublicProfilePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const user = getUser(id);
+  if (!user) {
+    notFound();
+  }
+  return <PublicProfileClient user={user} />;
+}


### PR DESCRIPTION
## Summary
- move sign-in/out and settings into a new user dropdown
- display the user's avatar or an icon in the navbar
- add "Public Profile" menu item
- implement public user profile page
- update translations for the new menu item

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6866a8f52774832b83b263fd0c68c1b5