### PR TITLE
feat: show case info on snail mail list

### DIFF
--- a/src/app/hooks/useSnailMail.ts
+++ b/src/app/hooks/useSnailMail.ts
@@ -1,0 +1,31 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+
+export interface MailInfo {
+  caseId: string;
+  subject: string;
+  status: "queued" | "saved" | "shortfall" | "error";
+  sentAt: string;
+}
+
+export interface SnailMailOptions {
+  openOnly: boolean;
+  hideDelivered: boolean;
+  caseId: string | null;
+}
+
+export function snailMailQueryKey(options: SnailMailOptions) {
+  const params = new URLSearchParams();
+  params.set("open", options.openOnly ? "true" : "false");
+  if (options.caseId) params.set("case", options.caseId);
+  if (options.hideDelivered) {
+    params.append("status", "queued");
+    params.append("status", "shortfall");
+    params.append("status", "error");
+  }
+  return [`/api/snail-mail?${params.toString()}`] as const;
+}
+
+export default function useSnailMail(options: SnailMailOptions) {
+  return useQuery<MailInfo[]>({ queryKey: snailMailQueryKey(options) });
+}


### PR DESCRIPTION
## Summary
- fetch the case when the snail mail list is filtered by case
- show the case ID and the violation type above the table

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke` *(fails: Timed out / environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68676f598c28832bb5a1ff66fb99906d