### PR TITLE
feat: show ownership request view option

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -43,6 +43,7 @@
   "cancelAnalysis": "Cancel Analysis",
   "draftEmail": "Draft Email to Authorities",
   "requestOwnershipInfo": "Request Ownership Info",
+  "viewOwnershipRequest": "View Ownership Request",
   "notifyRegisteredOwner": "Notify Registered Owner",
   "closeCase": "Close Case",
   "reopenCase": "Reopen Case",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -43,6 +43,7 @@
   "cancelAnalysis": "Cancelar análisis",
   "draftEmail": "Redactar correo a autoridades",
   "requestOwnershipInfo": "Solicitar información del propietario",
+  "viewOwnershipRequest": "Ver solicitud de titularidad",
   "notifyRegisteredOwner": "Notificar al propietario registrado",
   "closeCase": "Cerrar caso",
   "reopenCase": "Reabrir caso",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -43,6 +43,7 @@
   "cancelAnalysis": "Annuler l'analyse",
   "draftEmail": "Rédiger un email aux autorités",
   "requestOwnershipInfo": "Demander les informations du propriétaire",
+  "viewOwnershipRequest": "Voir la demande de propriété",
   "notifyRegisteredOwner": "Notifier le propriétaire enregistré",
   "closeCase": "Clôturer le cas",
   "reopenCase": "Rouvrir le cas",

--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -4,6 +4,7 @@ import ThumbnailImage from "@/components/thumbnail-image";
 import { caseActions } from "@/lib/caseActions";
 import type { CaseChatAction, CaseChatReply } from "@/lib/caseChat";
 import type { EmailDraft } from "@/lib/caseReport";
+import { getLatestOwnershipRequestLink } from "@/lib/caseUtils";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
 import { getLocalizedText } from "@/lib/localizedText";
 import type { ReportModule } from "@/lib/reportModules";
@@ -22,6 +23,7 @@ import { useTranslation } from "react-i18next";
 import InlineTranslateButton from "../../components/InlineTranslateButton";
 import { useNotify } from "../../components/NotificationProvider";
 import useChatTranslate from "../../useChatTranslate";
