### PR TITLE
Add user menu and public profiles

### DIFF
--- a/migrations/0022_public_profile_policies.sql
+++ b/migrations/0022_public_profile_policies.sql
@@ -1,0 +1,4 @@
+INSERT INTO casbin_rules (ptype, v0, v1, v2) VALUES
+  ('p', 'anonymous', 'public_profiles', 'read'),
+  ('p', 'user', 'public_profiles', 'read');
+

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -17,6 +17,7 @@
     "systemStatus": "System Status",
     "userSettings": "User Settings",
     "profile": "Profile",
+    "publicProfile": "Public Profile",
     "signOut": "Sign Out",
     "signIn": "Sign In"
   },

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -17,6 +17,7 @@
     "systemStatus": "Estado del sistema",
     "userSettings": "Configuración de usuario",
     "profile": "Perfil",
+    "publicProfile": "Perfil Público",
     "signOut": "Cerrar sesión",
     "signIn": "Iniciar sesión"
   },

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -17,6 +17,7 @@
     "systemStatus": "État du système",
     "userSettings": "Paramètres utilisateur",
     "profile": "Profil",
+    "publicProfile": "Profil Public",
     "signOut": "Déconnexion",
     "signIn": "Connexion"
   },

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FaBars } from "react-icons/fa";
+import { FaBars, FaUserCircle } from "react-icons/fa";
 import LanguageSwitcher from "./LanguageSwitcher";
 
 export default function NavBar() {
@@ -17,6 +17,7 @@ export default function NavBar() {
   const { data: session } = useSession();
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
+  const [userMenuOpen, setUserMenuOpen] = useState(false);
   if (pathname.startsWith("/point")) {
     return (
       <nav className="p-2 flex justify-end bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
@@ -87,40 +88,6 @@ export default function NavBar() {
           {t("nav.systemStatus")}
         </Link>
       ) : null}
-      {session ? (
-        <>
-          <Link
-            href="/settings"
-            className="hover:text-gray-600 dark:hover:text-gray-300"
-            onClick={() => setMenuOpen(false)}
-          >
-            {t("nav.userSettings")}
-          </Link>
-        </>
-      ) : null}
-      {session ? (
-        <button
-          type="button"
-          onClick={() => {
-            setMenuOpen(false);
-            signOut();
-          }}
-          className="hover:text-gray-600 dark:hover:text-gray-300"
-        >
-          {t("nav.signOut")}
-        </button>
-      ) : (
-        <button
-          type="button"
-          onClick={() => {
-            setMenuOpen(false);
-            signIn();
-          }}
-          className="hover:text-gray-600 dark:hover:text-gray-300"
-        >
-          {t("nav.signIn")}
-        </button>
-      )}
     </>
   );
 
@@ -144,6 +111,70 @@ export default function NavBar() {
         {navLinks}
         <LanguageSwitcher />
       </div>
+      <Popover.Root open={userMenuOpen} onOpenChange={setUserMenuOpen}>
+        <Popover.Trigger asChild>
+          <button
+            type="button"
+            className="relative w-8 h-8 flex items-center justify-center rounded-full overflow-hidden"
+          >
+            {session?.user?.image ? (
+              <img
+                src={session.user.image}
+                alt="avatar"
+                className="object-cover w-full h-full"
+              />
+            ) : (
+              <FaUserCircle className="w-full h-full" />
+            )}
+          </button>
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content
+            sideOffset={4}
+            className="flex flex-col gap-2 text-sm bg-gray-100 dark:bg-gray-900 border rounded shadow p-4"
+          >
+            {session ? (
+              <>
+                <Link
+                  href={`/public/users/${session.user?.id ?? ""}`}
+                  className="hover:text-gray-600 dark:hover:text-gray-300"
+                  onClick={() => setUserMenuOpen(false)}
+                >
+                  {t("nav.publicProfile")}
+                </Link>
+                <Link
+                  href="/settings"
+                  className="hover:text-gray-600 dark:hover:text-gray-300"
+                  onClick={() => setUserMenuOpen(false)}
+                >
+                  {t("nav.userSettings")}
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setUserMenuOpen(false);
+                    signOut();
+                  }}
+                  className="hover:text-gray-600 dark:hover:text-gray-300"
+                >
+                  {t("nav.signOut")}
+                </button>
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  setUserMenuOpen(false);
+                  signIn();
+                }}
+                className="hover:text-gray-600 dark:hover:text-gray-300"
+              >
+                {t("nav.signIn")}
+              </button>
+            )}
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
       <Popover.Root open={menuOpen} onOpenChange={setMenuOpen}>
         <Popover.Trigger asChild>
           <button

--- a/src/app/public/users/[id]/page.tsx
+++ b/src/app/public/users/[id]/page.tsx
@@ -1,0 +1,75 @@
+import { initI18n } from "@/i18n.server";
+import { getUser } from "@/lib/userStore";
+import { cookies, headers } from "next/headers";
+import { notFound } from "next/navigation";
+import { FaUserCircle } from "react-icons/fa";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export default async function PublicUserProfilePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const cookieStore = await cookies();
+  let lang = cookieStore.get("language")?.value;
+  if (!lang) {
+    const accept = (await headers()).get("accept-language") ?? "";
+    const supported = ["en", "es", "fr"];
+    for (const part of accept.split(",")) {
+      const code = part.split(";")[0].trim().toLowerCase().split("-")[0];
+      if (supported.includes(code)) {
+        lang = code;
+        break;
+      }
+    }
+    lang = lang ?? "en";
+  }
+  const { t } = await initI18n(lang);
+  const user = getUser(id);
+  if (!user) notFound();
+  const published = user.profileStatus === "published";
+  return (
+    <div className="p-8 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">{t("userProfile")}</h1>
+      <div className="flex items-center gap-4 mb-4">
+        {user.image ? (
+          <img
+            src={user.image}
+            alt="avatar"
+            className="w-24 h-24 rounded-full object-cover"
+          />
+        ) : (
+          <FaUserCircle className="w-24 h-24 text-gray-400" />
+        )}
+        <span className="text-xl font-semibold">
+          {user.name ?? user.email ?? t("unknown")}
+        </span>
+      </div>
+      {published ? (
+        user.bio ? (
+          <p className="whitespace-pre-line mb-4">{user.bio}</p>
+        ) : null
+      ) : (
+        <p className="text-gray-600 italic mb-4">
+          {t("profileStatusUnderReview")}
+        </p>
+      )}
+      {user.socialLinks ? (
+        <div className="space-y-1">
+          {user.socialLinks.split(/\r?\n/).map((link) => (
+            <a
+              key={link}
+              href={link}
+              className="block text-blue-600 underline break-all"
+            >
+              {link}
+            </a>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add dropdown menu for user actions with avatar trigger
- link to new public profile page from menu
- display public profile data and handle unpublished state
- include policies for public profile access
- update locale files

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866a8f52774832b83b263fd0c68c1b5