### PR TITLE
Add ownership module management

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -172,6 +172,7 @@
   "cameraAccessError": "Unable to access camera. Please check permissions.",
   "vinLookupModules": "VIN Lookup Modules",
   "snailMailProviders": "Snail Mail Providers",
+  "ownershipModules": "Request Information Modules",
   "oauthProviders": "OAuth Providers",
   "mockEmailRecipient": "Mock Email Recipient",
   "envVarOverrides": "MOCK_EMAIL_TO environment variable overrides this setting.",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -172,6 +172,7 @@
   "cameraAccessError": "No se pudo acceder a la cámara. Verifica permisos.",
   "vinLookupModules": "Módulos de búsqueda de VIN",
   "snailMailProviders": "Proveedores de correo postal",
+  "ownershipModules": "Módulos de solicitud de información",
   "oauthProviders": "Proveedores OAuth",
   "mockEmailRecipient": "Destinatario de correo simulado",
   "envVarOverrides": "La variable de entorno MOCK_EMAIL_TO tiene prioridad.",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -172,6 +172,7 @@
   "cameraAccessError": "Impossible d'accéder à la caméra. Vérifiez les autorisations.",
   "vinLookupModules": "Modules de recherche de VIN",
   "snailMailProviders": "Fournisseurs de courrier postal",
+  "ownershipModules": "Modules de demande d'information",
   "oauthProviders": "Fournisseurs OAuth",
   "mockEmailRecipient": "Destinataire de courriel factice",
   "envVarOverrides": "La variable d'environnement MOCK_EMAIL_TO a priorité.",

--- a/src/app/admin/AppConfigurationTab.tsx
+++ b/src/app/admin/AppConfigurationTab.tsx
@@ -22,9 +22,17 @@ interface OauthProviderStatus {
   enabled: boolean;
 }
 
+interface OwnershipModuleStatus {
+  id: string;
+  state: string;
+  enabled: boolean;
+  failureCount: number;
+}
+
 const VIN_SOURCES_QUERY_KEY = ["/api/vin-sources"] as const;
 const MAIL_PROVIDERS_QUERY_KEY = ["/api/snail-mail-providers"] as const;
 const OAUTH_PROVIDERS_QUERY_KEY = ["/api/oauth-providers"] as const;