+import { useOptionalCaseContext } from "./CaseContext";
 
 export interface Message {
   id: string;
@@ -130,6 +132,7 @@ export function CaseChatProvider({
   const [open, setOpen] = useState(false);
   const [expandedState, setExpandedState] = useState(false);
   const expanded = controlledExpanded ?? expandedState;
+  const { caseData } = useOptionalCaseContext() ?? { caseData: null };
   const [messages, setMessages] = useState<Message[]>([]);
   const [history, setHistory] = useState<ChatSession[]>([]);
   const [sessionId, setSessionId] = useState<string | null>(null);
@@ -561,6 +564,11 @@ export function CaseChatProvider({
                   void openDraft(msgId);
                 } else if (act.id === "take-photo") {
                   openCamera(msgId);
+                } else if (act.id === "view-ownership-request") {
+                  const link = caseData
+                    ? getLatestOwnershipRequestLink(caseData)
+                    : null;
+                  if (link) router.push(link);
                 } else {
                   router.push(act.href(caseId));
                 }

--- a/src/app/cases/[id]/CaseContext.tsx
+++ b/src/app/cases/[id]/CaseContext.tsx
@@ -192,3 +192,7 @@ export function useCaseContext() {
   if (!ctx) throw new Error("useCaseContext must be used within CaseProvider");
   return ctx;
 }
+
+export function useOptionalCaseContext() {
+  return useContext(CaseContext);
+}

--- a/src/app/cases/[id]/components/CaseHeader.tsx
+++ b/src/app/cases/[id]/components/CaseHeader.tsx
@@ -1,7 +1,12 @@
 "use client";
 import CaseToolbar from "@/app/components/CaseToolbar";
 import { useSession } from "@/app/useSession";
-import { getCaseOwnerContact, hasCaseViolation } from "@/lib/caseUtils";
+import { getCaseActionStatus } from "@/lib/caseActions";
+import {
+  getCaseOwnerContact,
+  getLatestOwnershipRequestLink,
+  hasCaseViolation,
+} from "@/lib/caseUtils";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
 import { FaArrowLeft, FaShare } from "react-icons/fa";
@@ -24,6 +29,14 @@ export default function CaseHeader({
   const ownerContact = getCaseOwnerContact(caseData);
   const violationIdentified =
     caseData.analysisStatus === "complete" && hasCaseViolation(caseData);
+  const statuses = getCaseActionStatus(caseData);
+  const viewRequestStatus = statuses.find(
+    (s) => s.id === "view-ownership-request",
+  );
+  const ownershipRequested = Boolean(viewRequestStatus?.applicable);
+  const ownershipRequestLink = ownershipRequested
+    ? getLatestOwnershipRequestLink(caseData)
+    : null;
   return (
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-2">
@@ -55,6 +68,8 @@ export default function CaseHeader({
         caseId={caseId}
         disabled={!violationIdentified}
         hasOwner={Boolean(ownerContact)}
+        ownershipRequested={ownershipRequested}
+        ownershipRequestLink={ownershipRequestLink}
         progress={isPhotoReanalysis ? null : progress}
         canDelete={isAdmin}
         closed={caseData.closed}

--- a/src/app/cases/[id]/ownership-request/page.tsx
+++ b/src/app/cases/[id]/ownership-request/page.tsx
@@ -1,0 +1,18 @@
+import { getAuthorizedCase } from "@/lib/caseAccess";
+import { notFound } from "next/navigation";
+import ThreadWrapper from "../ThreadWrapper";
+
+export const dynamic = "force-dynamic";
+
+export default async function OwnershipRequestPage({
+  params,
+}: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const c = await getAuthorizedCase(id);
+  if (!c) notFound();
+  const email = [...(c.sentEmails ?? [])]
+    .filter((m) => m.subject === "Ownership information request")
+    .sort((a, b) => b.sentAt.localeCompare(a.sentAt))[0];
+  if (!email) notFound();
+  return <ThreadWrapper caseId={id} startId={email.sentAt} caseData={c} />;
+}

--- a/src/app/components/CaseToolbar.tsx
+++ b/src/app/components/CaseToolbar.tsx
@@ -22,6 +22,8 @@ export default function CaseToolbar({
   archived = false,
   violationOverride = false,
   readOnly = false,
+  ownershipRequested = false,
+  ownershipRequestLink,
 }: {
   caseId: string;
   disabled?: boolean;
@@ -32,6 +34,8 @@ export default function CaseToolbar({
   archived?: boolean;
   violationOverride?: boolean;
   readOnly?: boolean;
+  ownershipRequested?: boolean;
+  ownershipRequestLink?: string | null;
 }) {
   const { t } = useTranslation();
   const reqText = progress
@@ -194,7 +198,19 @@ export default function CaseToolbar({
                       {t("draftEmail")}
                     </Link>
                   </DropdownMenuItem>
-                  {hasOwner ? null : (
+                  {hasOwner ? null : ownershipRequested ? (
+                    <DropdownMenuItem asChild>
+                      <Link
+                        href={
+                          ownershipRequestLink ??
+                          `/cases/${caseId}/ownership-request`
+                        }
+                        className="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                      >
+                        {t("viewOwnershipRequest")}
+                      </Link>
+                    </DropdownMenuItem>
+                  ) : (
                     <DropdownMenuItem asChild>
                       <Link
                         href={`/cases/${caseId}/ownership`}

--- a/src/lib/caseActions.ts
+++ b/src/lib/caseActions.ts
@@ -44,6 +44,12 @@ export const caseActions: CaseAction[] = [
       "Record the steps for requesting official ownership details from the state. Use if the license plate is known but contact info is missing.",
   },
   {
+    id: "view-ownership-request",
+    label: "View Ownership Request",
+    href: (id) => `/cases/${id}/ownership-request`,
+    description: "View the most recent ownership information request email.",
+  },
+  {
     id: "upload-photo",
     label: "Upload Photo",
     href: (id) => `/upload?case=${id}`,
@@ -111,6 +117,9 @@ export function getCaseActionStatus(
           applicable = false;
           reason = "ownership info already requested";
         }
+        break;
+      case "view-ownership-request":
+        applicable = (c.ownershipRequests ?? []).length > 0;
         break;
       default:
         break;

--- a/src/lib/caseUtils.ts
+++ b/src/lib/caseUtils.ts
@@ -167,6 +167,15 @@ export function getCaseOwnerContactInfo(
   return parseContactInfo(contact);
 }
 
+export function getLatestOwnershipRequestLink(caseData: Case): string | null {
+  const email = [...(caseData.sentEmails ?? [])]
+    .filter((m) => m.subject === "Ownership information request")
+    .sort((a, b) => b.sentAt.localeCompare(a.sentAt))[0];
+  return email
+    ? `/cases/${caseData.id}/thread/${encodeURIComponent(email.sentAt)}`
+    : null;
+}
+
 export function getBestViolationPhoto(
   caseData: Pick<Case, "photos" | "analysis">,
 ): { photo: string; caption?: string } | null {


### PR DESCRIPTION
## Summary
- hide Request Ownership action after it is sent
- add View Ownership Request action with shared logic
- surface latest ownership request link in Case Chat and menu
- add optional Case context hook
- add translations for the new action

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68676b455c88832b9b3bd9d0d0dddc3a