### PR TITLE
Display deployment time in local timezone

### DIFF
--- a/src/app/admin/AdminDeploymentInfo.tsx
+++ b/src/app/admin/AdminDeploymentInfo.tsx
@@ -1,35 +1,22 @@
-import { initI18n } from "@/i18n.server";
-import { config } from "@/lib/config";
-import { cookies, headers } from "next/headers";
+"use client";
+import { getPublicEnv } from "@/publicEnv";
+import { useTranslation } from "react-i18next";
 
-export default async function AdminDeploymentInfo() {
-  const cookieStore = await cookies();
-  let lang = cookieStore.get("language")?.value;
-  if (!lang) {
-    const accept = (await headers()).get("accept-language") ?? "";
-    const supported = ["en", "es", "fr"];
-    for (const part of accept.split(",")) {
-      const code = part.split(";")[0].trim().toLowerCase().split("-")[0];
-      if (supported.includes(code)) {
-        lang = code;
-        break;
-      }
-    }
-    lang = lang ?? "en";
-  }
-  const { t } = await initI18n(lang);
+export default function AdminDeploymentInfo() {
   const {
     NEXT_PUBLIC_DEPLOY_TIME,
     NEXT_PUBLIC_APP_COMMIT,
     NEXT_PUBLIC_APP_VERSION,
-  } = config;
+  } = getPublicEnv();
+  const { t } = useTranslation();
+  const deployedAt = NEXT_PUBLIC_DEPLOY_TIME
+    ? new Date(NEXT_PUBLIC_DEPLOY_TIME).toLocaleString(undefined, {
+        timeZoneName: "short",
+      })
+    : t("unknown");
   return (
     <div className="mt-4 text-sm text-gray-600 dark:text-gray-400 space-y-1">
-      <p>
-        {t("admin.deployedAt", {
-          date: NEXT_PUBLIC_DEPLOY_TIME ?? t("unknown"),
-        })}
-      </p>
+      <p>{t("admin.deployedAt", { date: deployedAt })}</p>
       <p>
         {t("admin.deployCommit", {
           commit: NEXT_PUBLIC_APP_COMMIT ?? t("unknown"),


### PR DESCRIPTION
## Summary
- show deployment info with local timezone on admin page

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68673fede7a0832b8915c436b103b62f