### PR TITLE
Add system status tab on admin page

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -106,7 +106,8 @@
     "saveRules": "Save Rules",
     "deployedAt": "Deployed: {{date}}",
     "deployCommit": "Commit: {{commit}}",
-    "deployVersion": "Version: {{version}}"
+    "deployVersion": "Version: {{version}}",
+    "systemStatus": "System Status"
   },
   "menu": "Menu",
   "orderBy": "Order by:",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -106,7 +106,8 @@
     "saveRules": "Guardar reglas",
     "deployedAt": "Desplegado: {{date}}",
     "deployCommit": "Commit: {{commit}}",
-    "deployVersion": "Versión: {{version}}"
+    "deployVersion": "Versión: {{version}}",
+    "systemStatus": "Estado del sistema"
   },
   "menu": "Menú",
   "orderBy": "Ordenar por:",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -106,7 +106,8 @@
     "saveRules": "Enregistrer les règles",
     "deployedAt": "Déployé : {{date}}",
     "deployCommit": "Commit : {{commit}}",
-    "deployVersion": "Version : {{version}}"
+    "deployVersion": "Version : {{version}}",
+    "systemStatus": "État du système"
   },
   "menu": "Menu",
   "orderBy": "Trier par :",

--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -4,6 +4,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import SystemStatusClient from "../system-status/SystemStatusClient";
 import AppConfigurationTab from "./AppConfigurationTab";
 import InviteUserForm from "./components/InviteUserForm";
 import RulesTable from "./components/RulesTable";
@@ -38,11 +39,12 @@ export default function AdminPageClient({
 }: {
   initialUsers: UserRecord[];
   initialRules: RuleInput[];
-  initialTab?: "users" | "config";
+  initialTab?: "users" | "config" | "status";
 }) {
   const router = useRouter();
-  const [tab, setTab] = useState<"users" | "config">(initialTab);
+  const [tab, setTab] = useState<"users" | "config" | "status">(initialTab);
   const { data: session } = useSession();
+  const isSuperadmin = session?.user?.role === "superadmin";
 
   const userHooks = useUsers(initialUsers);
   const ruleHooks = useCasbinRules(
@@ -55,13 +57,16 @@ export default function AdminPageClient({
     <Tabs
       value={tab}
       onValueChange={(v) => {
-        setTab(v as "users" | "config");
+        setTab(v as "users" | "config" | "status");
         router.replace(`?tab=${v}`);
       }}
     >
       <TabsList className="mb-4 flex gap-4 border-b">
         <TabsTrigger value="users">{t("admin.userManagement")}</TabsTrigger>
         <TabsTrigger value="config">{t("admin.appConfiguration")}</TabsTrigger>
+        {isSuperadmin && (
+          <TabsTrigger value="status">{t("admin.systemStatus")}</TabsTrigger>
+        )}
       </TabsList>
       <TabsContent value="users">
         <>
@@ -75,6 +80,11 @@ export default function AdminPageClient({
       <TabsContent value="config">
         <AppConfigurationTab />
       </TabsContent>
+      {isSuperadmin && (
+        <TabsContent value="status">
+          <SystemStatusClient />
+        </TabsContent>
+      )}
     </Tabs>
   );
 }

--- a/src/app/admin/__tests__/AdminPageClient.test.tsx
+++ b/src/app/admin/__tests__/AdminPageClient.test.tsx
@@ -166,4 +166,35 @@ describe("AdminPageClient", () => {
     await waitFor(() => expect(confirmSpy).toHaveBeenCalled());
     expect(apiFetch).toHaveBeenCalledTimes(1);
   });
+
+  it("shows system status tab for superadmins", () => {
+    vi.mocked(useSession).mockReturnValueOnce({
+      data: { user: { role: "superadmin" }, expires: "0" },
+    } as unknown as ReturnType<typeof useSessionFn>);
+    vi.mocked(apiFetch).mockResolvedValue({
+      ok: true,
+      json: async () => users,
+    } as Response);
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AdminPageClient initialUsers={users} initialRules={rules} />
+      </QueryClientProvider>,
+    );
+    expect(
+      screen.getByRole("tab", { name: /system status/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides system status tab for admins", () => {
+    vi.mocked(apiFetch).mockResolvedValue({
+      ok: true,
+      json: async () => users,
+    } as Response);
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AdminPageClient initialUsers={users} initialRules={rules} />
+      </QueryClientProvider>,
+    );
+    expect(screen.queryByRole("tab", { name: /system status/i })).toBeNull();
+  });
 });

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -36,8 +36,11 @@ const handler = withAuthorization<
     const users = listUsers();
     const rules = getCasbinRules();
     const { tab } = (await searchParams) ?? {};
-    const t = tab === "config" ? "config" : "users";
     const isSuperadmin = s?.user?.role === "superadmin";
+    const t =
+      tab === "config" || (tab === "status" && isSuperadmin)
+        ? (tab as "config" | "status")
+        : "users";
     return (
       <div className="p-8">
         <AdminPageClient

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -79,15 +79,6 @@ export default function NavBar() {
           {t("nav.admin")}
         </Link>
       ) : null}
-      {session?.user?.role === "superadmin" ? (
-        <Link
-          href="/system-status"
-          className="hover:text-gray-600 dark:hover:text-gray-300"
-          onClick={() => setMenuOpen(false)}
-        >
-          {t("nav.systemStatus")}
-        </Link>
-      ) : null}
       {/* user menu items removed from navLinks */}
     </>
   );


### PR DESCRIPTION
## Summary
- drop System Status from navigation bar
- translate Admin page System Status tab
- show System Status tab for superadmins
- handle `?tab=status` query on admin page
- test System Status tab behavior

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68673b112314832ba7871242dfb63e8a