### PR TITLE
feat: fill Illinois ownership form with checkboxes

### DIFF
--- a/src/app/api/cases/[id]/ownership-form/route.ts
+++ b/src/app/api/cases/[id]/ownership-form/route.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs";
-import { withCaseAuthorization } from "@/lib/authz";
+import { getSessionDetails, withCaseAuthorization } from "@/lib/authz";
 import { getCase } from "@/lib/caseStore";
-import { fillIlForm } from "@/lib/ownershipModules";
+import { config } from "@/lib/config";
+import { fillIlForm, type OwnershipRequestInfo } from "@/lib/ownershipModules";
+import { getUser } from "@/lib/userStore";
 import { NextResponse } from "next/server";
 
 export const runtime = "nodejs";
@@ -9,7 +11,16 @@ export const dynamic = "force-dynamic";
 
 export const GET = withCaseAuthorization(
   { obj: "cases" },
-  async (_req: Request, { params }: { params: Promise<{ id: string }> }) => {
+  async (
+    _req: Request,
+    {
+      params,
+      session,
+    }: {
+      params: Promise<{ id: string }>;
+      session?: { user?: { id?: string } };
+    },
+  ) => {
     const { id } = await params;
     const c = getCase(id);
     if (!c) {
@@ -19,10 +30,38 @@ export const GET = withCaseAuthorization(
     if (state !== "il") {
       return NextResponse.json({ error: "unsupported" }, { status: 400 });
     }
-    const info = {
+    const { userId } = getSessionDetails({ session }, "user");
+    const user = userId ? getUser(userId) : null;
+    const addr = config.RETURN_ADDRESS
+      ? (() => {
+          const lines = config.RETURN_ADDRESS.split(/\n+/);
+          const name = lines.length > 3 ? lines.shift() : undefined;
+          const address1 = lines.shift() || "";
+          const possibleCity = lines.pop() || "";
+          const address2 = lines.length > 0 ? lines.shift() : undefined;
+          const m = possibleCity.match(
+            /^(.*),\s*([A-Z]{2})\s+(\d{5}(?:-\d{4})?)/,
+          );
+          const city = m ? m[1] : "";
+          const state2 = m ? m[2] : "";
+          const postalCode = m ? m[3] : "";
+          return { name, address1, address2, city, state: state2, postalCode };
+        })()
+      : null;
+    const cityStateZip = addr
+      ? `${addr.city}, ${addr.state} ${addr.postalCode}`.trim()
+      : "";
+    const info: OwnershipRequestInfo = {
       plate: c.analysis?.vehicle?.licensePlateNumber ?? "",
       state: c.analysis?.vehicle?.licensePlateState ?? "",
       vin: c.vinOverride ?? c.vin ?? undefined,
+      requesterName: user?.name ?? undefined,
+      requesterBusinessName: addr?.name ?? undefined,
+      requesterAddress: addr
+        ? [addr.address1, addr.address2].filter(Boolean).join(" ")
+        : undefined,
+      requesterCityStateZip: cityStateZip || undefined,
+      requesterEmailAddress: user?.email ?? undefined,
     };
     const pdfPath = await fillIlForm(info);
     const data = fs.readFileSync(pdfPath);

--- a/src/app/ownership/IlFormDebug.stories.tsx
+++ b/src/app/ownership/IlFormDebug.stories.tsx
@@ -5,8 +5,7 @@ import { useEffect, useState } from "react";
 
 const pdfUrl = new URL("../../../forms/il/vsd375.pdf", import.meta.url);
 
-const IL_FORM_FIELD_MAP: Record<keyof OwnershipRequestInfo, string> = {
-  driversLicense: "6",
+const IL_FORM_FIELD_MAP: Partial<Record<keyof OwnershipRequestInfo, string>> = {
   plate: "16",
   vin: "13",
   vehicleYear: "11",
@@ -28,7 +27,37 @@ const IL_FORM_FIELD_MAP: Record<keyof OwnershipRequestInfo, string> = {
   requesterProfessionalLicenseOrARDCNumber: "21",
 };
 
-function IlFormViewer(props: OwnershipRequestInfo) {
+const IL_FORM_CHECKBOXES = {
+  titleSearch: "cb1",
+  registrationSearch: "cb2",
+  certifiedTitleSearch: "cb3",
+  certifiedRegistrationSearch: "cb4",
+  microfilmWithSearch: "cb5",
+  microfilmOnly: "cb5a",
+  plateCategoryPassenger: "cb6",
+  plateCategoryBTruck: "cb7",
+  plateCategoryOtherBox: "cb8",
+  reasonA: "cb9",
+  reasonB: "cb10",
+  reasonC: "cb11",
+  reasonD: "cb12",
+  reasonE: "cb13",
+  reasonF: "cb14",
+  reasonG: "cb15",
+  reasonH: "cb16",
+  reasonI: "cb17",
+  reasonJ: "cb18",
+  reasonK: "cb19",
+  reasonL: "cb20",
+  reasonM: "cb21",
+  reasonN: "cb22",
+  reasonO: "cb23",
+};
+
+type IlFormProps = OwnershipRequestInfo &
+  Partial<Record<keyof typeof IL_FORM_CHECKBOXES, boolean>>;
+
+function IlFormViewer(props: IlFormProps) {
   const [url, setUrl] = useState<string | null>(null);
   useEffect(() => {
     async function build() {
@@ -43,6 +72,17 @@ function IlFormViewer(props: OwnershipRequestInfo) {
         const val = props[key];
         try {
           form.getTextField(field).setText(val ?? "");
+        } catch {}
+      }
+      for (const [key, field] of Object.entries(IL_FORM_CHECKBOXES) as [
+        keyof typeof IL_FORM_CHECKBOXES,
+        string,
+      ][]) {
+        const val = props[key];
+        try {
+          const cb = form.getCheckBox(field);
+          if (val) cb.check();
+          else cb.uncheck();
         } catch {}
       }
       const b64 = await pdf.saveAsBase64({ dataUri: true });
@@ -64,6 +104,9 @@ type Story = StoryObj<typeof IlFormViewer>;
 
 export const Default: Story = {
   args: {
+    titleSearch: true,
+    reasonO: true,
+    plateCategoryOtherBox: true,
     requesterName: "requesterName",
     requesterAddress: "requesterAddress",
     requesterBusinessName: "requesterBusinessName",
@@ -73,7 +116,8 @@ export const Default: Story = {
     requesterEmailAddress: "requesterEmailAddress",
     requesterPhoneNumber: "requesterPhoneNumber",
     requesterPositionInOrginization: "requesterPositionInOrginization",
-    requesterProfessionalLicenseOrARDCNumber: "requesterProfessionalLicenseOrARDCNumber",
+    requesterProfessionalLicenseOrARDCNumber:
+      "requesterProfessionalLicenseOrARDCNumber",
     titleNumber: "titleNumber",
     plateYear: "plateYear",
     reasonForRequestingRecords: "reasonForRequestingRecords",

--- a/src/generated/zod/openai.ts
+++ b/src/generated/zod/openai.ts
@@ -69,3 +69,8 @@ export const violationReportSchema = z.object({
     }),
   ),
 });
+
+export const profileReviewSchema = z.object({
+  flagged: z.boolean(),
+  reason: z.string().optional(),
+});

--- a/src/generated/zod/ownershipModules.ts
+++ b/src/generated/zod/ownershipModules.ts
@@ -10,6 +10,22 @@ export const ownershipRequestInfoSchema = z.object({
   address2: z.string().optional().nullable(),
   city: z.string().optional().nullable(),
   postalCode: z.string().optional().nullable(),
+  vehicleYear: z.string().optional().nullable(),
+  vehicleMake: z.string().optional().nullable(),
+  titleNumber: z.string().optional().nullable(),
+  plateYear: z.string().optional().nullable(),
+  requesterName: z.string().optional().nullable(),
+  requesterBusinessName: z.string().optional().nullable(),
+  requesterAddress: z.string().optional().nullable(),
+  requesterCityStateZip: z.string().optional().nullable(),
+  requesterDaytimePhoneNumber: z.string().optional().nullable(),
+  requesterDriverLicenseNumber: z.string().optional().nullable(),
+  requesterEmailAddress: z.string().optional().nullable(),
+  requesterPhoneNumber: z.string().optional().nullable(),
+  reasonForRequestingRecords: z.string().optional().nullable(),
+  plateCategoryOther: z.string().optional().nullable(),
+  requesterPositionInOrginization: z.string().optional().nullable(),
+  requesterProfessionalLicenseOrARDCNumber: z.string().optional().nullable(),
 });
 
 export const ownershipModuleSchema = z.object({
@@ -27,5 +43,10 @@ export const ownershipModuleSchema = z.object({
     .function()
     .args(ownershipRequestInfoSchema)
     .returns(z.promise(z.void()))
+    .optional(),
+  generateForms: z
+    .function()
+    .args(ownershipRequestInfoSchema)
+    .returns(z.promise(z.union([z.string(), z.array(z.string())])))
     .optional(),
 });

--- a/src/lib/__tests__/ownershipModules.test.ts
+++ b/src/lib/__tests__/ownershipModules.test.ts
@@ -25,8 +25,7 @@ describe("ownershipModules.il.requestVin", () => {
     const pdfBytes = fs.readFileSync(opts.contents);
     const pdf = await PDFDocument.load(new Uint8Array(pdfBytes));
     const form = pdf.getForm();
-    expect(form.getTextField("1").getText()).toBe("ABC123");
-    expect(form.getTextField("2").getText()).toBe("IL");
-    expect(form.getTextField("3").getText()).toBe("1HGCM82633A004352");
+    expect(form.getTextField("16").getText()).toBe("ABC123");
+    expect(form.getTextField("13").getText()).toBe("1HGCM82633A004352");
   });
 });

--- a/src/lib/ownershipModules.ts
+++ b/src/lib/ownershipModules.ts
@@ -15,6 +15,22 @@ export interface OwnershipRequestInfo {
   address2?: string | null;
   city?: string | null;
   postalCode?: string | null;
+  vehicleYear?: string | null;
+  vehicleMake?: string | null;
+  titleNumber?: string | null;
+  plateYear?: string | null;
+  requesterName?: string | null;
+  requesterBusinessName?: string | null;
+  requesterAddress?: string | null;
+  requesterCityStateZip?: string | null;
+  requesterDaytimePhoneNumber?: string | null;
+  requesterDriverLicenseNumber?: string | null;
+  requesterEmailAddress?: string | null;
+  requesterPhoneNumber?: string | null;
+  reasonForRequestingRecords?: string | null;
+  plateCategoryOther?: string | null;
+  requesterPositionInOrginization?: string | null;
+  requesterProfessionalLicenseOrARDCNumber?: string | null;
 }
 
 export interface OwnershipModule {
@@ -33,15 +49,55 @@ export interface OwnershipModule {
   generateForms?: (info: OwnershipRequestInfo) => Promise<string | string[]>;
 }
 
-export const IL_FORM_FIELD_MAP: Record<keyof OwnershipRequestInfo, string> = {
-  plate: "1",
-  state: "2",
-  vin: "3",
-  ownerName: "4",
-  address1: "5",
-  address2: "6",
-  city: "7",
-  postalCode: "8",
+export const IL_FORM_FIELD_MAP: Partial<
+  Record<keyof OwnershipRequestInfo, string>
+> = {
+  plate: "16",
+  vin: "13",
+  vehicleYear: "11",
+  ownerName: "15",
+  vehicleMake: "12",
+  requesterName: "1",
+  requesterAddress: "4",
+  requesterBusinessName: "2",
+  requesterCityStateZip: "3",
+  requesterDaytimePhoneNumber: "5",
+  requesterDriverLicenseNumber: "6",
+  requesterEmailAddress: "7",
+  requesterPhoneNumber: "9",
+  titleNumber: "10",
+  plateYear: "17",
+  reasonForRequestingRecords: "19",
+  plateCategoryOther: "14",
+  requesterPositionInOrginization: "20",
+  requesterProfessionalLicenseOrARDCNumber: "21",
+};
+
+export const IL_FORM_CHECKBOXES = {
+  titleSearch: "cb1",
+  registrationSearch: "cb2",
+  certifiedTitleSearch: "cb3",
+  certifiedRegistrationSearch: "cb4",
+  microfilmWithSearch: "cb5",
+  microfilmOnly: "cb5a",
+  plateCategoryPassenger: "cb6",
+  plateCategoryBTruck: "cb7",
+  plateCategoryOther: "cb8",
+  reasonA: "cb9",
+  reasonB: "cb10",
+  reasonC: "cb11",
+  reasonD: "cb12",
+  reasonE: "cb13",
+  reasonF: "cb14",
+  reasonG: "cb15",
+  reasonH: "cb16",
+  reasonI: "cb17",
+  reasonJ: "cb18",
+  reasonK: "cb19",
+  reasonL: "cb20",
+  reasonM: "cb21",
+  reasonN: "cb22",
+  reasonO: "cb23",
 };
 
 function parseAddress(text: string): MailingAddress {
@@ -96,6 +152,15 @@ export async function fillIlForm(info: OwnershipRequestInfo): Promise<string> {
     const value = info[key] ?? undefined;
     setField(field, value ?? "");
   }
+  const checkBox = (name: string, value: boolean) => {
+    try {
+      const cb = form.getCheckBox(name);
+      if (value) cb.check();
+      else cb.uncheck();
+    } catch {}
+  };
+  checkBox(IL_FORM_CHECKBOXES.titleSearch, true);
+  checkBox(IL_FORM_CHECKBOXES.reasonO, true);
   const outDir = path.join(process.cwd(), "data", "ownership_tmp");
   fs.mkdirSync(outDir, { recursive: true });
   const outPath = path.join(outDir, `${crypto.randomUUID()}.pdf`);


### PR DESCRIPTION
## Summary
- map Illinois form fields to descriptive keys
- check form boxes when generating the PDF
- expand ownership info interface and fill with user and case data
- update sample story to toggle checkboxes
- adjust tests for new field mapping

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6866cbd54e64832bbe7ac354c4915e3f