### PR TITLE
Fix Storybook useSession error

### DIFF
--- a/.storybook/NextAuthStub.tsx
+++ b/.storybook/NextAuthStub.tsx
@@ -1,0 +1,6 @@
+export const useSession = () => ({ data: null });
+export const signIn = () => {};
+export const signOut = () => {};
+export function SessionProvider({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -19,6 +19,11 @@ const config: StorybookConfig = {
         ".storybook",
         "MapPreviewStub.tsx",
       ),
+      "next-auth/react": path.resolve(
+        process.cwd(),
+        ".storybook",
+        "NextAuthStub.tsx",
+      ),
       "@": path.resolve(process.cwd(), "src"),
     };
     config.resolve.fallback = {


### PR DESCRIPTION
## Summary
- stub `next-auth/react` for Storybook so hooks like `useSession` work

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`

------
https://chatgpt.com/codex/tasks/task_e_6868146de8cc832bb9000a0cba228540