### PR TITLE
fix profile image default

### DIFF
--- a/src/lib/userStore.ts
+++ b/src/lib/userStore.ts
@@ -23,7 +23,11 @@ export interface UserRecord {
 export function getUser(id: string): UserRecord | null {
   const row = orm.select().from(users).where(eq(users.id, id)).get();
   if (!row) return null;
-  const image = row.image ?? (row.email ? gravatarUrl(row.email) : null);
+  const image = row.image?.trim()
+    ? row.image
+    : row.email
+      ? gravatarUrl(row.email)
+      : null;
   return { ...row, image };
 }
 
@@ -48,7 +52,8 @@ export function updateUser(
 ): UserRecord | null {
   const data: Record<string, string | null> = {};
   if (updates.name !== undefined) data.name = updates.name;
-  if (updates.image !== undefined) data.image = updates.image;
+  if (updates.image !== undefined)
+    data.image = updates.image?.trim() ? updates.image : null;
   if (updates.bio !== undefined) data.bio = updates.bio;
   if (updates.socialLinks !== undefined) data.socialLinks = updates.socialLinks;
   if (updates.address !== undefined) data.address = updates.address;

--- a/test/profileRoute.test.ts
+++ b/test/profileRoute.test.ts
@@ -62,4 +62,19 @@ describe("profile API", () => {
     expect(updated?.driverLicenseNumber).toBe("D123");
     expect(updated?.driverLicenseState).toBe("IL");
   });
+
+  it("defaults image to gravatar when blank", async () => {
+    const { orm } = await import("@/lib/orm");
+    const schema = await import("@/lib/schema");
+    const { eq } = await import("drizzle-orm");
+    orm
+      .update(schema.users)
+      .set({ image: "" })
+      .where(eq(schema.users.id, "u1"))
+      .run();
+
+    const { getUser } = await import("@/lib/userStore");
+    const user = getUser("u1");
+    expect(user?.image).toMatch(/gravatar\.com/);
+  });
 });


### PR DESCRIPTION
## Summary
- default profile image to gravatar if stored image is blank
- test profile blank image fallback

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_68680f9d532c832b88d9c1b7d508c822