### PR TITLE
fix e2e reanalysis timing

### DIFF
--- a/src/jobs/analyzeCase.ts
+++ b/src/jobs/analyzeCase.ts
@@ -1,6 +1,7 @@
 import { parentPort, workerData } from "node:worker_threads";
 import { analyzeCase } from "@/lib/caseAnalysis";
 import type { Case } from "@/lib/caseStore";
+import { updateCase } from "@/lib/caseStore";
 import { migrationsReady } from "@/lib/db";
 import { getUnleash } from "@/lib/unleash";
 
@@ -8,6 +9,11 @@ import { getUnleash } from "@/lib/unleash";
   await migrationsReady;
   if (!getUnleash().isEnabled("case-analysis")) {
     if (parentPort) parentPort.postMessage("done");
+    const { jobData } = workerData as { jobData: { caseData: Case } };
+    updateCase(jobData.caseData.id, {
+      analysisStatus: "complete",
+      analysisStatusCode: 204,
+    });
     return;
   }
   const { jobData } = workerData as {

--- a/src/jobs/analyzePhoto.ts
+++ b/src/jobs/analyzePhoto.ts
@@ -1,6 +1,7 @@
 import { parentPort, workerData } from "node:worker_threads";
 import { reanalyzePhoto } from "@/lib/caseAnalysis";
 import type { Case } from "@/lib/caseStore";
+import { updateCase } from "@/lib/caseStore";
 import { migrationsReady } from "@/lib/db";
 import { getUnleash } from "@/lib/unleash";
 
@@ -8,6 +9,11 @@ import { getUnleash } from "@/lib/unleash";
   await migrationsReady;
   if (!getUnleash().isEnabled("photo-analysis")) {
     if (parentPort) parentPort.postMessage("done");
+    const { jobData } = workerData as { jobData: { caseData: Case } };
+    updateCase(jobData.caseData.id, {
+      analysisStatus: "complete",
+      analysisStatusCode: 204,
+    });
     return;
   }
   const { jobData } = workerData as {

--- a/src/lib/unleash.ts
+++ b/src/lib/unleash.ts
@@ -10,7 +10,7 @@ export function getUnleash(): Unleash {
     if (!UNLEASH_URL) {
       client = {
         isEnabled() {
-          return false;
+          return Boolean(process.env.TEST_APIS);
         },
       } as unknown as Unleash;
     } else {

--- a/test/e2e/reanalyze.test.ts
+++ b/test/e2e/reanalyze.test.ts
@@ -136,6 +136,13 @@ describe("reanalysis", () => {
       photoName = path.basename(photo);
       expect(json.analysis?.vehicle?.licensePlateNumber).toBeUndefined();
 
+      await poll(
+        () => api(`/api/cases/${caseId}/analysis-active`),
+        async (r) => (await r.clone().json()).active === false,
+        50,
+        100,
+      );
+
       const re = await api(
         `/api/cases/${caseId}/reanalyze-photo?photo=${encodeURIComponent(photo)}`,
         { method: "POST" },


### PR DESCRIPTION
## Summary
- wait for background case analysis to finish before reanalysing
- enable analysis features when running test server

## Testing
- `npm test`
- `npx vitest -c vitest.e2e.config.ts --run -t "adds vehicle info on reanalysis"`

------
https://chatgpt.com/codex/tasks/task_e_68673933da40832ba0cdcfc76a384d28