### PR TITLE
Add case-filtered snail mail link

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -147,6 +147,7 @@
   "emailLog": "Email Log",
   "to": "To:",
   "viewThread": "View Thread",
+  "viewSnailMail": "View Snail Mail",
   "paperwork": "Paperwork",
   "activeJobs": "Active Jobs",
   "lastAudit": "Last audit:",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -147,6 +147,7 @@
   "emailLog": "Registro de correo",
   "to": "Para:",
   "viewThread": "Ver hilo",
+  "viewSnailMail": "Ver correo postal",
   "paperwork": "Documentos",
   "activeJobs": "Trabajos activos",
   "lastAudit": "Última auditoría:",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -147,6 +147,7 @@
   "emailLog": "Journal des emails",
   "to": "À :",
   "viewThread": "Voir la discussion",
+  "viewSnailMail": "Voir le courrier postal",
   "paperwork": "Documents",
   "activeJobs": "Tâches actives",
   "lastAudit": "Dernier audit :",

--- a/src/app/api/snail-mail/route.ts
+++ b/src/app/api/snail-mail/route.ts
@@ -8,10 +8,13 @@ export const GET = withAuthorization({ obj: "cases" }, async (req: Request) => {
   const url = new URL(req.url);
   const statuses = url.searchParams.getAll("status");
   const openParam = url.searchParams.get("open");
+  const caseId = url.searchParams.get("case");
   const openOnly = openParam !== "false" && openParam !== "0";
-  const cases = getCases().filter((c) =>
-    openOnly ? !c.closed && !c.archived : true,
-  );
+  const cases = getCases().filter((c) => {
+    if (caseId && c.id !== caseId) return false;
+    if (!caseId && openOnly && (c.closed || c.archived)) return false;
+    return true;
+  });
   const mails: Array<{
     caseId: string;
     subject: string;

--- a/src/app/cases/[id]/components/CaseExtraInfo.tsx
+++ b/src/app/cases/[id]/components/CaseExtraInfo.tsx
@@ -2,6 +2,7 @@
 import DebugWrapper from "@/app/components/DebugWrapper";
 import ThumbnailImage from "@/components/thumbnail-image";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
+import Link from "next/link";
 import { useTranslation } from "react-i18next";
 import { FaFileAlt, FaFilePdf } from "react-icons/fa";
 import { useCaseContext } from "../CaseContext";
@@ -11,6 +12,7 @@ export default function CaseExtraInfo({ caseId }: { caseId: string }) {
   const { caseData, selectedPhoto, setSelectedPhoto } = useCaseContext();
   const { t } = useTranslation();
   if (!caseData) return null;
+  const hasSnail = (caseData.sentEmails ?? []).some((m) => m.snailMailStatus);
   const analysisImages = caseData.analysis?.images ?? {};
   const paperworkScans = (caseData.threadImages ?? []).map((img) => ({
     url: img.url,
@@ -27,7 +29,17 @@ export default function CaseExtraInfo({ caseId }: { caseId: string }) {
     <div className="grid gap-4 md:grid-cols-2">
       {caseData.sentEmails && caseData.sentEmails.length > 0 ? (
         <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded flex flex-col gap-2">
-          <h2 className="font-semibold">{t("emailLog")}</h2>
+          <h2 className="font-semibold flex items-center gap-2">
+            {t("emailLog")}
+            {hasSnail && (
+              <Link
+                href={`/snail-mail?case=${caseId}`}
+                className="text-blue-500 underline text-sm"
+              >
+                {t("viewSnailMail")}
+              </Link>
+            )}
+          </h2>
           <ul className="flex flex-col gap-2 text-sm">
             {buildThreads(caseData).map((mail) => (
               <li

--- a/src/app/snail-mail/SnailMailPageClient.tsx
+++ b/src/app/snail-mail/SnailMailPageClient.tsx
@@ -3,6 +3,7 @@
 import { apiFetch } from "@/apiClient";
 import SnailMailStatusIcon from "@/components/SnailMailStatusIcon";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -18,10 +19,13 @@ export default function SnailMailPageClient() {
   const [hideDelivered, setHideDelivered] = useState(true);
   const [mails, setMails] = useState<MailInfo[]>([]);
   const { t } = useTranslation();
+  const params = useSearchParams();
+  const caseId = params.get("case");
 
   useEffect(() => {
     const params = new URLSearchParams();
     params.set("open", openOnly ? "true" : "false");
+    if (caseId) params.set("case", caseId);
     if (hideDelivered) {
       params.append("status", "queued");
       params.append("status", "shortfall");
@@ -31,7 +35,7 @@ export default function SnailMailPageClient() {
       .then((r) => r.json() as Promise<MailInfo[]>)
       .then(setMails)
       .catch(() => setMails([]));
-  }, [openOnly, hideDelivered]);
+  }, [openOnly, hideDelivered, caseId]);
 
   return (
     <div className="p-8">


### PR DESCRIPTION
## Summary
- filter snail mail route by `case` query parameter
- let snail mail page pass case filter via search params
- show "View Snail Mail" link next to thread list when available
- translate new `viewSnailMail` label in all locales

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686768aad9f0832bb8fc2954820cd869