### PR TITLE
feat: dynamic casbin policy options

### DIFF
--- a/src/app/admin/components/RuleRow.tsx
+++ b/src/app/admin/components/RuleRow.tsx
@@ -1,15 +1,19 @@
 "use client";
 import type { CasbinRule } from "../AdminPageClient";
-import { groupOptions, policyOptions } from "../hooks/useCasbinRules";
+import type { GroupOptions, PolicyOptions } from "../hooks/useCasbinRules";
 
 export default function RuleRow({
   rule,
   onChange,
   onRemove,
+  policyOptions,
+  groupOptions,
 }: {
   rule: CasbinRule;
   onChange: (field: keyof Omit<CasbinRule, "id">, value: string) => void;
   onRemove: () => void;
+  policyOptions: PolicyOptions;
+  groupOptions: GroupOptions;
 }) {
   const ptypeOptions = ["p", "g"];
   const v0Options =
@@ -17,18 +21,14 @@ export default function RuleRow({
   const v1Options =
     rule.ptype === "p"
       ? rule.v0
-        ? Object.keys(
-            policyOptions[rule.v0 as keyof typeof policyOptions] ?? {},
-          )
+        ? Object.keys(policyOptions[rule.v0] ?? {})
         : []
       : rule.v0
-        ? (groupOptions[rule.v0 as keyof typeof groupOptions] ?? [])
+        ? (groupOptions[rule.v0] ?? [])
         : [];
   const v2Options =
     rule.ptype === "p" && rule.v0 && rule.v1
-      ? (policyOptions[rule.v0 as keyof typeof policyOptions][
-          rule.v1 as keyof (typeof policyOptions)[keyof typeof policyOptions]
-        ] ?? [])
+      ? (policyOptions[rule.v0][rule.v1] ?? [])
       : [];
 
   return (

--- a/src/app/admin/components/RulesTable.tsx
+++ b/src/app/admin/components/RulesTable.tsx
@@ -13,6 +13,8 @@ export default function RulesTable({
     removeRule,
     saveRulesMutation,
     isSuperadmin,
+    policyOptions,
+    groupOptions,
   } = hooks;
   const { t } = useTranslation();
   return (
@@ -37,6 +39,8 @@ export default function RulesTable({
               rule={r}
               onChange={(field, value) => updateRule(r.id, field, value)}
               onRemove={() => removeRule(r.id)}
+              policyOptions={policyOptions}
+              groupOptions={groupOptions}
             />
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- dynamically derive policy and group options from DB rules
- pass policy & group options to rule table components

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6867634e7074832baa7119e55559e444