### PR TITLE
feat: display thread attachments

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -184,6 +184,7 @@
   "thread": "Thread",
   "uploadScan": "Upload Scan",
   "followUp": "Follow Up",
+  "attachments": "Attachments",
   "addAsEvidence": "Add as Evidence",
   "close": "Close",
   "jumpToLatest": "Jump to latest",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -184,6 +184,7 @@
   "thread": "Conversación",
   "uploadScan": "Subir escaneo",
   "followUp": "Seguimiento",
+  "attachments": "Adjuntos",
   "addAsEvidence": "Agregar como evidencia",
   "close": "Cerrar",
   "jumpToLatest": "Saltar al último",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -184,6 +184,7 @@
   "thread": "Fil",
   "uploadScan": "Téléverser le scan",
   "followUp": "Suivi",
+  "attachments": "Pièces jointes",
   "addAsEvidence": "Ajouter comme preuve",
   "close": "Fermer",
   "jumpToLatest": "Aller au dernier",

--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -131,6 +131,23 @@ export default function ClientThreadPage({
             </div>
             <div className="font-semibold">{mail.subject}</div>
             <pre className="whitespace-pre-wrap text-sm">{mail.body}</pre>
+            {mail.attachments && mail.attachments.length > 0 ? (
+              <ul className="mt-2 flex flex-col gap-1">
+                <li className="font-semibold">{t("attachments")}</li>
+                {mail.attachments.map((att) => (
+                  <li key={att}>
+                    <a
+                      href={`/uploads/${att}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-500 underline"
+                    >
+                      {att}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
           </li>
         ))}
         {images.map((img) => (

--- a/src/app/uploads/[...path]/route.ts
+++ b/src/app/uploads/[...path]/route.ts
@@ -60,7 +60,9 @@ export async function GET(
           ? "image/webp"
           : ext === ".jpg" || ext === ".jpeg"
             ? "image/jpeg"
-            : "application/octet-stream";
+            : ext === ".pdf"
+              ? "application/pdf"
+              : "application/octet-stream";
     return new NextResponse(data, {
       headers: { "Content-Type": contentType },
     });


### PR DESCRIPTION
## Summary
- detect PDF uploads on the uploads route
- show email attachments in case threads
- add translation for attachments

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6866f088a9b4832b94fb1e4f8d1fe573