### PR TITLE
fix: specify runtime for stream routes

### DIFF
--- a/src/app/api/cases/[id]/jobs/stream/route.ts
+++ b/src/app/api/cases/[id]/jobs/stream/route.ts
@@ -5,6 +5,7 @@ import { jobEvents } from "@/lib/jobEvents";
 import { listJobs } from "@/lib/jobScheduler";
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export const GET = withAuthorization(

--- a/src/app/api/public/cases/[id]/jobs/stream/route.ts
+++ b/src/app/api/public/cases/[id]/jobs/stream/route.ts
@@ -4,6 +4,7 @@ import { jobEvents } from "@/lib/jobEvents";
 import { listJobs } from "@/lib/jobScheduler";
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(

--- a/src/app/api/system/jobs/stream/route.ts
+++ b/src/app/api/system/jobs/stream/route.ts
@@ -3,6 +3,7 @@ import { jobEvents } from "@/lib/jobEvents";
 import { listJobs } from "@/lib/jobScheduler";
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export const GET = withAuthorization(


### PR DESCRIPTION
## Summary
- ensure server runtime for job stream routes

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke` *(fails: Failed to load SWC binary)*

------
https://chatgpt.com/codex/tasks/task_e_6867d7b38290832bbec624b914504010