### PR TITLE
Implement dynamic ownership form and plate category analysis

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -265,5 +265,6 @@
     "awaitingAuthorityResponse": "awaiting response from authorities",
     "citationProcessing": "citation processing",
     "awaitingDelivery": "awaiting delivery"
-  }
+  },
+  "plateCategories": "Plate categories"
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -265,5 +265,6 @@
     "awaitingAuthorityResponse": "esperando respuesta de las autoridades",
     "citationProcessing": "procesando citación",
     "awaitingDelivery": "esperando entrega"
-  }
+  },
+  "plateCategories": "Categorías de placa"
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -265,5 +265,6 @@
     "awaitingAuthorityResponse": "en attente de réponse des autorités",
     "citationProcessing": "traitement de la citation",
     "awaitingDelivery": "en attente de livraison"
-  }
+  },
+  "plateCategories": "Catégories de plaque"
 }

--- a/src/app/cases/[id]/ownership/OwnershipEditor.tsx
+++ b/src/app/cases/[id]/ownership/OwnershipEditor.tsx
@@ -2,9 +2,10 @@
 import { apiFetch } from "@/apiClient";
 import type { OwnershipModule } from "@/lib/ownershipModules";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNotify } from "../../../components/NotificationProvider";
+import { useSession } from "../../../useSession";
 
 export default function OwnershipEditor({
   caseId,
@@ -17,9 +18,44 @@ export default function OwnershipEditor({
 }) {
   const [checkNumber, setCheckNumber] = useState("");
   const [snailMail, setSnailMail] = useState(false);
+  const [form, setForm] = useState<Record<string, string>>({
+    reasonForRequestingRecords: "private investigation",
+    reasonH: "true",
+  });
+  const [option, setOption] = useState<string>("titleSearch");
   const notify = useNotify();
   const router = useRouter();
   const { t } = useTranslation();
+  const { data: session } = useSession();
+
+  useEffect(() => {
+    if (session?.user) {
+      const { name, email } = session.user;
+      setForm((f) => ({
+        ...f,
+        requesterName: name ?? "",
+        requesterEmailAddress: email ?? "",
+      }));
+    }
+  }, [session]);
+
+  const optionCost = useMemo(() => {
+    switch (option) {
+      case "certifiedTitleSearch":
+      case "certifiedRegistrationSearch":
+        return 20;
+      default:
+        return 5;
+    }
+  }, [option]);
+
+  const total = module.fee + optionCost;
+
+  const pdfUrl = useMemo(() => {
+    const params = new URLSearchParams(form);
+    params.set(option, "true");
+    return `/api/cases/${caseId}/ownership-form?${params.toString()}`;
+  }, [caseId, form, option]);
 
   async function record() {
     const res = await apiFetch(`/api/cases/${caseId}/ownership-request`, {
@@ -29,6 +65,7 @@ export default function OwnershipEditor({
         moduleId: module.id,
         checkNumber,
         ...(snailMail ? { snailMail: true } : {}),
+        form: { ...form, [option]: true },
       }),
     });
     if (res.ok) {
@@ -61,11 +98,71 @@ export default function OwnershipEditor({
       </pre>
       {showPdf ? (
         <iframe
-          src={`/api/cases/${caseId}/ownership-form`}
+          src={pdfUrl}
           className="w-full h-96 border"
           title="Ownership form"
         />
       ) : null}
+      <label className="flex flex-col">
+        Name
+        <input
+          type="text"
+          value={form.requesterName ?? ""}
+          onChange={(e) =>
+            setForm((f) => ({ ...f, requesterName: e.target.value }))
+          }
+          className="border p-1"
+        />
+      </label>
+      <label className="flex flex-col">
+        Email
+        <input
+          type="text"
+          value={form.requesterEmailAddress ?? ""}
+          onChange={(e) =>
+            setForm((f) => ({ ...f, requesterEmailAddress: e.target.value }))
+          }
+          className="border p-1"
+        />
+      </label>
+      <label className="flex flex-col">
+        Address
+        <input
+          type="text"
+          value={form.requesterAddress ?? ""}
+          onChange={(e) =>
+            setForm((f) => ({ ...f, requesterAddress: e.target.value }))
+          }
+          className="border p-1"
+        />
+      </label>
+      <label className="flex flex-col">
+        City/State/Zip
+        <input
+          type="text"
+          value={form.requesterCityStateZip ?? ""}
+          onChange={(e) =>
+            setForm((f) => ({ ...f, requesterCityStateZip: e.target.value }))
+          }
+          className="border p-1"
+        />
+      </label>
+      <label className="flex flex-col">
+        Section 2
+        <select
+          value={option}
+          onChange={(e) => setOption(e.target.value)}
+          className="border p-1"
+        >
+          <option value="titleSearch">Title Search</option>
+          <option value="registrationSearch">Registration Search</option>
+          <option value="certifiedTitleSearch">Certified Title Search</option>
+          <option value="certifiedRegistrationSearch">
+            Certified Registration Search
+          </option>
+        </select>
+      </label>
+      <p>Total: ${total}</p>
       <label className="flex flex-col">
         {t("checkNumberLabel")}
         <input

--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -82,6 +82,12 @@ export default function AnalysisInfo({
             {vehicle.licensePlateNumber}
           </span>
         ) : null}
+        {vehicle.plateCategoryOptions &&
+        vehicle.plateCategoryOptions.length > 0 ? (
+          <span>
+            {t("plateCategories")}: {vehicle.plateCategoryOptions.join(", ")}
+          </span>
+        ) : null}
       </div>
     </div>
   );

--- a/src/generated/zod/openai.ts
+++ b/src/generated/zod/openai.ts
@@ -56,6 +56,7 @@ export const violationReportSchema = z.object({
     color: z.string().optional(),
     licensePlateState: z.string().optional(),
     licensePlateNumber: z.string().optional(),
+    plateCategoryOptions: z.array(z.string()).optional(),
   }),
   images: z.record(
     z.object({
@@ -68,4 +69,9 @@ export const violationReportSchema = z.object({
       paperworkInfo: paperworkInfoSchema.optional(),
     }),
   ),
+});
+
+export const profileReviewSchema = z.object({
+  flagged: z.boolean(),
+  reason: z.string().optional(),
 });

--- a/src/generated/zod/ownershipModules.ts
+++ b/src/generated/zod/ownershipModules.ts
@@ -10,6 +10,47 @@ export const ownershipRequestInfoSchema = z.object({
   address2: z.string().optional().nullable(),
   city: z.string().optional().nullable(),
   postalCode: z.string().optional().nullable(),
+  driversLicense: z.string().optional().nullable(),
+  requesterName: z.string().optional().nullable(),
+  requesterBusinessName: z.string().optional().nullable(),
+  requesterAddress: z.string().optional().nullable(),
+  requesterCityStateZip: z.string().optional().nullable(),
+  requesterDaytimePhoneNumber: z.string().optional().nullable(),
+  requesterDriverLicenseNumber: z.string().optional().nullable(),
+  requesterEmailAddress: z.string().optional().nullable(),
+  requesterPhoneNumber: z.string().optional().nullable(),
+  vehicleYear: z.string().optional().nullable(),
+  vehicleMake: z.string().optional().nullable(),
+  titleNumber: z.string().optional().nullable(),
+  plateYear: z.string().optional().nullable(),
+  reasonForRequestingRecords: z.string().optional().nullable(),
+  plateCategoryOther: z.string().optional().nullable(),
+  requesterPositionInOrginization: z.string().optional().nullable(),
+  requesterProfessionalLicenseOrARDCNumber: z.string().optional().nullable(),
+  titleSearch: z.boolean().optional(),
+  registrationSearch: z.boolean().optional(),
+  certifiedTitleSearch: z.boolean().optional(),
+  certifiedRegistrationSearch: z.boolean().optional(),
+  microfilmWithSearchOption: z.boolean().optional(),
+  microfilmOnly: z.boolean().optional(),
+  passenger: z.boolean().optional(),
+  bTruck: z.boolean().optional(),
+  plateCategoryOtherCheck: z.boolean().optional(),
+  reasonA: z.boolean().optional(),
+  reasonB: z.boolean().optional(),
+  reasonC: z.boolean().optional(),
+  reasonD: z.boolean().optional(),
+  reasonE: z.boolean().optional(),
+  reasonF: z.boolean().optional(),
+  reasonG: z.boolean().optional(),
+  reasonH: z.boolean().optional(),
+  reasonI: z.boolean().optional(),
+  reasonJ: z.boolean().optional(),
+  reasonK: z.boolean().optional(),
+  reasonL: z.boolean().optional(),
+  reasonM: z.boolean().optional(),
+  reasonN: z.boolean().optional(),
+  reasonO: z.boolean().optional(),
 });
 
 export const ownershipModuleSchema = z.object({
@@ -27,5 +68,10 @@ export const ownershipModuleSchema = z.object({
     .function()
     .args(ownershipRequestInfoSchema)
     .returns(z.promise(z.void()))
+    .optional(),
+  generateForms: z
+    .function()
+    .args(ownershipRequestInfoSchema)
+    .returns(z.promise(z.union([z.string(), z.array(z.string())])))
     .optional(),
 });

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -127,6 +127,7 @@ export interface ViolationReport {
     color?: string;
     licensePlateState?: string;
     licensePlateNumber?: string;
+    plateCategoryOptions?: string[];
   };
   images: Record<
     string,
@@ -154,6 +155,7 @@ export const violationReportSchema: z.ZodType<ViolationReport> = z.object({
       color: z.string().optional(),
       licensePlateState: licensePlateStateSchema.optional(),
       licensePlateNumber: z.string().optional(),
+      plateCategoryOptions: z.array(z.string()).optional(),
     })
     .default({}),
   images: z
@@ -183,6 +185,7 @@ const violationReportInputSchema = z.object({
       color: z.string().optional(),
       licensePlateState: licensePlateStateSchema.optional(),
       licensePlateNumber: z.string().optional(),
+      plateCategoryOptions: z.array(z.string()).optional(),
     })
     .default({}),
   images: z
@@ -225,6 +228,7 @@ export async function analyzeViolation(
           color: { type: "string" },
           licensePlateState: { type: "string", enum: US_STATES },
           licensePlateNumber: { type: "string" },
+          plateCategoryOptions: { type: "array", items: { type: "string" } },
         },
       },
       images: {


### PR DESCRIPTION
## Summary
- store possible plate categories in analysis results
- expose plate category info in the case UI
- allow editing requester info on the ownership request page
- render VSD form preview with updated requester details
- include requester data when recording ownership requests
- localize new `plateCategories` string

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6866eff0f490832ba1e22bf05eb7485a