### PR TITLE
feat: add ownership request view action

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -43,6 +43,7 @@
   "cancelAnalysis": "Cancel Analysis",
   "draftEmail": "Draft Email to Authorities",
   "requestOwnershipInfo": "Request Ownership Info",
+  "viewOwnershipRequest": "View Ownership Request",
   "notifyRegisteredOwner": "Notify Registered Owner",
   "closeCase": "Close Case",
   "reopenCase": "Reopen Case",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -43,6 +43,7 @@
   "cancelAnalysis": "Cancelar análisis",
   "draftEmail": "Redactar correo a autoridades",
   "requestOwnershipInfo": "Solicitar información del propietario",
+  "viewOwnershipRequest": "Ver solicitud de propiedad",
   "notifyRegisteredOwner": "Notificar al propietario registrado",
   "closeCase": "Cerrar caso",
   "reopenCase": "Reabrir caso",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -43,6 +43,7 @@
   "cancelAnalysis": "Annuler l'analyse",
   "draftEmail": "Rédiger un email aux autorités",
   "requestOwnershipInfo": "Demander les informations du propriétaire",
+  "viewOwnershipRequest": "Voir la demande de propriété",
   "notifyRegisteredOwner": "Notifier le propriétaire enregistré",
   "closeCase": "Clôturer le cas",
   "reopenCase": "Rouvrir le cas",

--- a/src/app/cases/[id]/components/CaseHeader.tsx
+++ b/src/app/cases/[id]/components/CaseHeader.tsx
@@ -55,6 +55,9 @@ export default function CaseHeader({
         caseId={caseId}
         disabled={!violationIdentified}
         hasOwner={Boolean(ownerContact)}
+        ownershipRequested={Boolean(
+          caseData.ownershipRequests && caseData.ownershipRequests.length > 0,
+        )}
         progress={isPhotoReanalysis ? null : progress}
         canDelete={isAdmin}
         closed={caseData.closed}

--- a/src/app/cases/[id]/ownership-request/page.tsx
+++ b/src/app/cases/[id]/ownership-request/page.tsx
@@ -1,0 +1,20 @@
+import { getAuthorizedCase } from "@/lib/caseAccess";
+import { notFound } from "next/navigation";
+import ThreadWrapper from "../ThreadWrapper";
+
+export const dynamic = "force-dynamic";
+
+export default async function OwnershipRequestPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const c = await getAuthorizedCase(id);
+  if (!c) notFound();
+  const email = (c.sentEmails ?? []).find(
+    (e) => e.subject === "Ownership information request",
+  );
+  if (!email) notFound();
+  return <ThreadWrapper caseId={id} startId={email.sentAt} caseData={c} />;
+}

--- a/src/app/components/CaseSummary.tsx
+++ b/src/app/components/CaseSummary.tsx
@@ -30,6 +30,9 @@ export default function CaseSummary({ cases }: { cases: Case[] }) {
     (c) => c.analysisStatus === "complete" && hasCaseViolation(c),
   );
   const hasOwnerAll = cases.every((c) => Boolean(getCaseOwnerContact(c)));
+  const ownershipRequestedAll = cases.every(
+    (c) => (c.ownershipRequests ?? []).length > 0,
+  );
   const ids = cases.map((c) => c.id);
   const { t } = useTranslation();
 
@@ -39,6 +42,7 @@ export default function CaseSummary({ cases }: { cases: Case[] }) {
         caseIds={ids}
         disabled={actionsDisabled}
         hasOwner={hasOwnerAll}
+        ownershipRequested={ownershipRequestedAll}
       />
       <div className="p-8 flex flex-col gap-2">
         <h1 className="text-xl font-semibold">{t("caseSummary")}</h1>

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -16,6 +16,7 @@ export default function CaseToolbar({
   caseId,
   disabled = false,
   hasOwner = false,
+  ownershipRequested = false,
   progress,
   canDelete = false,
   closed = false,
@@ -26,6 +27,7 @@ export default function CaseToolbar({
   caseId: string;
   disabled?: boolean;
   hasOwner?: boolean;
+  ownershipRequested?: boolean;
   progress?: LlmProgress | null;
   canDelete?: boolean;
   closed?: boolean;
@@ -194,7 +196,16 @@ export default function CaseToolbar({
                       {t("draftEmail")}
                     </Link>
                   </DropdownMenuItem>
-                  {hasOwner ? null : (
+                  {hasOwner ? null : ownershipRequested ? (
+                    <DropdownMenuItem asChild>
+                      <Link
+                        href={`/cases/${caseId}/ownership-request`}
+                        className="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                      >
+                        {t("viewOwnershipRequest")}
+                      </Link>
+                    </DropdownMenuItem>
+                  ) : (
                     <DropdownMenuItem asChild>
                       <Link
                         href={`/cases/${caseId}/ownership`}

--- a/src/app/components/MultiCaseToolbar.tsx
+++ b/src/app/components/MultiCaseToolbar.tsx
@@ -14,10 +14,12 @@ export default function MultiCaseToolbar({
   caseIds,
   disabled = false,
   hasOwner = false,
+  ownershipRequested = false,
 }: {
   caseIds: string[];
   disabled?: boolean;
   hasOwner?: boolean;
+  ownershipRequested?: boolean;
 }) {
   const idsParam = caseIds.join(",");
   const first = caseIds[0];
@@ -83,7 +85,16 @@ export default function MultiCaseToolbar({
                   {t("draftEmail")}
                 </Link>
               </DropdownMenuItem>
-              {hasOwner ? null : (
+              {hasOwner ? null : ownershipRequested ? (
+                <DropdownMenuItem asChild>
+                  <Link
+                    href={`/cases/${first}/ownership-request?ids=${idsParam}`}
+                    className="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                  >
+                    {t("viewOwnershipRequest")}
+                  </Link>
+                </DropdownMenuItem>
+              ) : (
                 <DropdownMenuItem asChild>
                   <Link
                     href={`/cases/${first}/ownership?ids=${idsParam}`}

--- a/src/lib/caseActions.ts
+++ b/src/lib/caseActions.ts
@@ -44,6 +44,13 @@ export const caseActions: CaseAction[] = [
       "Record the steps for requesting official ownership details from the state. Use if the license plate is known but contact info is missing.",
   },
   {
+    id: "view-ownership-request",
+    label: "View Ownership Request",
+    href: (id) => `/cases/${id}/ownership-request`,
+    description:
+      "View the ownership information request that was previously sent.",
+  },
+  {
     id: "upload-photo",
     label: "Upload Photo",
     href: (id) => `/upload?case=${id}`,
@@ -110,6 +117,12 @@ export function getCaseActionStatus(
         } else if ((c.ownershipRequests ?? []).length > 0) {
           applicable = false;
           reason = "ownership info already requested";
+        }
+        break;
+      case "view-ownership-request":
+        if ((c.ownershipRequests ?? []).length === 0) {
+          applicable = false;
+          reason = "no ownership request";
         }
         break;
       default:


### PR DESCRIPTION
## Summary
- add `view-ownership-request` action when ownership info already requested
- hide request option once used
- show link to view ownership request in case and multi-case toolbars
- include page for viewing ownership request thread
- add translations

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68676b455c88832b9b3bd9d0d0dddc3a