### PR TITLE
feat: add driver license fields

### DIFF
--- a/migrations/0024_user_driver_license.sql
+++ b/migrations/0024_user_driver_license.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user ADD COLUMN driver_license_number TEXT;
+ALTER TABLE user ADD COLUMN driver_license_state TEXT;

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -220,6 +220,8 @@
   "stateLabel": "State:",
   "sendCheckTo": "Send a check for ${{fee}} to:",
   "checkNumberLabel": "Check Number",
+  "driverLicenseNumberLabel": "Driver License Number",
+  "driverLicenseStateLabel": "Driver License State",
   "sendSnailAutomatically": "Send snail mail automatically",
   "sendSnailMailRequest": "Send Snail Mail Request",
   "snailMailQueued": "Snail mail queued",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -220,6 +220,8 @@
   "stateLabel": "Estado:",
   "sendCheckTo": "Envía un cheque por ${{fee}} a:",
   "checkNumberLabel": "Número de cheque",
+  "driverLicenseNumberLabel": "Número de licencia de conducir",
+  "driverLicenseStateLabel": "Estado de la licencia",
   "sendSnailAutomatically": "Enviar correo postal automáticamente",
   "sendSnailMailRequest": "Enviar solicitud por correo",
   "snailMailQueued": "Correo postal en cola",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -220,6 +220,8 @@
   "stateLabel": "État :",
   "sendCheckTo": "Envoyez un chèque de ${{fee}} à :",
   "checkNumberLabel": "Numéro de chèque",
