### PR TITLE
Redesign case list

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
   },
   "optionalDependencies": {
     "@biomejs/cli-linux-x64": "^1.9.4",
-    "@rollup/rollup-linux-x64-gnu": "^4.44.1",
+    "@rollup/rollup-linux-x64-gnu": "^4.44.2",
     "@tailwindcss/oxide-linux-x64-gnu": "^4.1.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,7 +166,7 @@ importers:
         specifier: ^1.9.4
         version: 1.9.4
       '@rollup/rollup-linux-x64-gnu':
-        specifier: ^4.44.1
+        specifier: ^4.44.2
         version: 4.44.2
       '@tailwindcss/oxide-linux-x64-gnu':
         specifier: ^4.1.11
@@ -23174,7 +23174,9 @@ snapshots:
       pretty-format: 24.9.0
       throat: 4.1.0
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   jest-leak-detector@24.9.0:
     dependencies:

--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -1,12 +1,10 @@
 "use client";
 import { apiFetch } from "@/apiClient";
-import AnalysisInfo from "@/app/components/AnalysisInfo";
-import MapPreview from "@/app/components/MapPreview";
 import useNewCaseFromFiles from "@/app/useNewCaseFromFiles";
+import CaseCard from "@/components/CaseCard";
 import type { Case } from "@/lib/caseStore";
-import { getOfficialCaseGps, getRepresentativePhoto } from "@/lib/caseUtils";
+import { getOfficialCaseGps } from "@/lib/caseUtils";
 import { distanceBetween } from "@/lib/distance";
-import { useQueryClient } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
@@ -57,11 +55,10 @@ export default function ClientCasesPage({
     lon: number;
   } | null>(null);
   const router = useRouter();
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const uploadNewCase = useNewCaseFromFiles();
   const [dragging, setDragging] = useState(false);
   const [dropCase, setDropCase] = useState<string | null>(null);
-  const queryClient = useQueryClient();
   const notify = useNotify();
   const { data: session } = useSession();
   const params = useParams<{ id?: string }>();
@@ -141,19 +138,6 @@ export default function ClientCasesPage({
     if (results.some((r) => !r.ok)) {
       notify(t("failedUpload"));
       return;
-    }
-  }
-
-  async function translate(id: string, path: string, lang: string) {
-    const res = await apiFetch(`/api/cases/${id}/translate`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ path, lang }),
-    });
-    if (res.ok) {
-      queryClient.invalidateQueries({ queryKey: caseQueryKey(id) });
-    } else {
-      notify("Failed to translate.");
     }
   }
 
@@ -240,12 +224,12 @@ export default function ClientCasesPage({
                     setDropCase(null);
                   }
                 }}
-                className={`border p-2 mb-4 last:mb-0 h-[150px] overflow-hidden ${
+                className={`border rounded p-2 mb-4 last:mb-0${
                   selectedIds.includes(c.id)
-                    ? "bg-gray-100 dark:bg-gray-800 ring-2 ring-blue-500"
+                    ? " bg-gray-100 dark:bg-gray-800 ring-2 ring-blue-500"
                     : dropCase === c.id
-                      ? "ring-2 ring-green-500"
-                      : "ring-1 ring-transparent"
+                      ? " ring-2 ring-green-500"
+                      : " ring-1 ring-transparent"
                 }`}
                 style={{
                   position: "absolute",
@@ -264,63 +248,9 @@ export default function ClientCasesPage({
                       router.push(`/cases?ids=${ids.join(",")}`);
                     }
                   }}
-                  className="flex flex-wrap lg:flex-nowrap items-start gap-4 w-full text-left h-full overflow-hidden"
+                  className="block text-left"
                 >
-                  <div className="relative">
-                    {(() => {
-                      const photo = getRepresentativePhoto(c);
-                      return photo ? (
-                        <img
-                          src={`/uploads/${photo}`}
-                          alt={t("casePreview")}
-                          width={80}
-                          height={60}
-                          loading="lazy"
-                        />
-                      ) : null;
-                    })()}
-                    {c.photos.length > 1 ? (
-                      <span className="absolute bottom-1 right-1 bg-black bg-opacity-75 text-white text-xs rounded px-1">
-                        {c.photos.length}
-                      </span>
-                    ) : null}
-                  </div>
-                  {(() => {
-                    const g = getOfficialCaseGps(c);
-                    return g ? (
-                      <MapPreview
-                        lat={g.lat}
-                        lon={g.lon}
-                        width={120}
-                        height={90}
-                        className="w-20 aspect-[4/3]"
-                      />
-                    ) : null;
-                  })()}
-                  <div className="flex flex-col text-sm gap-1 overflow-hidden">
-                    <span className="font-semibold">
-                      {t("caseLabel", { id: c.id })}
-                    </span>
-                    {c.analysis ? (
-                      <>
-                        <AnalysisInfo
-                          analysis={c.analysis}
-                          onTranslate={() =>
-                            translate(c.id, "analysis.details", i18n.language)
-                          }
-                        />
-                        {c.analysisStatus === "pending" ? (
-                          <span className="text-gray-500 dark:text-gray-400">
-                            {t("updatingAnalysis")}
-                          </span>
-                        ) : null}
-                      </>
-                    ) : (
-                      <span className="text-gray-500 dark:text-gray-400">
-                        {t("analyzingPhoto")}
-                      </span>
-                    )}
-                  </div>
+                  <CaseCard caseData={c} />
                 </Link>
               </div>
             );
@@ -340,12 +270,12 @@ export default function ClientCasesPage({
                   setDropCase(null);
                 }
               }}
-              className={`border p-2 h-[150px] overflow-hidden ${
+              className={`border rounded p-2${
                 selectedIds.includes(c.id)
-                  ? "bg-gray-100 dark:bg-gray-800 ring-2 ring-blue-500"
+                  ? " bg-gray-100 dark:bg-gray-800 ring-2 ring-blue-500"
                   : dropCase === c.id
-                    ? "ring-2 ring-green-500"
-                    : "ring-1 ring-transparent"
+                    ? " ring-2 ring-green-500"
+                    : " ring-1 ring-transparent"
               }`}
             >
               <Link
@@ -357,63 +287,9 @@ export default function ClientCasesPage({
                     router.push(`/cases?ids=${ids.join(",")}`);
                   }
                 }}
-                className="flex flex-wrap lg:flex-nowrap items-start gap-4 w-full text-left h-full overflow-hidden"
+                className="block text-left"
               >
-                <div className="relative">
-                  {(() => {
-                    const photo = getRepresentativePhoto(c);
-                    return photo ? (
-                      <img
-                        src={`/uploads/${photo}`}
-                        alt={t("casePreview")}
-                        width={80}
-                        height={60}
-                        loading="lazy"
-                      />
-                    ) : null;
-                  })()}
-                  {c.photos.length > 1 ? (
-                    <span className="absolute bottom-1 right-1 bg-black bg-opacity-75 text-white text-xs rounded px-1">
-                      {c.photos.length}
-                    </span>
-                  ) : null}
-                </div>
-                {(() => {
-                  const g = getOfficialCaseGps(c);
-                  return g ? (
-                    <MapPreview
-                      lat={g.lat}
-                      lon={g.lon}
-                      width={120}
-                      height={90}
-                      className="w-20 aspect-[4/3]"
-                    />
-                  ) : null;
-                })()}
-                <div className="flex flex-col text-sm gap-1 overflow-hidden">
-                  <span className="font-semibold">
-                    {t("caseLabel", { id: c.id })}
-                  </span>
-                  {c.analysis ? (
-                    <>
-                      <AnalysisInfo
-                        analysis={c.analysis}
-                        onTranslate={() =>
-                          translate(c.id, "analysis.details", i18n.language)
-                        }
-                      />
-                      {c.analysisStatus === "pending" ? (
-                        <span className="text-gray-500 dark:text-gray-400">
-                          {t("updatingAnalysis")}
-                        </span>
-                      ) : null}
-                    </>
-                  ) : (
-                    <span className="text-gray-500 dark:text-gray-400">
-                      {t("analyzingPhoto")}
-                    </span>
-                  )}
-                </div>
+                <CaseCard caseData={c} />
               </Link>
             </li>
           ))}

