### PR TITLE
feat: add vertical tabs to admin configuration

### DIFF
--- a/src/app/admin/AppConfigurationTab.tsx
+++ b/src/app/admin/AppConfigurationTab.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { apiFetch } from "@/apiClient";
 import { useSession } from "@/app/useSession";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -130,141 +131,173 @@ export default function AppConfigurationTab() {
   });
 
   return (
-    <div>
-      <h1 className="text-xl font-bold mb-4">{t("vinLookupModules")}</h1>
-      <ul className="grid gap-2">
-        {sources.map((s) => (
-          <li key={s.id} className="flex items-center gap-4">
-            <span className="flex-1">
-              {s.id} (failures: {s.failureCount})
-            </span>
-            <button
-              type="button"
-              onClick={() =>
-                toggleMutation.mutate({ id: s.id, enabled: !s.enabled })
-              }
-              disabled={!isAdmin}
-              className={
-                s.enabled
-                  ? "bg-green-500 text-white px-2 py-1 rounded"
-                  : "bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
-              }
-            >
-              {s.enabled ? t("admin.disable") : t("enable")}
-            </button>
-          </li>
-        ))}
-      </ul>
-      <h1 className="text-xl font-bold my-4">{t("snailMailProviders")}</h1>
-      <ul className="grid gap-2">
-        {mailProviders.map((p) => (
-          <li key={p.id} className="flex items-center gap-4">
-            <span className="flex-1">
-              {p.id} (failures: {p.failureCount})
-            </span>
-            {p.active ? (
-              <span className="px-2 py-1 bg-green-500 text-white rounded">
-                {t("active")}
-              </span>
-            ) : (
-              <button
-                type="button"
-                onClick={() => activateMutation.mutate(p.id)}
-                disabled={!isAdmin}
-                className="bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
-              >
-                {t("activate")}
-              </button>
-            )}
-          </li>
-        ))}
-      </ul>
-      <h1 className="text-xl font-bold my-4">{t("ownershipModules")}</h1>
-      {(() => {
-        const grouped = ownershipModules.reduce<
-          Record<string, OwnershipModuleStatus[]>
-        >((acc, mod) => {
-          const arr = acc[mod.state] ?? [];
-          arr.push(mod);
-          acc[mod.state] = arr;
-          return acc;
-        }, {});
-        return Object.entries(grouped).map(([state, mods]) => (
-          <div key={state} className="mb-2">
-            <h2 className="font-semibold">{state}</h2>
-            <ul className="grid gap-2">
-              {mods.map((m) => (
-                <li key={m.id} className="flex items-center gap-4">
-                  <span className="flex-1">
-                    {m.id} (failures: {m.failureCount})
+    <Tabs orientation="vertical" className="flex gap-4" defaultValue="vin">
+      <TabsList className="flex flex-col w-48 shrink-0 border-r border-b-0 mr-4">
+        <TabsTrigger className="justify-start" value="vin">
+          {t("vinLookupModules")}
+        </TabsTrigger>
+        <TabsTrigger className="justify-start" value="mail">
+          {t("snailMailProviders")}
+        </TabsTrigger>
+        <TabsTrigger className="justify-start" value="ownership">
+          {t("ownershipModules")}
+        </TabsTrigger>
+        <TabsTrigger className="justify-start" value="oauth">
+          {t("oauthProviders")}
+        </TabsTrigger>
+        <TabsTrigger className="justify-start" value="mock">
+          {t("mockEmailRecipient")}
+        </TabsTrigger>
+      </TabsList>
+      <div className="flex-1">
+        <TabsContent value="vin">
+          <h1 className="text-xl font-bold mb-4">{t("vinLookupModules")}</h1>
+          <ul className="grid gap-2">
+            {sources.map((s) => (
+              <li key={s.id} className="flex items-center gap-4">
+                <span className="flex-1">
+                  {s.id} (failures: {s.failureCount})
+                </span>
+                <button
+                  type="button"
+                  onClick={() =>
+                    toggleMutation.mutate({ id: s.id, enabled: !s.enabled })
+                  }
+                  disabled={!isAdmin}
+                  className={
+                    s.enabled
+                      ? "bg-green-500 text-white px-2 py-1 rounded"
+                      : "bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
+                  }
+                >
+                  {s.enabled ? t("admin.disable") : t("enable")}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </TabsContent>
+        <TabsContent value="mail">
+          <h1 className="text-xl font-bold mb-4">{t("snailMailProviders")}</h1>
+          <ul className="grid gap-2">
+            {mailProviders.map((p) => (
+              <li key={p.id} className="flex items-center gap-4">
+                <span className="flex-1">
+                  {p.id} (failures: {p.failureCount})
+                </span>
+                {p.active ? (
+                  <span className="px-2 py-1 bg-green-500 text-white rounded">
+                    {t("active")}
                   </span>
+                ) : (
                   <button
                     type="button"
-                    onClick={() =>
-                      ownershipToggleMutation.mutate({
-                        id: m.id,
-                        enabled: !m.enabled,
-                      })
-                    }
+                    onClick={() => activateMutation.mutate(p.id)}
                     disabled={!isAdmin}
-                    className={
-                      m.enabled
-                        ? "bg-green-500 text-white px-2 py-1 rounded"
-                        : "bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
-                    }
+                    className="bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
                   >
-                    {m.enabled ? t("admin.disable") : t("enable")}
+                    {t("activate")}
                   </button>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ));
-      })()}
-      <h1 className="text-xl font-bold my-4">{t("oauthProviders")}</h1>
-      <ul className="grid gap-2">
-        {oauthProviders.map((p) => (
-          <li key={p.id} className="flex items-center gap-4">
-            <span className="flex-1">{p.id}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </TabsContent>
+        <TabsContent value="ownership">
+          <h1 className="text-xl font-bold mb-4">{t("ownershipModules")}</h1>
+          {(() => {
+            const grouped = ownershipModules.reduce<
+              Record<string, OwnershipModuleStatus[]>
+            >((acc, mod) => {
+              const arr = acc[mod.state] ?? [];
+              arr.push(mod);
+              acc[mod.state] = arr;
+              return acc;
+            }, {});
+            return Object.entries(grouped).map(([state, mods]) => (
+              <div key={state} className="mb-2">
+                <h2 className="font-semibold">{state}</h2>
+                <ul className="grid gap-2">
+                  {mods.map((m) => (
+                    <li key={m.id} className="flex items-center gap-4">
+                      <span className="flex-1">
+                        {m.id} (failures: {m.failureCount})
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          ownershipToggleMutation.mutate({
+                            id: m.id,
+                            enabled: !m.enabled,
+                          })
+                        }
+                        disabled={!isAdmin}
+                        className={
+                          m.enabled
+                            ? "bg-green-500 text-white px-2 py-1 rounded"
+                            : "bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
+                        }
+                      >
+                        {m.enabled ? t("admin.disable") : t("enable")}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ));
+          })()}
+        </TabsContent>
+        <TabsContent value="oauth">
+          <h1 className="text-xl font-bold mb-4">{t("oauthProviders")}</h1>
+          <ul className="grid gap-2">
+            {oauthProviders.map((p) => (
+              <li key={p.id} className="flex items-center gap-4">
+                <span className="flex-1">{p.id}</span>
+                <button
+                  type="button"
+                  onClick={() =>
+                    oauthToggleMutation.mutate({
+                      id: p.id,
+                      enabled: !p.enabled,
+                    })
+                  }
+                  disabled={!isAdmin}
+                  className={
+                    p.enabled
+                      ? "bg-green-500 text-white px-2 py-1 rounded"
+                      : "bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
+                  }
+                >
+                  {p.enabled ? t("admin.disable") : t("enable")}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </TabsContent>
+        <TabsContent value="mock">
+          <h1 className="text-xl font-bold mb-4">{t("mockEmailRecipient")}</h1>
+          <div className="flex items-center gap-2 mb-2">
+            <input
+              type="email"
+              value={mockTo}
+              onChange={(e) => setMockTo(e.target.value)}
+              placeholder={t("mockEmailRecipientPlaceholder")}
+              className="flex-1 border rounded p-1 bg-white dark:bg-gray-900"
+              disabled={!isAdmin}
+            />
             <button
               type="button"
-              onClick={() =>
-                oauthToggleMutation.mutate({ id: p.id, enabled: !p.enabled })
-              }
+              onClick={() => mockEmailMutation.mutate(mockTo)}
               disabled={!isAdmin}
-              className={
-                p.enabled
-                  ? "bg-green-500 text-white px-2 py-1 rounded"
-                  : "bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
-              }
+              className="bg-blue-600 text-white px-2 py-1 rounded"
             >
-              {p.enabled ? t("admin.disable") : t("enable")}
+              {t("save")}
             </button>
-          </li>
-        ))}
-      </ul>
-      <h1 className="text-xl font-bold my-4">{t("mockEmailRecipient")}</h1>
-      <div className="flex items-center gap-2 mb-2">
-        <input
-          type="email"
-          value={mockTo}
-          onChange={(e) => setMockTo(e.target.value)}
-          placeholder={t("mockEmailRecipientPlaceholder")}
-          className="flex-1 border rounded p-1 bg-white dark:bg-gray-900"
-          disabled={!isAdmin}
-        />
-        <button
-          type="button"
-          onClick={() => mockEmailMutation.mutate(mockTo)}
-          disabled={!isAdmin}
-          className="bg-blue-600 text-white px-2 py-1 rounded"
-        >
-          {t("save")}
-        </button>
+          </div>
+          {mockEmail?.envOverride && (
+            <p className="text-sm text-red-600">{t("envVarOverrides")}</p>
+          )}
+        </TabsContent>
       </div>
-      {mockEmail?.envOverride && (
-        <p className="text-sm text-red-600">{t("envVarOverrides")}</p>
-      )}
-    </div>
+    </Tabs>
   );
 }


### PR DESCRIPTION
## Summary
- add vertical Tabs layout to admin App Configuration

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686764652f84832b84db14f34c0c175b