### PR TITLE
Add commit link and copy icon to admin page

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -106,7 +106,8 @@
     "addRule": "Add Rule",
     "saveRules": "Save Rules",
     "deployedAt": "Deployed: {{date}}",
-    "deployCommit": "Commit: {{commit}}",
+    "deployCommit": "Commit:",
+    "copyCommitHash": "Copy commit hash",
     "deployVersion": "Version: {{version}}",
     "systemStatus": "System Status"
   },

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -106,7 +106,8 @@
     "addRule": "Agregar regla",
     "saveRules": "Guardar reglas",
     "deployedAt": "Desplegado: {{date}}",
-    "deployCommit": "Commit: {{commit}}",
+    "deployCommit": "Commit:",
+    "copyCommitHash": "Copiar hash del commit",
     "deployVersion": "Versión: {{version}}",
     "systemStatus": "Estado del sistema"
   },

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -106,7 +106,8 @@
     "addRule": "Ajouter une règle",
     "saveRules": "Enregistrer les règles",
     "deployedAt": "Déployé : {{date}}",
-    "deployCommit": "Commit : {{commit}}",
+    "deployCommit": "Commit :",
+    "copyCommitHash": "Copier le hash du commit",
     "deployVersion": "Version : {{version}}",
     "systemStatus": "État du système"
   },

--- a/src/app/admin/AdminDeploymentInfo.tsx
+++ b/src/app/admin/AdminDeploymentInfo.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { getPublicEnv } from "@/publicEnv";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { FaCopy } from "react-icons/fa";
 
 export default function AdminDeploymentInfo() {
   const {
@@ -9,6 +11,13 @@ export default function AdminDeploymentInfo() {
     NEXT_PUBLIC_APP_VERSION,
   } = getPublicEnv();
   const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  function copyCommit() {
+    if (!NEXT_PUBLIC_APP_COMMIT) return;
+    navigator.clipboard.writeText(NEXT_PUBLIC_APP_COMMIT);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
   const deployedAt = NEXT_PUBLIC_DEPLOY_TIME
     ? new Date(NEXT_PUBLIC_DEPLOY_TIME).toLocaleString(undefined, {
         timeZoneName: "short",
@@ -17,10 +26,31 @@ export default function AdminDeploymentInfo() {
   return (
     <div className="mt-4 text-sm text-gray-600 dark:text-gray-400 space-y-1">
       <p>{t("admin.deployedAt", { date: deployedAt })}</p>
-      <p>
-        {t("admin.deployCommit", {
-          commit: NEXT_PUBLIC_APP_COMMIT ?? t("unknown"),
-        })}
+      <p className="flex items-center gap-1">
+        <span>{t("admin.deployCommit")}</span>
+        {NEXT_PUBLIC_APP_COMMIT ? (
+          <a
+            href={`https://github.com/antialias/photo-to-citation/commit/${NEXT_PUBLIC_APP_COMMIT}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline text-blue-500 hover:text-blue-700"
+          >
+            {NEXT_PUBLIC_APP_COMMIT}
+          </a>
+        ) : (
+          <span>{t("unknown")}</span>
+        )}
+        {NEXT_PUBLIC_APP_COMMIT && (
+          <button
+            type="button"
+            onClick={copyCommit}
+            aria-label={t("admin.copyCommitHash")}
+            className="text-blue-500 hover:text-blue-700"
+          >
+            <FaCopy />
+          </button>
+        )}
+        {copied && <span className="text-green-600">{t("copied")}</span>}
       </p>
       <p>
         {t("admin.deployVersion", {


### PR DESCRIPTION
## Summary
- show commit details with a link to the GitHub commit
- allow copying the commit hash from the admin page
- translate new copy tooltip

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68676579f51c832bb134e13b325c16f9