### PR TITLE
feat: add view ownership request action

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -43,6 +43,7 @@
   "cancelAnalysis": "Cancel Analysis",
   "draftEmail": "Draft Email to Authorities",
   "requestOwnershipInfo": "Request Ownership Info",
+  "viewOwnershipRequest": "View Ownership Request",
   "notifyRegisteredOwner": "Notify Registered Owner",
   "closeCase": "Close Case",
   "reopenCase": "Reopen Case",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -43,6 +43,7 @@
   "cancelAnalysis": "Cancelar análisis",
   "draftEmail": "Redactar correo a autoridades",
   "requestOwnershipInfo": "Solicitar información del propietario",
+  "viewOwnershipRequest": "Ver solicitud de titularidad",
   "notifyRegisteredOwner": "Notificar al propietario registrado",
   "closeCase": "Cerrar caso",
   "reopenCase": "Reabrir caso",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -43,6 +43,7 @@
   "cancelAnalysis": "Annuler l'analyse",
   "draftEmail": "Rédiger un email aux autorités",
   "requestOwnershipInfo": "Demander les informations du propriétaire",
+  "viewOwnershipRequest": "Voir la demande de propriété",
   "notifyRegisteredOwner": "Notifier le propriétaire enregistré",
   "closeCase": "Clôturer le cas",
   "reopenCase": "Rouvrir le cas",

--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from "react-i18next";
 import InlineTranslateButton from "../../components/InlineTranslateButton";
 import { useNotify } from "../../components/NotificationProvider";
 import useChatTranslate from "../../useChatTranslate";
+import { useCaseContext } from "./CaseContext";
 
 export interface Message {
   id: string;
@@ -548,6 +549,10 @@ export function CaseChatProvider({
   }
 
   function renderActions(actions: CaseChatAction[], msgId: string) {
+    let caseData: import("@/lib/caseStore").Case | null = null;
+    try {
+      caseData = useCaseContext().caseData;
+    } catch {}
     const buttons = actions.map((a, idx) => {
       if ("id" in a) {
         const act = caseActions.find((c) => c.id === a.id);
@@ -562,7 +567,7 @@ export function CaseChatProvider({
                 } else if (act.id === "take-photo") {
                   openCamera(msgId);
                 } else {
-                  router.push(act.href(caseId));
+                  router.push(act.href(caseId, caseData ?? ({} as any)));
                 }
               }}
               className="bg-blue-600 text-white px-2 py-1 rounded mx-1"

--- a/src/app/cases/[id]/components/CaseHeader.tsx
+++ b/src/app/cases/[id]/components/CaseHeader.tsx
@@ -54,7 +54,6 @@ export default function CaseHeader({
       <CaseToolbar
         caseId={caseId}
         disabled={!violationIdentified}
-        hasOwner={Boolean(ownerContact)}
         progress={isPhotoReanalysis ? null : progress}
         canDelete={isAdmin}
         closed={caseData.closed}

--- a/src/lib/caseUtils.ts
+++ b/src/lib/caseUtils.ts
@@ -142,6 +142,26 @@ export interface OwnerContactInfo {
   address?: string;
 }
 
+export function getLatestOwnershipRequestThread(caseData: Case): string | null {
+  const reqs = caseData.ownershipRequests;
+  if (!reqs || reqs.length === 0) return null;
+  const latest = [...reqs].sort(
+    (a, b) =>
+      new Date(b.requestedAt).getTime() - new Date(a.requestedAt).getTime(),
+  )[0];
+  const mails = caseData.sentEmails ?? [];
+  const email = [...mails]
+    .reverse()
+    .find(
+      (m) =>
+        m.subject === "Ownership information request" &&
+        new Date(m.sentAt).getTime() >= new Date(latest.requestedAt).getTime(),
+    );
+  return email
+    ? `/cases/${caseData.id}/thread/${encodeURIComponent(email.sentAt)}`
+    : null;
+}
+
 function parseContactInfo(text: string): OwnerContactInfo {
   const emailMatch = text.match(
     /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/,

--- a/test/caseActions.test.ts
+++ b/test/caseActions.test.ts
@@ -1,0 +1,54 @@
+import { getCaseActionStatus } from "@/lib/caseActions";
+import type { Case } from "@/lib/caseStore";
+import { describe, expect, it } from "vitest";
+
+const baseCase: Case = {
+  id: "1",
+  photos: [],
+  photoTimes: {},
+  photoGps: {},
+  createdAt: "0",
+  updatedAt: "0",
+  public: false,
+  sessionId: null,
+  gps: null,
+  streetAddress: null,
+  intersection: null,
+  vin: null,
+  vinOverride: null,
+  analysis: null,
+  analysisOverrides: null,
+  analysisStatus: "complete",
+  analysisStatusCode: null,
+  analysisError: null,
+  analysisProgress: null,
+  sentEmails: [],
+  ownershipRequests: [],
+  threadImages: [],
+  closed: false,
+  note: null,
+  photoNotes: {},
+  archived: false,
+  violationOverride: null,
+  violationOverrideReason: null,
+};
+
+describe("getCaseActionStatus", () => {
+  it("disables ownership action after request", () => {
+    const c: Case = {
+      ...baseCase,
+      ownershipRequests: [
+        {
+          moduleId: "il",
+          requestedAt: "2024-01-01T00:00:00Z",
+          checkNumber: null,
+        },
+      ],
+    };
+    const statuses = getCaseActionStatus(c);
+    const ownership = statuses.find((s) => s.id === "ownership");
+    const viewReq = statuses.find((s) => s.id === "view-ownership-request");
+    expect(ownership?.applicable).toBe(false);
+    expect(viewReq?.applicable).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add helper to fetch latest ownership request thread
- add `view-ownership-request` case action and status checks
- show/hide ownership actions in toolbar using shared logic
- expose view ownership request option in translations
- update case chat provider for optional case context
- add unit test for ownership action status

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68676b455c88832b9b3bd9d0d0dddc3a