### PR TITLE
feat: add snail mail listing API and page

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -215,6 +215,8 @@
   "snailMailSaved": "Snail mail saved",
   "snailMailShortfall": "Snail mail payment required",
   "snailMailError": "Snail mail error",
+  "openCasesOnly": "Open cases only",
+  "pendingOnly": "Pending only",
   "markRequested": "Mark as Requested",
   "noOwnershipModule": "No ownership module for state {{label}}. Supported states: {{supported}}. Please ensure the license plate state uses a two-letter abbreviation.",
   "failedUpdateVin": "Failed to update VIN.",

--- a/src/app/api/snail-mail/route.ts
+++ b/src/app/api/snail-mail/route.ts
@@ -1,0 +1,33 @@
+import { getSessionDetails, withAuthorization } from "@/lib/authz";
+import { getSentMails } from "@/lib/snailMailStore";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withAuthorization(
+  { obj: "cases" },
+  async (
+    req: Request,
+    {
+      session,
+    }: {
+      params: Promise<Record<string, string>>;
+      session?: { user?: { id?: string; role?: string } };
+    },
+  ) => {
+    const { userId } = getSessionDetails({ session }, "user");
+    if (!userId) {
+      return new Response(null, { status: 403 });
+    }
+    const url = new URL(req.url);
+    const caseId = url.searchParams.get("caseId") ?? undefined;
+    const status = url.searchParams.get("status") ?? undefined;
+    const mails = getSentMails().filter((m) => {
+      if (m.userId !== userId) return false;
+      if (caseId && m.caseId !== caseId) return false;
+      if (status && m.status !== status) return false;
+      return true;
+    });
+    return NextResponse.json(mails);
+  },
+);

--- a/src/app/snail-mail/page.tsx
+++ b/src/app/snail-mail/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+import { apiFetch } from "@/apiClient";
+import useCase from "@/app/hooks/useCase";
+import SnailMailStatusIcon from "@/components/SnailMailStatusIcon";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+interface SentMail {
+  id: string;
+  caseId?: string;
+  subject?: string;
+  status: "queued" | "saved" | "shortfall" | "error";
+  sentAt: string;
+}
+
+function SnailMailItem({
+  mail,
+  openOnly,
+}: { mail: SentMail; openOnly: boolean }) {
+  const { data: caseData } = useCase(mail.caseId ?? "", null);
+  if (openOnly && mail.caseId && caseData && caseData.closed) {
+    return null;
+  }
+  return (
+    <li className="border rounded p-2">
+      <div className="flex justify-between items-center">
+        <span className="font-semibold">{mail.subject ?? mail.id}</span>
+        <SnailMailStatusIcon status={mail.status} />
+      </div>
+      <div className="text-sm text-gray-500">
+        {mail.caseId ? <span className="mr-2">Case: {mail.caseId}</span> : null}
+        {new Date(mail.sentAt).toLocaleString()}
+      </div>
+    </li>
+  );
+}
+
+export default function SnailMailPage() {
+  const { t } = useTranslation();
+  const [openOnly, setOpenOnly] = useState(false);
+  const [pendingOnly, setPendingOnly] = useState(false);
+  const { data: mails = [] } = useQuery<SentMail[]>({
+    queryKey: ["/api/snail-mail"],
+    async queryFn() {
+      const res = await apiFetch("/api/snail-mail");
+      if (!res.ok) throw new Error("failed");
+      return res.json();
+    },
+  });
+
+  const filtered = mails.filter((m) =>
+    pendingOnly ? m.status === "queued" || m.status === "saved" : true,
+  );
+
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">Snail Mail</h1>
+      <div className="mb-4 flex gap-4">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={openOnly}
+            onChange={() => setOpenOnly(!openOnly)}
+          />
+          {t("openCasesOnly")}
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={pendingOnly}
+            onChange={() => setPendingOnly(!pendingOnly)}
+          />
+          {t("pendingOnly")}
+        </label>
+      </div>
+      <ul className="grid gap-2">
+        {filtered.map((m) => (
+          <SnailMailItem key={m.id} mail={m} openOnly={openOnly} />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/lib/snailMailStore.ts
+++ b/src/lib/snailMailStore.ts
@@ -2,6 +2,10 @@ export interface SentMail {
   id: string;
   providerId: string;
   providerMessageId: string;
+  /** Optional case this mail relates to */
+  caseId?: string;
+  /** Optional user who initiated the mail */
+  userId?: string;
   to: import("./snailMail").MailingAddress;
   from: import("./snailMail").MailingAddress;
   subject?: string;

--- a/test/snailMailRoute.test.ts
+++ b/test/snailMailRoute.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "smail-"));
+  process.env.SNAIL_MAIL_FILE = path.join(tmpDir, "snailMail.json");
+  vi.resetModules();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  process.env.SNAIL_MAIL_FILE = undefined;
+  vi.restoreAllMocks();
+});
+
+describe("snail mail API", () => {
+  it("lists mails for current user with filters", async () => {
+    const store = await import("@/lib/snailMailStore");
+    store.addSentMail({
+      id: "1",
+      providerId: "mock",
+      providerMessageId: "p1",
+      caseId: "c1",
+      userId: "u1",
+      to: {
+        address1: "a",
+        city: "b",
+        state: "c",
+        postalCode: "1",
+      },
+      from: {
+        address1: "a",
+        city: "b",
+        state: "c",
+        postalCode: "1",
+      },
+      contents: "f.pdf",
+      status: "queued",
+      sentAt: new Date().toISOString(),
+    });
+    const mod = await import("@/app/api/snail-mail/route");
+    const res = await mod.GET(new Request("http://test"), {
+      params: Promise.resolve({}) as Promise<Record<string, string>>,
+      session: { user: { id: "u1", role: "user" } },
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as unknown[];
+    expect(data).toHaveLength(1);
+
+    const resFiltered = await mod.GET(new Request("http://test?caseId=other"), {
+      params: Promise.resolve({}) as Promise<Record<string, string>>,
+      session: { user: { id: "u1", role: "user" } },
+    });
+    expect(resFiltered.status).toBe(200);
+    const dataFiltered = (await resFiltered.json()) as unknown[];
+    expect(dataFiltered).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add optional `caseId` and `userId` fields in snail mail store
- create `/api/snail-mail` to return sent mail for current user with optional filters
- add a snail mail page with filtering controls and status icons
- expose translation strings for new filters
- test snail mail API route

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke` *(fails: Hook timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68673dcd03d0832b9bd33e0638bc2516