### PR TITLE
Fix System Status tab mount

### DIFF
--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -82,7 +82,7 @@ export default function AdminPageClient({
       </TabsContent>
       {isSuperadmin && (
         <TabsContent value="status">
-          <SystemStatusClient />
+          {tab === "status" && <SystemStatusClient />}
         </TabsContent>
       )}
     </Tabs>


### PR DESCRIPTION
## Summary
- mount `SystemStatusClient` only when System Status tab is active

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke` *(fails: Hook timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6867d7c12798832b94bda4f8713dcd44