### PR TITLE
Fix event source reconnections

### DIFF
--- a/src/app/hooks/useEventSource.ts
+++ b/src/app/hooks/useEventSource.ts
@@ -1,25 +1,29 @@
 import { apiEventSource } from "@/apiClient";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 export default function useEventSource<T>(
   url: string | null,
   onData: (data: T) => void,
 ) {
-  const handleMessage = useCallback(
-    (e: MessageEvent<string>) => {
-      try {
-        onData(JSON.parse(e.data) as T);
-      } catch {
-        // ignore invalid JSON
-      }
-    },
-    [onData],
-  );
+  const cbRef = useRef(onData);
 
+  useEffect(() => {
+    cbRef.current = onData;
+  }, [onData]);
+
+  const handleMessage = useCallback((e: MessageEvent<string>) => {
+    try {
+      cbRef.current(JSON.parse(e.data) as T);
+    } catch {
+      // ignore invalid JSON
+    }
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: handleMessage uses a ref
   useEffect(() => {
     if (!url) return;
     const es = apiEventSource(url);
     es.onmessage = handleMessage;
     return () => es.close();
-  }, [url, handleMessage]);
+  }, [url]);
 }


### PR DESCRIPTION
## Summary
- keep `onData` callback ref for `useEventSource`
- prevent SSE reconnects caused by state updates

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6867e9344e6c832bbe46af0333814bc8