### PR TITLE
fix: ensure pnpm during Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,15 @@
 FROM node:20-bookworm AS deps
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
-RUN corepack install -g pnpm@9.15.4 \
+RUN corepack enable \
+    && corepack prepare pnpm@9.15.4 --activate \
     && pnpm install --frozen-lockfile
 
 # Build the application
 FROM node:20-bookworm AS builder
 WORKDIR /app
-RUN corepack install -g pnpm@9.15.4
+RUN corepack enable \
+    && corepack prepare pnpm@9.15.4 --activate
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ARG NEXT_PUBLIC_BASE_PATH=""
@@ -26,7 +28,8 @@ RUN pnpm run build && pnpm prune --prod
 # Runtime image
 FROM node:20-bookworm AS runner
 WORKDIR /app
-RUN corepack install -g pnpm@9.15.4
+RUN corepack enable \
+    && corepack prepare pnpm@9.15.4 --activate
 ENV NODE_ENV=production
 ENV PORT=3000
 ARG NEXT_PUBLIC_BASE_PATH=""


### PR DESCRIPTION
## Summary
- ensure `pnpm` is activated via Corepack in all Dockerfile stages

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6867efb7f128832b86beee26c69914c3