### PR TITLE
feat: show attachment thumbnails

### DIFF
--- a/src/app/cases/[id]/components/CaseExtraInfo.tsx
+++ b/src/app/cases/[id]/components/CaseExtraInfo.tsx
@@ -3,6 +3,7 @@ import DebugWrapper from "@/app/components/DebugWrapper";
 import ThumbnailImage from "@/components/thumbnail-image";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import { useTranslation } from "react-i18next";
+import { FaFileAlt, FaFilePdf } from "react-icons/fa";
 import { useCaseContext } from "../CaseContext";
 import { baseName, buildThreads } from "../utils";
 
@@ -43,6 +44,48 @@ export default function CaseExtraInfo({ caseId }: { caseId: string }) {
                 <span className="text-gray-500 dark:text-gray-400 whitespace-pre-wrap">
                   {mail.body}
                 </span>
+                {mail.attachments && mail.attachments.length > 0 ? (
+                  <ul className="flex flex-wrap gap-2 mt-1">
+                    {mail.attachments.map((att) => {
+                      const ext = att.toLowerCase().split(".").pop() ?? "";
+                      const isImage = [
+                        "jpg",
+                        "jpeg",
+                        "png",
+                        "webp",
+                        "gif",
+                      ].includes(ext);
+                      const isPdf = ext === "pdf";
+                      return (
+                        <li key={att}>
+                          <a
+                            href={`/uploads/${att}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center gap-1"
+                          >
+                            {isImage ? (
+                              <ThumbnailImage
+                                src={getThumbnailUrl(att, 128)}
+                                alt={att}
+                                width={64}
+                                height={48}
+                                imgClassName="object-contain"
+                              />
+                            ) : isPdf ? (
+                              <FaFilePdf className="w-8 h-8 text-red-600" />
+                            ) : (
+                              <FaFileAlt className="w-8 h-8" />
+                            )}
+                            <span className="text-blue-500 underline">
+                              {att}
+                            </span>
+                          </a>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                ) : null}
                 <a
                   href={`/cases/${caseId}/thread/${encodeURIComponent(mail.sentAt)}`}
                   className="self-start text-blue-500 underline"

--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -8,7 +8,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FaArrowLeft } from "react-icons/fa";
+import { FaArrowLeft, FaFileAlt, FaFilePdf } from "react-icons/fa";
 import { useNotify } from "../../../components/NotificationProvider";
 import useCase, { caseQueryKey } from "../../../hooks/useCase";
 import useEventSource from "../../../hooks/useEventSource";
@@ -140,18 +140,42 @@ export default function ClientThreadPage({
             {mail.attachments && mail.attachments.length > 0 ? (
               <ul className="mt-2 flex flex-col gap-1">
                 <li className="font-semibold">{t("attachments")}</li>
-                {mail.attachments.map((att) => (
-                  <li key={att}>
-                    <a
-                      href={`/uploads/${att}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-500 underline"
-                    >
-                      {att}
-                    </a>
-                  </li>
-                ))}
+                {mail.attachments.map((att) => {
+                  const ext = att.toLowerCase().split(".").pop() ?? "";
+                  const isImage = [
+                    "jpg",
+                    "jpeg",
+                    "png",
+                    "webp",
+                    "gif",
+                  ].includes(ext);
+                  const isPdf = ext === "pdf";
+                  return (
+                    <li key={att} className="flex items-center gap-2">
+                      <a
+                        href={`/uploads/${att}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-2 text-blue-500 underline"
+                      >
+                        {isImage ? (
+                          <ThumbnailImage
+                            src={getThumbnailUrl(att, 128)}
+                            alt={att}
+                            width={64}
+                            height={48}
+                            imgClassName="object-contain"
+                          />
+                        ) : isPdf ? (
+                          <FaFilePdf className="w-8 h-8 text-red-600" />
+                        ) : (
+                          <FaFileAlt className="w-8 h-8" />
+                        )}
+                        <span>{att}</span>
+                      </a>
+                    </li>
+                  );
+                })}
               </ul>
             ) : null}
           </li>


### PR DESCRIPTION
## Summary
- display attachment thumbnails in thread view
- display attachment thumbnails in case view email log

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68671e6d2194832b9dd993b9ae6e959d