### PR TITLE
feat: store ownership request pdfs in thread

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -185,6 +185,7 @@
   "uploadScan": "Upload Scan",
   "followUp": "Follow Up",
   "addAsEvidence": "Add as Evidence",
+  "viewAttachment": "View Attachment",
   "close": "Close",
   "jumpToLatest": "Jump to latest",
   "askQuestion": "Ask a question...",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -185,6 +185,7 @@
   "uploadScan": "Subir escaneo",
   "followUp": "Seguimiento",
   "addAsEvidence": "Agregar como evidencia",
+  "viewAttachment": "Ver adjunto",
   "close": "Cerrar",
   "jumpToLatest": "Saltar al último",
   "askQuestion": "Haz una pregunta...",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -185,6 +185,7 @@
   "uploadScan": "Téléverser le scan",
   "followUp": "Suivi",
   "addAsEvidence": "Ajouter comme preuve",
+  "viewAttachment": "Voir la pièce jointe",
   "close": "Fermer",
   "jumpToLatest": "Aller au dernier",
   "askQuestion": "Posez une question...",

--- a/src/app/api/cases/[id]/ownership-request/route.ts
+++ b/src/app/api/cases/[id]/ownership-request/route.ts
@@ -1,10 +1,16 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
 import { NextResponse } from "next/server";
 
 import { withCaseAuthorization } from "@/lib/authz";
-import { addCaseEmail, addOwnershipRequest, getCase } from "@/lib/caseStore";
+import {
+  addCaseEmail,
+  addCaseThreadImage,
+  addOwnershipRequest,
+  getCase,
+} from "@/lib/caseStore";
 import { config } from "@/lib/config";
 import { sendSnailMail } from "@/lib/contactMethods";
 import { ownershipModules } from "@/lib/ownershipModules";
@@ -80,14 +86,24 @@ export const POST = withCaseAuthorization(
         storedAttachments.push(att);
       }
     }
+    const sentAt = new Date().toISOString();
     const withEmail = addCaseEmail(id, {
       to: mod?.address ?? "",
       subject: "Ownership information request",
       body: `Check number: ${checkNumber ?? ""}`,
       attachments: storedAttachments,
-      sentAt: new Date().toISOString(),
+      sentAt,
       replyTo: null,
     });
+
+    for (const file of storedAttachments) {
+      addCaseThreadImage(id, {
+        id: `${sentAt}-${crypto.randomUUID()}`,
+        threadParent: sentAt,
+        url: file,
+        uploadedAt: sentAt,
+      });
+    }
     return NextResponse.json({ case: withEmail ?? updated });
   },
 );

--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -131,6 +131,34 @@ export default function ClientThreadPage({
             </div>
             <div className="font-semibold">{mail.subject}</div>
             <pre className="whitespace-pre-wrap text-sm">{mail.body}</pre>
+            {mail.attachments && mail.attachments.length > 0 && (
+              <div className="flex gap-2 flex-wrap mt-2">
+                {mail.attachments.map((att) =>
+                  att.toLowerCase().endsWith(".pdf") ? (
+                    <a
+                      key={att}
+                      href={`/uploads/${att}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-500 underline"
+                    >
+                      {t("viewAttachment")}
+                    </a>
+                  ) : (
+                    <ThumbnailImage
+                      key={att}
+                      src={getThumbnailUrl(att, 128)}
+                      alt="attachment"
+                      width={96}
+                      height={72}
+                      className="cursor-pointer"
+                      imgClassName="object-contain"
+                      onClick={() => setViewImage(`/uploads/${att}`)}
+                    />
+                  ),
+                )}
+              </div>
+            )}
           </li>
         ))}
         {images.map((img) => (


### PR DESCRIPTION
## Summary
- store ownership request attachments as thread images for easier viewing
- show email attachments in the case thread view
- add `viewAttachment` translation key in en/es/fr locales

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6866f088a9b4832b94fb1e4f8d1fe573