### PR TITLE
feat: detect and store user language

### DIFF
--- a/migrations/0025_user_language.sql
+++ b/migrations/0025_user_language.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user ADD COLUMN language TEXT;

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -64,6 +64,7 @@
   "imageUrlLabel": "Image URL",
   "socialLinksLabel": "Social Links (one per line)",
   "bioLabel": "About You",
+  "languageLabel": "Language",
   "profileStatusUnderReview": "Profile under review",
   "profileStatusPublished": "Profile published",
   "profileStatusHidden": "Profile hidden. Revision requested:",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -64,6 +64,7 @@
   "imageUrlLabel": "URL de imagen",
   "socialLinksLabel": "Enlaces de redes sociales (uno por línea)",
   "bioLabel": "Acerca de ti",
+  "languageLabel": "Idioma",
   "profileStatusUnderReview": "Perfil en revisión",
   "profileStatusPublished": "Perfil publicado",
   "profileStatusHidden": "Perfil oculto. Se requiere revisión:",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -64,6 +64,7 @@
   "imageUrlLabel": "URL de l'image",
   "socialLinksLabel": "Liens sociaux (un par ligne)",
   "bioLabel": "À propos de vous",
+  "languageLabel": "Langue",
   "profileStatusUnderReview": "Profil en cours d'examen",
   "profileStatusPublished": "Profil publié",
   "profileStatusHidden": "Profil masqué. Révision requise :",

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -36,6 +36,7 @@ export async function PUT(
     daytimePhone,
     driverLicenseNumber,
     driverLicenseState,
+    language,
   } = (await req.json()) as {
     name?: string | null;
     image?: string | null;
@@ -46,6 +47,7 @@ export async function PUT(
     daytimePhone?: string | null;
     driverLicenseNumber?: string | null;
     driverLicenseState?: string | null;
+    language?: string | null;
   };
   const user = updateUser(userId, {
     name,
@@ -57,6 +59,7 @@ export async function PUT(
     daytimePhone,
     driverLicenseNumber,
     driverLicenseState,
+    language,
     profileStatus: "under_review",
     profileReviewNotes: null,
   });

--- a/src/app/components/LanguageSwitcher.tsx
+++ b/src/app/components/LanguageSwitcher.tsx
@@ -12,15 +12,25 @@ const LABELS: Record<string, string> = {
   fr: "Fran\u00e7ais",
 };
 
-export default function LanguageSwitcher() {
+export default function LanguageSwitcher({
+  id,
+  value = i18n.language,
+  onChange,
+}: {
+  id?: string;
+  value?: string;
+  onChange?: (lang: string) => void;
+}) {
   return (
     <select
+      id={id}
       className="border rounded p-1 text-sm bg-white dark:bg-gray-800"
-      value={i18n.language}
+      value={value}
       onChange={(e) => {
         const lang = e.target.value;
         document.cookie = `language=${lang}; path=/; max-age=31536000`;
         i18n.changeLanguage(lang);
+        onChange?.(lang);
       }}
     >
       <option value="en" aria-label={LABELS.en}>

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -9,7 +9,6 @@ import { usePathname } from "next/navigation";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FaBars, FaUserCircle } from "react-icons/fa";
-import LanguageSwitcher from "./LanguageSwitcher";
 
 export default function NavBar() {
   const pathname = usePathname();
@@ -159,7 +158,6 @@ export default function NavBar() {
       />
       <div className="hidden sm:flex gap-4 sm:gap-6 md:gap-8 text-sm items-center">
         {navLinks}
-        <LanguageSwitcher />
         {userMenu}
       </div>
       <div className="sm:hidden flex items-center gap-2">
@@ -179,7 +177,6 @@ export default function NavBar() {
               className="sm:hidden flex flex-col gap-2 text-sm bg-gray-100 dark:bg-gray-900 border rounded shadow p-4"
             >
               {navLinks}
-              <LanguageSwitcher />
             </Popover.Content>
           </Popover.Portal>
         </Popover.Root>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,8 +32,9 @@ export default async function RootLayout({
 }>) {
   const session = await getServerSession(authOptions);
   const cookieStore = await cookies();
-  // Prefer the language cookie but fall back to Accept-Language
-  let storedLang = cookieStore.get("language")?.value;
+  // Prefer the user's profile language, then cookie, then Accept-Language
+  let storedLang =
+    session?.user?.language || cookieStore.get("language")?.value;
   if (!storedLang) {
     const headerList = await headers();
     const accept = headerList.get("accept-language") ?? "";

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -6,6 +6,7 @@ import { US_STATES } from "@/lib/usStates";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import LanguageSwitcher from "../components/LanguageSwitcher";
 import useAddCredits from "../hooks/useAddCredits";
 import useCreditBalance from "../hooks/useCreditBalance";
 
@@ -30,6 +31,7 @@ export default function UserSettingsPage() {
     driverLicenseState?: string;
     profileStatus?: string;
     profileReviewNotes?: string | null;
+    language?: string;
   }>({
     queryKey: ["/api/profile"],
     queryFn: async () => {
@@ -46,6 +48,7 @@ export default function UserSettingsPage() {
         driverLicenseState?: string;
         profileStatus?: string;
         profileReviewNotes?: string | null;
+        language?: string;
       };
     },
     enabled: !!session,
@@ -60,6 +63,7 @@ export default function UserSettingsPage() {
   const [daytimePhone, setDaytimePhone] = useState("");
   const [driverLicenseNumber, setDriverLicenseNumber] = useState("");
   const [driverLicenseState, setDriverLicenseState] = useState("IL");
+  const [language, setLanguage] = useState("en");
   const [status, setStatus] = useState<string | undefined>(undefined);
   const [notes, setNotes] = useState<string | null | undefined>(undefined);
 
@@ -74,6 +78,7 @@ export default function UserSettingsPage() {
       setDaytimePhone(data.daytimePhone ?? "");
       setDriverLicenseNumber(data.driverLicenseNumber ?? "");
       setDriverLicenseState(data.driverLicenseState ?? "IL");
+      setLanguage(data.language ?? "en");
       setStatus(data.profileStatus);
       setNotes(data.profileReviewNotes ?? null);
     }
@@ -94,6 +99,7 @@ export default function UserSettingsPage() {
           daytimePhone,
           driverLicenseNumber,
           driverLicenseState,
+          language,
         }),
       });
     },
@@ -194,6 +200,14 @@ export default function UserSettingsPage() {
                 ))}
               </select>
             </label>
+            <label htmlFor="language" className="flex flex-col">
+              {t("languageLabel")}
+            </label>
+            <LanguageSwitcher
+              id="language"
+              value={language}
+              onChange={(v) => setLanguage(v)}
+            />
             <label className="flex flex-col">
               {t("socialLinksLabel")}
               <textarea

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -1,18 +1,22 @@
 import { writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { eq } from "drizzle-orm";
 import type { NextAuthOptions, Session, User } from "next-auth";
 import type { Adapter } from "next-auth/adapters";
 import EmailProvider from "next-auth/providers/email";
 import FacebookProvider from "next-auth/providers/facebook";
 import GoogleProvider from "next-auth/providers/google";
 import type { Provider } from "next-auth/providers/index";
+import { headers } from "next/headers";
 import { authAdapter, seedSuperAdmin } from "./auth";
 import { config } from "./config";
 import { sendEmail } from "./email";
 import { gravatarUrl } from "./gravatar";
 import { log } from "./logger";
 import { getOauthProviderStatuses } from "./oauthProviders";
+import { orm } from "./orm";
+import { users } from "./schema";
 
 if (
   process.env.NEXT_PHASE !== "phase-production-build" &&
@@ -71,14 +75,13 @@ export const authOptions: NextAuthOptions = {
   pages: { signIn: "/signin" },
   session: { strategy: "database" as const },
   callbacks: {
-    async session({
-      session,
-      user,
-    }: { session: Session; user: User & { role?: string } }) {
+    async session({ session, user }) {
       log("session callback", user.id);
       if (session.user) {
         (session.user as User & { role?: string }).role = user.role;
         (session.user as User & { id: string }).id = user.id;
+        (session.user as User & { language?: string | null }).language =
+          user.language ?? null;
         if (!session.user.image && user.email) {
           (session.user as User).image = gravatarUrl(user.email);
         }
@@ -90,6 +93,22 @@ export const authOptions: NextAuthOptions = {
     async createUser({ user }) {
       log("new user", user.id);
       try {
+        const headerList = await headers();
+        let lang: string | undefined;
+        const accept = headerList.get("accept-language") ?? "";
+        const supported = ["en", "es", "fr"];
+        for (const part of accept.split(",")) {
+          const code = part.split(";")[0].trim().toLowerCase().split("-")[0];
+          if (supported.includes(code)) {
+            lang = code;
+            break;
+          }
+        }
+        orm
+          .update(users)
+          .set({ language: lang ?? "en" })
+          .where(eq(users.id, user.id))
+          .run();
         await seedSuperAdmin({ id: user.id, email: user.email ?? null });
       } catch (err) {
         console.error("Failed to assign super admin role", err);

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -58,6 +58,7 @@ export const users = sqliteTable("user", {
   daytimePhone: text("daytime_phone"),
   driverLicenseNumber: text("driver_license_number"),
   driverLicenseState: text("driver_license_state"),
+  language: text("language"),
   profileStatus: text("profile_status").notNull().default("under_review"),
   profileReviewNotes: text("profile_review_notes"),
   role: text("role").notNull().default("user"),

--- a/src/lib/userStore.ts
+++ b/src/lib/userStore.ts
@@ -15,6 +15,7 @@ export interface UserRecord {
   daytimePhone: string | null;
   driverLicenseNumber: string | null;
   driverLicenseState: string | null;
+  language: string | null;
   profileStatus: string;
   profileReviewNotes: string | null;
   role: string;
@@ -41,6 +42,7 @@ export function updateUser(
       | "daytimePhone"
       | "driverLicenseNumber"
       | "driverLicenseState"
+      | "language"
       | "profileStatus"
       | "profileReviewNotes"
     >
@@ -60,6 +62,7 @@ export function updateUser(
     data.driverLicenseNumber = updates.driverLicenseNumber;
   if (updates.driverLicenseState !== undefined)
     data.driverLicenseState = updates.driverLicenseState;
+  if (updates.language !== undefined) data.language = updates.language;
   if (updates.profileStatus !== undefined)
     data.profileStatus = updates.profileStatus;
   if (updates.profileReviewNotes !== undefined)

--- a/test/e2e/signinEmptyDb.test.ts
+++ b/test/e2e/signinEmptyDb.test.ts
@@ -32,7 +32,10 @@ describe("sign in with empty db @smoke", () => {
       (
         await api("/api/auth/signin/email", {
           method: "POST",
-          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "accept-language": "es",
+          },
           body: new URLSearchParams({
             csrfToken: csrf.csrfToken,
             email,
@@ -46,10 +49,15 @@ describe("sign in with empty db @smoke", () => {
     expect(ver.url).toBeTruthy();
     await api(
       `${new URL(ver.url).pathname}?${new URL(ver.url).searchParams.toString()}`,
+      {
+        headers: { "accept-language": "es" },
+      },
     );
 
     const session = await api("/api/auth/session").then((r) => r.json());
     expect(session?.user?.email).toBe(email);
     expect(session?.user?.role).toBe("superadmin");
+    const profile = await api("/api/profile").then((r) => r.json());
+    expect(profile.language).toBe("es");
   });
 });

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -2,11 +2,16 @@ import type { DefaultSession } from "next-auth";
 
 declare module "next-auth" {
   interface Session {
-    user?: DefaultSession["user"] & { id: string; role: string };
+    user?: DefaultSession["user"] & {
+      id: string;
+      role: string;
+      language?: string | null;
+    };
   }
 
   interface User {
     id: string;
     role: string;
+    language?: string | null;
   }
 }


### PR DESCRIPTION
## Summary
- save language preference when account is created using Accept-Language
- surface saved language in the session and app layout
- move language selector to Settings page
- support language field in profile API and schema
- test language detection on first sign-in

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686800fb726c832b969ac0f180146ea8