+  "driverLicenseNumberLabel": "Numéro de permis de conduire",
+  "driverLicenseStateLabel": "État du permis",
   "sendSnailAutomatically": "Envoyer le courrier postal automatiquement",
   "sendSnailMailRequest": "Envoyer la demande par courrier",
   "snailMailQueued": "Courrier postal en file d'attente",

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -26,16 +26,27 @@ export async function PUT(
 ) {
   const { userId } = await loadAuthContext(ctx, "user");
   if (!userId) return new Response(null, { status: 401 });
-  const { name, image, bio, socialLinks, address, cityStateZip, daytimePhone } =
-    (await req.json()) as {
-      name?: string | null;
-      image?: string | null;
-      bio?: string | null;
-      socialLinks?: string | null;
-      address?: string | null;
-      cityStateZip?: string | null;
-      daytimePhone?: string | null;
-    };
+  const {
+    name,
+    image,
+    bio,
+    socialLinks,
+    address,
+    cityStateZip,
+    daytimePhone,
+    driverLicenseNumber,
+    driverLicenseState,
+  } = (await req.json()) as {
+    name?: string | null;
+    image?: string | null;
+    bio?: string | null;
+    socialLinks?: string | null;
+    address?: string | null;
+    cityStateZip?: string | null;
+    daytimePhone?: string | null;
+    driverLicenseNumber?: string | null;
+    driverLicenseState?: string | null;
+  };
   const user = updateUser(userId, {
     name,
     image,
@@ -44,6 +55,8 @@ export async function PUT(
     address,
     cityStateZip,
     daytimePhone,
+    driverLicenseNumber,
+    driverLicenseState,
     profileStatus: "under_review",
     profileReviewNotes: null,
   });

--- a/src/app/cases/[id]/ownership/OwnershipEditor.tsx
+++ b/src/app/cases/[id]/ownership/OwnershipEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { apiFetch } from "@/apiClient";
 import type { OwnershipModule } from "@/lib/ownershipModules";
+import { US_STATES } from "@/lib/usStates";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -20,6 +21,7 @@ export default function OwnershipEditor({
   const [form, setForm] = useState<Record<string, string>>({
     reasonForRequestingRecords: "private investigation",
     reasonH: "true",
+    requesterDriverLicenseState: "IL",
   });
   const [option, setOption] = useState<string>("titleSearch");
   const [microfilmWithSearchOption, setMicrofilmWithSearchOption] =
@@ -53,6 +55,8 @@ export default function OwnershipEditor({
             address?: string;
             cityStateZip?: string;
             daytimePhone?: string;
+            driverLicenseNumber?: string;
+            driverLicenseState?: string;
           }) => {
             setForm((f) => ({
               ...f,
@@ -61,6 +65,10 @@ export default function OwnershipEditor({
                 p.cityStateZip ?? f.requesterCityStateZip ?? "",
               requesterDaytimePhoneNumber:
                 p.daytimePhone ?? f.requesterDaytimePhoneNumber ?? "",
+              requesterDriverLicenseNumber:
+                p.driverLicenseNumber ?? f.requesterDriverLicenseNumber ?? "",
+              requesterDriverLicenseState:
+                p.driverLicenseState ?? f.requesterDriverLicenseState ?? "IL",
             }));
           },
         )
@@ -129,6 +137,8 @@ export default function OwnershipEditor({
           address: form.requesterAddress,
           cityStateZip: form.requesterCityStateZip,
           daytimePhone: form.requesterDaytimePhoneNumber,
+          driverLicenseNumber: form.requesterDriverLicenseNumber,
+          driverLicenseState: form.requesterDriverLicenseState,
         }),
       }).catch(() => {});
     }
@@ -234,6 +244,39 @@ export default function OwnershipEditor({
           }
           className="border p-1"
         />
+      </label>
+      <label className="flex flex-col">
+        {t("driverLicenseNumberLabel")}
+        <input
+          type="text"
+          value={form.requesterDriverLicenseNumber ?? ""}
+          onChange={(e) =>
+            setForm((f) => ({
+              ...f,
+              requesterDriverLicenseNumber: e.target.value,
+            }))
+          }
+          className="border p-1"
+        />
+      </label>
+      <label className="flex flex-col">
+        {t("driverLicenseStateLabel")}
+        <select
+          value={form.requesterDriverLicenseState ?? "IL"}
+          onChange={(e) =>
+            setForm((f) => ({
+              ...f,
+              requesterDriverLicenseState: e.target.value,
+            }))
+          }
+          className="border p-1"
+        >
+          {US_STATES.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
       </label>
       <label className="flex flex-col">
         Section 2

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,6 +2,7 @@
 import { apiFetch } from "@/apiClient";
 import { useSession } from "@/app/useSession";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { US_STATES } from "@/lib/usStates";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -25,6 +26,8 @@ export default function UserSettingsPage() {
     address?: string;
     cityStateZip?: string;
     daytimePhone?: string;
+    driverLicenseNumber?: string;
+    driverLicenseState?: string;
     profileStatus?: string;
     profileReviewNotes?: string | null;
   }>({
@@ -39,6 +42,8 @@ export default function UserSettingsPage() {
         address?: string;
         cityStateZip?: string;
         daytimePhone?: string;
+        driverLicenseNumber?: string;
+        driverLicenseState?: string;
         profileStatus?: string;
         profileReviewNotes?: string | null;
       };
@@ -53,6 +58,8 @@ export default function UserSettingsPage() {
   const [address, setAddress] = useState("");
   const [cityStateZip, setCityStateZip] = useState("");
   const [daytimePhone, setDaytimePhone] = useState("");
+  const [driverLicenseNumber, setDriverLicenseNumber] = useState("");
+  const [driverLicenseState, setDriverLicenseState] = useState("IL");
   const [status, setStatus] = useState<string | undefined>(undefined);
   const [notes, setNotes] = useState<string | null | undefined>(undefined);
 
@@ -65,6 +72,8 @@ export default function UserSettingsPage() {
       setAddress(data.address ?? "");
       setCityStateZip(data.cityStateZip ?? "");
       setDaytimePhone(data.daytimePhone ?? "");
+      setDriverLicenseNumber(data.driverLicenseNumber ?? "");
+      setDriverLicenseState(data.driverLicenseState ?? "IL");
       setStatus(data.profileStatus);
       setNotes(data.profileReviewNotes ?? null);
     }
@@ -83,6 +92,8 @@ export default function UserSettingsPage() {
           address,
           cityStateZip,
           daytimePhone,
+          driverLicenseNumber,
+          driverLicenseState,
         }),
       });
     },
@@ -160,6 +171,28 @@ export default function UserSettingsPage() {
                 onChange={(e) => setDaytimePhone(e.target.value)}
                 className="border p-1"
               />
+            </label>
+            <label className="flex flex-col">
+              {t("driverLicenseNumberLabel")}
+              <input
+                value={driverLicenseNumber}
+                onChange={(e) => setDriverLicenseNumber(e.target.value)}
+                className="border p-1"
+              />
+            </label>
+            <label className="flex flex-col">
+              {t("driverLicenseStateLabel")}
+              <select
+                value={driverLicenseState}
+                onChange={(e) => setDriverLicenseState(e.target.value)}
+                className="border p-1"
+              >
+                {US_STATES.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
             </label>
             <label className="flex flex-col">
               {t("socialLinksLabel")}

--- a/src/generated/zod/ownershipModules.ts
+++ b/src/generated/zod/ownershipModules.ts
@@ -17,6 +17,7 @@ export const ownershipRequestInfoSchema = z.object({
   requesterCityStateZip: z.string().optional().nullable(),
   requesterDaytimePhoneNumber: z.string().optional().nullable(),
   requesterDriverLicenseNumber: z.string().optional().nullable(),
+  requesterDriverLicenseState: z.string().optional().nullable(),
   requesterEmailAddress: z.string().optional().nullable(),
   requesterPhoneNumber: z.string().optional().nullable(),
   vehicleYear: z.string().optional().nullable(),
@@ -74,4 +75,11 @@ export const ownershipModuleSchema = z.object({
     .args(ownershipRequestInfoSchema)
     .returns(z.promise(z.union([z.string(), z.array(z.string())])))
     .optional(),
+});
+
+export const ownershipModuleStatusSchema = z.object({
+  id: z.string(),
+  state: z.string(),
+  enabled: z.boolean(),
+  failureCount: z.number(),
 });

--- a/src/lib/ownershipModules.ts
+++ b/src/lib/ownershipModules.ts
@@ -23,6 +23,7 @@ export interface OwnershipRequestInfo {
   requesterCityStateZip?: string | null;
   requesterDaytimePhoneNumber?: string | null;
   requesterDriverLicenseNumber?: string | null;
+  requesterDriverLicenseState?: string | null;
   requesterEmailAddress?: string | null;
   requesterPhoneNumber?: string | null;
   vehicleYear?: string | null;

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -56,6 +56,8 @@ export const users = sqliteTable("user", {
   address: text("address"),
   cityStateZip: text("city_state_zip"),
   daytimePhone: text("daytime_phone"),
+  driverLicenseNumber: text("driver_license_number"),
+  driverLicenseState: text("driver_license_state"),
   profileStatus: text("profile_status").notNull().default("under_review"),
   profileReviewNotes: text("profile_review_notes"),
   role: text("role").notNull().default("user"),

--- a/src/lib/userStore.ts
+++ b/src/lib/userStore.ts
@@ -13,6 +13,8 @@ export interface UserRecord {
   address: string | null;
   cityStateZip: string | null;
   daytimePhone: string | null;
+  driverLicenseNumber: string | null;
+  driverLicenseState: string | null;
   profileStatus: string;
   profileReviewNotes: string | null;
   role: string;
@@ -37,6 +39,8 @@ export function updateUser(
       | "address"
       | "cityStateZip"
       | "daytimePhone"
+      | "driverLicenseNumber"
+      | "driverLicenseState"
       | "profileStatus"
       | "profileReviewNotes"
     >
@@ -52,6 +56,10 @@ export function updateUser(
     data.cityStateZip = updates.cityStateZip;
   if (updates.daytimePhone !== undefined)
     data.daytimePhone = updates.daytimePhone;
+  if (updates.driverLicenseNumber !== undefined)
+    data.driverLicenseNumber = updates.driverLicenseNumber;
+  if (updates.driverLicenseState !== undefined)
+    data.driverLicenseState = updates.driverLicenseState;
   if (updates.profileStatus !== undefined)
     data.profileStatus = updates.profileStatus;
   if (updates.profileReviewNotes !== undefined)

--- a/test/e2e/profile.test.ts
+++ b/test/e2e/profile.test.ts
@@ -60,6 +60,8 @@ describe("profile page e2e @smoke", () => {
       address?: string;
       cityStateZip?: string;
       daytimePhone?: string;
+      driverLicenseNumber?: string;
+      driverLicenseState?: string;
     };
     expect(data.name ?? "").toBe("");
 
@@ -74,6 +76,8 @@ describe("profile page e2e @smoke", () => {
         address: "123 A St",
         cityStateZip: "City, ST 12345",
         daytimePhone: "555-0000",
+        driverLicenseNumber: "D123",
+        driverLicenseState: "IL",
       }),
     });
     expect(res.status).toBe(200);
@@ -85,12 +89,16 @@ describe("profile page e2e @smoke", () => {
       address?: string;
       cityStateZip?: string;
       daytimePhone?: string;
+      driverLicenseNumber?: string;
+      driverLicenseState?: string;
     };
     expect(data.name).toBe("Tester");
     expect(data.image).toBe("/img");
     expect(data.address).toBe("123 A St");
     expect(data.cityStateZip).toBe("City, ST 12345");
     expect(data.daytimePhone).toBe("555-0000");
+    expect(data.driverLicenseNumber).toBe("D123");
+    expect(data.driverLicenseState).toBe("IL");
 
     const page = await api("/settings").then((r) => r.text());
     const dom = new JSDOM(page);

--- a/test/profileRoute.test.ts
+++ b/test/profileRoute.test.ts
@@ -43,6 +43,8 @@ describe("profile API", () => {
         address: "123 A St",
         cityStateZip: "City, ST 12345",
         daytimePhone: "555-0000",
+        driverLicenseNumber: "D123",
+        driverLicenseState: "IL",
       }),
     });
     await mod.PUT(req, {
@@ -57,5 +59,7 @@ describe("profile API", () => {
     expect(updated?.address).toBe("123 A St");
     expect(updated?.cityStateZip).toBe("City, ST 12345");
     expect(updated?.daytimePhone).toBe("555-0000");
+    expect(updated?.driverLicenseNumber).toBe("D123");
+    expect(updated?.driverLicenseState).toBe("IL");
   });
 });


### PR DESCRIPTION
## Summary
- add migrations for user driver license fields
- include driver license number and state in the user schema and store
- persist fields via profile API and settings page UI
- preload info in ownership request editor
- update localization strings
- regenerate zod schemas
- add tests for profile fields

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6867f0b71da4832bae5b6563d9638c92