### PR TITLE
feat: stream profile updates via SSE

### DIFF
--- a/src/app/api/profile/stream/route.ts
+++ b/src/app/api/profile/stream/route.ts
@@ -1,0 +1,23 @@
+import { loadAuthContext } from "@/lib/authz";
+import { profileEvents } from "@/lib/profileEvents";
+import { eventStream } from "@/lib/sse";
+import { type UserRecord, getUser } from "@/lib/userStore";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  req: Request,
+  ctx: {
+    params: Promise<Record<string, string>>;
+    session?: { user?: { id?: string } };
+  },
+) {
+  const { userId } = await loadAuthContext(ctx, "user");
+  if (!userId) return new Response(null, { status: 401 });
+  const user = getUser(userId);
+  if (!user) return new Response(null, { status: 404 });
+  return eventStream<UserRecord>(req, profileEvents, {
+    filter: (u) => u.id === userId,
+    initial: user,
+  });
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import useAddCredits from "../hooks/useAddCredits";
 import useCreditBalance from "../hooks/useCreditBalance";
+import useEventSource from "../hooks/useEventSource";
 
 export default function UserSettingsPage() {
   const { data: session } = useSession();
@@ -38,6 +39,16 @@ export default function UserSettingsPage() {
       };
     },
     enabled: !!session,
+  });
+  useEventSource<{
+    name?: string;
+    image?: string;
+    bio?: string;
+    socialLinks?: string;
+    profileStatus?: string;
+    profileReviewNotes?: string | null;
+  }>(session ? "/api/profile/stream" : null, (payload) => {
+    queryClient.setQueryData(["/api/profile"], payload);
   });
   const [name, setName] = useState("");
   const [image, setImage] = useState("");

--- a/src/lib/profileEvents.ts
+++ b/src/lib/profileEvents.ts
@@ -1,0 +1,18 @@
+import { EventEmitter } from "node:events";
+import { parentPort } from "node:worker_threads";
+
+const globalStore = globalThis as unknown as { profileEvents?: EventEmitter };
+
+const emitter: EventEmitter = globalStore.profileEvents ?? new EventEmitter();
+
+if (parentPort) {
+  emitter.on("update", (data) => {
+    parentPort?.postMessage({ event: "profileUpdate", data });
+  });
+}
+
+if (!globalStore.profileEvents) {
+  globalStore.profileEvents = emitter;
+}
+
+export const profileEvents = emitter;

--- a/src/lib/sse.ts
+++ b/src/lib/sse.ts
@@ -1,0 +1,69 @@
+import type { EventEmitter } from "node:events";
+import { NextResponse } from "next/server";
+
+export interface EventStreamOptions<T> {
+  filter?: (data: T) => boolean;
+  initial?: T;
+}
+
+export function eventStream<T>(
+  req: Request,
+  emitter: EventEmitter,
+  opts: EventStreamOptions<T> = {},
+): NextResponse {
+  const { filter, initial } = opts;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      function sendData(data: T) {
+        try {
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify(data)}\n\n`),
+          );
+        } catch {
+          cleanup();
+        }
+      }
+
+      function sendKeepAlive() {
+        try {
+          controller.enqueue(encoder.encode(":\n\n"));
+        } catch {
+          cleanup();
+        }
+      }
+
+      function onUpdate(data: T) {
+        if (!filter || filter(data)) sendData(data);
+      }
+
+      function cleanup() {
+        clearInterval(keepAlive);
+        emitter.off("update", onUpdate);
+      }
+
+      emitter.on("update", onUpdate);
+      if (initial !== undefined) onUpdate(initial);
+
+      const keepAlive = setInterval(sendKeepAlive, 15000);
+
+      req.signal.addEventListener("abort", () => {
+        cleanup();
+        controller.close();
+      });
+
+      const ctrl = controller as ReadableStreamDefaultController<Uint8Array> & {
+        oncancel?: () => void;
+      };
+      ctrl.oncancel = cleanup;
+    },
+  });
+
+  return new NextResponse(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/src/lib/userStore.ts
+++ b/src/lib/userStore.ts
@@ -1,5 +1,6 @@
 import { eq } from "drizzle-orm";
 import { orm } from "./orm";
+import { profileEvents } from "./profileEvents";
 import { users } from "./schema";
 
 export interface UserRecord {
@@ -44,7 +45,9 @@ export function updateUser(
     data.profileReviewNotes = updates.profileReviewNotes;
   if (Object.keys(data).length)
     orm.update(users).set(data).where(eq(users.id, id)).run();
-  return getUser(id);
+  const updated = getUser(id);
+  if (updated) profileEvents.emit("update", updated);
+  return updated;
 }
 
 export function setProfileStatus(
@@ -57,4 +60,6 @@ export function setProfileStatus(
     .set({ profileStatus: status, profileReviewNotes: notes ?? null })
     .where(eq(users.id, id))
     .run();
+  const updated = getUser(id);
+  if (updated) profileEvents.emit("update", updated);
 }


### PR DESCRIPTION
## Summary
- add a small `eventStream` helper to produce SSE responses
- simplify `/api/profile/stream` to use the helper

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke` *(fails: ENOMEM or network issue)*

------
https://chatgpt.com/codex/tasks/task_e_6866af82cafc832ba830487428e9087a