--- a/src/components/CaseCard.tsx
+++ b/src/components/CaseCard.tsx
@@ -1,0 +1,77 @@
+import MapPreview from "@/app/components/MapPreview";
+import type { Case } from "@/lib/caseStore";
+import {
+  getCasePlateNumber,
+  getCasePlateState,
+  getOfficialCaseGps,
+  getRepresentativePhoto,
+} from "@/lib/caseUtils";
+import { useTranslation } from "react-i18next";
+
+export interface CaseCardProps {
+  caseData: Case;
+  className?: string;
+}
+
+export default function CaseCard({ caseData, className }: CaseCardProps) {
+  const { t } = useTranslation();
+  const photo = getRepresentativePhoto(caseData);
+  const location = getOfficialCaseGps(caseData);
+  const plateNumber = getCasePlateNumber(caseData);
+  const plateState = getCasePlateState(caseData);
+  const status = caseData.archived
+    ? t("archived")
+    : caseData.closed
+      ? t("closed")
+      : t("open");
+  return (
+    <div
+      className={`grid grid-cols-[auto_auto_1fr] items-center gap-2 ${className ?? ""}`}
+    >
+      {photo ? (
+        <div className="relative w-16 h-12 shrink-0">
+          <img
+            src={`/uploads/${photo}`}
+            alt={t("casePreview")}
+            width={64}
+            height={48}
+            className="object-cover w-full h-full"
+            loading="lazy"
+          />
+          {caseData.photos.length > 1 ? (
+            <span className="absolute bottom-1 right-1 bg-black/75 text-white text-xs rounded px-1">
+              {caseData.photos.length}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+      {location ? (
+        <MapPreview
+          lat={location.lat}
+          lon={location.lon}
+          width={96}
+          height={72}
+          className="w-16 aspect-[4/3]"
+        />
+      ) : null}
+      <div className="flex flex-col text-xs gap-0.5 overflow-hidden">
+        <span className="font-semibold text-sm truncate">
+          {t("caseLabel", { id: caseData.id })}
+        </span>
+        {caseData.analysis?.violationType ? (
+          <span className="truncate">{caseData.analysis.violationType}</span>
+        ) : null}
+        {plateNumber || plateState ? (
+          <span className="text-gray-500 dark:text-gray-400 truncate">
+            {plateState ? `${plateState} ` : ""}
+            {plateNumber}
+          </span>
+        ) : null}
+        <span className="text-gray-500 dark:text-gray-400">{status}</span>
+        {caseData.analysisStatus === "pending" ? (
+          <span className="text-gray-400">{t("updatingAnalysis")}</span>
+        ) : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `CaseCard` component for compact case listings
- update client cases page to use `CaseCard`

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6867f007bf8c832b90858c5fd7947bca