### PR TITLE
fix: cache google avatars

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "staticmap.openstreetmap.de",
       },
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+      },
     ],
   },
 };

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -3,6 +3,7 @@
 import useNewCaseFromFiles from "@/app/useNewCaseFromFiles";
 import { signIn, signOut, useSession } from "@/app/useSession";
 import * as Popover from "@radix-ui/react-popover";
+import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useRef, useState } from "react";
@@ -95,9 +96,11 @@ export default function NavBar() {
     <details className="relative" onToggle={() => setMenuOpen(false)}>
       <summary className="cursor-pointer list-none flex items-center">
         {session?.user?.image ? (
-          <img
+          <Image
             src={session.user.image}
             alt="avatar"
+            width={24}
+            height={24}
             className="w-6 h-6 rounded-full object-cover"
           />
         ) : (

--- a/src/app/public/users/[id]/PublicProfileClient.tsx
+++ b/src/app/public/users/[id]/PublicProfileClient.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import { FaUserCircle } from "react-icons/fa";
 
@@ -24,9 +25,11 @@ export default function PublicProfileClient({
   return (
     <div className="p-8 flex flex-col items-center gap-4 text-center">
       {user.image ? (
-        <img
+        <Image
           src={user.image}
           alt="avatar"
+          width={96}
+          height={96}
           className="w-24 h-24 rounded-full object-cover"
         />
       ) : (


### PR DESCRIPTION
## Summary
- use Next.js Image component for avatars
- cache Google user images through next/image config

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke` *(fails: hung during execution)*

------
https://chatgpt.com/codex/tasks/task_e_6866f022797c832b9320517058a36d8a