### PR TITLE
Default user avatars to gravatar

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,6 +20,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "lh3.googleusercontent.com",
       },
+      {
+        protocol: "https",
+        hostname: "www.gravatar.com",
+      },
     ],
   },
 };

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -10,6 +10,7 @@ import type { Provider } from "next-auth/providers/index";
 import { authAdapter, seedSuperAdmin } from "./auth";
 import { config } from "./config";
 import { sendEmail } from "./email";
+import { gravatarUrl } from "./gravatar";
 import { log } from "./logger";
 import { getOauthProviderStatuses } from "./oauthProviders";
 
@@ -78,6 +79,9 @@ export const authOptions: NextAuthOptions = {
       if (session.user) {
         (session.user as User & { role?: string }).role = user.role;
         (session.user as User & { id: string }).id = user.id;
+        if (!session.user.image && user.email) {
+          (session.user as User).image = gravatarUrl(user.email);
+        }
       }
       return session;
     },

--- a/src/lib/gravatar.ts
+++ b/src/lib/gravatar.ts
@@ -1,0 +1,9 @@
+import crypto from "node:crypto";
+
+export function gravatarUrl(email: string): string {
+  const hash = crypto
+    .createHash("md5")
+    .update(email.trim().toLowerCase())
+    .digest("hex");
+  return `https://www.gravatar.com/avatar/${hash}?d=identicon`;
+}

--- a/src/lib/userStore.ts
+++ b/src/lib/userStore.ts
@@ -1,4 +1,5 @@
 import { eq } from "drizzle-orm";
+import { gravatarUrl } from "./gravatar";
 import { orm } from "./orm";
 import { users } from "./schema";
 
@@ -16,7 +17,9 @@ export interface UserRecord {
 
 export function getUser(id: string): UserRecord | null {
   const row = orm.select().from(users).where(eq(users.id, id)).get();
-  return row ? { ...row } : null;
+  if (!row) return null;
+  const image = row.image ?? (row.email ? gravatarUrl(row.email) : null);
+  return { ...row, image };
 }
 
 export function updateUser(


### PR DESCRIPTION
## Summary
- create `gravatarUrl` helper to compute gravatar images
- return gravatar URLs from `getUser`
- populate gravatar URL in auth session callback
- allow gravatar.com images in Next.js config

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npx vitest run -c vitest.e2e.config.ts --testNamePattern "@smoke"` *(fails: address in use)*

------
https://chatgpt.com/codex/tasks/task_e_686701962648832b82c4f7ac1a4a1aef