### PR TITLE
fix: unify case list card height

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -240,7 +240,7 @@ export default function ClientCasesPage({
                     setDropCase(null);
                   }
                 }}
-                className={`border p-2 mb-4 last:mb-0 ${
+                className={`border p-2 mb-4 last:mb-0 h-[150px] ${
                   selectedIds.includes(c.id)
                     ? "bg-gray-100 dark:bg-gray-800 ring-2 ring-blue-500"
                     : dropCase === c.id
@@ -340,7 +340,7 @@ export default function ClientCasesPage({
                   setDropCase(null);
                 }
               }}
-              className={`border p-2 ${
+              className={`border p-2 h-[150px] ${
                 selectedIds.includes(c.id)
                   ? "bg-gray-100 dark:bg-gray-800 ring-2 ring-blue-500"
                   : dropCase === c.id


### PR DESCRIPTION
## Summary
- keep each case card a uniform height so react-virtual works reliably

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6867de2ddb30832b8df4ec82053338d9