+const OWNERSHIP_MODULES_QUERY_KEY = ["/api/ownership-modules"] as const;
 const MOCK_EMAIL_QUERY_KEY = ["/api/mock-email"] as const;
 
 export default function AppConfigurationTab() {
@@ -34,6 +42,9 @@ export default function AppConfigurationTab() {
   });
   const { data: mailProviders = [] } = useQuery<SnailMailProviderStatus[]>({
     queryKey: MAIL_PROVIDERS_QUERY_KEY,
+  });
+  const { data: ownershipModules = [] } = useQuery<OwnershipModuleStatus[]>({
+    queryKey: OWNERSHIP_MODULES_QUERY_KEY,
   });
   const { data: oauthProviders = [] } = useQuery<OauthProviderStatus[]>({
     queryKey: OAUTH_PROVIDERS_QUERY_KEY,
@@ -89,6 +100,19 @@ export default function AppConfigurationTab() {
     },
     onSuccess() {
       queryClient.invalidateQueries({ queryKey: OAUTH_PROVIDERS_QUERY_KEY });
+    },
+  });
+
+  const ownershipToggleMutation = useMutation({
+    async mutationFn({ id, enabled }: { id: string; enabled: boolean }) {
+      await apiFetch(`/api/ownership-modules/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled }),
+      });
+    },
+    onSuccess() {
+      queryClient.invalidateQueries({ queryKey: OWNERSHIP_MODULES_QUERY_KEY });
     },
   });
 
@@ -155,6 +179,48 @@ export default function AppConfigurationTab() {
           </li>
         ))}
       </ul>
+      <h1 className="text-xl font-bold my-4">{t("ownershipModules")}</h1>
+      {(() => {
+        const grouped = ownershipModules.reduce<
+          Record<string, OwnershipModuleStatus[]>
+        >((acc, mod) => {
+          const arr = acc[mod.state] ?? [];
+          arr.push(mod);
+          acc[mod.state] = arr;
+          return acc;
+        }, {});
+        return Object.entries(grouped).map(([state, mods]) => (
+          <div key={state} className="mb-2">
+            <h2 className="font-semibold">{state}</h2>
+            <ul className="grid gap-2">
+              {mods.map((m) => (
+                <li key={m.id} className="flex items-center gap-4">
+                  <span className="flex-1">
+                    {m.id} (failures: {m.failureCount})
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      ownershipToggleMutation.mutate({
+                        id: m.id,
+                        enabled: !m.enabled,
+                      })
+                    }
+                    disabled={!isAdmin}
+                    className={
+                      m.enabled
+                        ? "bg-green-500 text-white px-2 py-1 rounded"
+                        : "bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
+                    }
+                  >
+                    {m.enabled ? t("admin.disable") : t("enable")}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ));
+      })()}
       <h1 className="text-xl font-bold my-4">{t("oauthProviders")}</h1>
       <ul className="grid gap-2">
         {oauthProviders.map((p) => (

--- a/src/app/admin/hooks/useCasbinRules.ts
+++ b/src/app/admin/hooks/useCasbinRules.ts
@@ -9,6 +9,7 @@ const policyOptions = {
     upload: ["create"],
     cases: ["read", "update", "delete"],
     snail_mail_providers: ["read"],
+    ownership_modules: ["read"],
     vin_sources: ["read"],
   },
   admin: {
@@ -16,6 +17,7 @@ const policyOptions = {
     users: ["create", "read", "update", "delete"],
     cases: ["update", "delete"],
     snail_mail_providers: ["update"],
+    ownership_modules: ["update"],
     vin_sources: ["update"],
   },
   superadmin: { superadmin: ["read", "update"] },

--- a/src/app/api/ownership-modules/[id]/route.ts
+++ b/src/app/api/ownership-modules/[id]/route.ts
@@ -1,0 +1,19 @@
+import { withAuthorization } from "@/lib/authz";
+import {
+  getOwnershipModuleStatuses,
+  setOwnershipModuleEnabled,
+} from "@/lib/ownershipModules";
+import { NextResponse } from "next/server";
+
+export const PUT = withAuthorization(
+  { obj: "ownership_modules", act: "update" },
+  async (req: Request, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const { enabled } = (await req.json()) as { enabled: boolean };
+    const result = setOwnershipModuleEnabled(id, enabled);
+    if (!result) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    return NextResponse.json(getOwnershipModuleStatuses());
+  },
+);

--- a/src/app/api/ownership-modules/route.ts
+++ b/src/app/api/ownership-modules/route.ts
@@ -1,0 +1,8 @@
+import { withAuthorization } from "@/lib/authz";
+import { getOwnershipModuleStatuses } from "@/lib/ownershipModules";
+import { NextResponse } from "next/server";
+
+export const GET = withAuthorization({ obj: "ownership_modules" }, async () => {
+  const list = getOwnershipModuleStatuses();
+  return NextResponse.json(list);
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -36,6 +36,7 @@ const envSchema = z
     FACEBOOK_CLIENT_SECRET: z.string().optional(),
     CASE_STORE_FILE: z.string().optional(),
     VIN_SOURCE_FILE: z.string().optional(),
+    OWNERSHIP_MODULE_FILE: z.string().optional(),
     SNAIL_MAIL_FILE: z.string().optional(),
     SNAIL_MAIL_PROVIDER_FILE: z.string().optional(),
     OAUTH_PROVIDER_FILE: z.string().optional(),


### PR DESCRIPTION
## Summary
- manage ownership modules at the API and admin UI level
- add translations for new "Request Information Modules" heading
- extend Casbin policies to cover ownership modules
- store ownership module statuses in a file via config setting
- test enabling/disabling ownership modules

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686741ec578c832b808e666fc53c9768