### PR TITLE
Fix pnpm setup in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9.15.4
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "pnpm"
       - name: Install dependencies
-        run: |
-          corepack install -g pnpm@9.15.4
-          pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - run: pnpm run lint
       - run: pnpm run typecheck
 
@@ -27,14 +29,16 @@ jobs:
     needs: lint_typecheck
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9.15.4
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "pnpm"
       - name: Install dependencies
-        run: |
-          corepack install -g pnpm@9.15.4
-          pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - run: pnpm test -- --bail 1
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
@@ -44,14 +48,16 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9.15.4
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "pnpm"
       - name: Install dependencies
-        run: |
-          corepack install -g pnpm@9.15.4
-          pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - run: pnpm run e2e -- --bail 1
         env:
           NODE_OPTIONS: '--max-old-space-size=6144'
@@ -66,14 +72,16 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9.15.4
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "pnpm"
       - name: Install dependencies
-        run: |
-          corepack install -g pnpm@9.15.4
-          pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - run: pnpm run build-storybook
         env:
           STORYBOOK_DISABLE_TELEMETRY: "1"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,14 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9.15.4
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "pnpm"
       - name: Install dependencies
-        run: |
-          corepack install -g pnpm@9.15.4
-          pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - name: Verify build
         run: pnpm run build
       - name: Set build time

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -21,14 +21,16 @@ jobs:
         run: |
           git remote set-url origin https://github.com/${{ github.repository }}.git
           git fetch origin gh-pages --depth=1 || true
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9.15.4
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
       - name: Install dependencies
-        run: |
-          corepack install -g pnpm@9.15.4
-          pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - run: pnpm run website
         env:
           PATH_PREFIX: /photo-to-citation/website/


### PR DESCRIPTION
## Summary
- ensure `pnpm` is available before `actions/setup-node` caches dependencies
- update CI, Docker build and website workflows

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6867e6f8e068832b874158e2aff11f4a