### PR TITLE
Add capacitor build plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,5 +532,6 @@ When these variables are omitted, all feature flags default to disabled.
 - [**Documentation Outline**](docs/feature-outline.md) — discover planned features and architecture.
 - [**Credit System**](docs/credit-system.md) — how users purchase credits and how balances update.
 - [**Case Chat Buttons**](docs/case-chat-actions.md) — LLM syntax for inserting action buttons.
+- [**Capacitor Build Plan**](docs/capacitor-parallel-build.md) — run native builds alongside the web app.
 - [**Releases**](https://github.com/antialias/photo-to-citation/releases) — download the latest packaged version.
 - [**Live Demo**](https://730op.synology.me/photo-citation) — try the hosted web app.

--- a/docs/capacitor-parallel-build.md
+++ b/docs/capacitor-parallel-build.md
@@ -1,0 +1,46 @@
+# Capacitor Mobile Build Plan
+
+This plan outlines how to add a Capacitor mobile app alongside the Next.js web project.
+The goal is to reuse the core logic while compiling native iOS and Android binaries.
+
+## 1. Structure
+
+- Keep the existing web code under `src/`.
+- Create a new `mobile/` folder for the Capacitor project.
+- Use a shared `packages/` folder for UI components and utilities used by both the web and mobile apps.
+- Declare each folder in a `pnpm-workspace.yaml` file so mobile and packages resolve correctly.
+
+```text
+repo/
+├─ mobile/
+│  ├─ capacitor.config.ts
+│  ├─ ios/
+│  └─ android/
+├─ packages/
+│  └─ ui/ (shared components)
+└─ src/ (web)
+```
+
+## 2. Development
+
+1. Inside `mobile/`, run `pnpm init` and install `@capacitor/core` and `@capacitor/cli`.
+   Add `@capacitor/android` or `@capacitor/ios` depending on the platform.
+2. Create `pnpm-workspace.yaml` in the repo root listing `mobile`, `packages/*`, and `src` as workspaces.
+3. Configure `capacitor.config.ts` to point `webDir` at the production build from `packages/ui` or `src`.
+4. Use `pnpm run build` from the repo root to generate web assets, then
+   `pnpm --filter ./mobile capacitor copy` to sync them into the native projects.
+5. For local testing, open the iOS or Android project folder and run the
+   platform‑specific commands (`npx cap open ios`, `npx cap open android`).
+
+## 3. Continuous Integration
+
+- Add a separate job in the CI workflow that installs Capacitor dependencies and builds the native projects.
+- The job can run in parallel with the existing Next.js build job.
+- Run `pnpm --filter ./mobile capacitor copy` and the platform-specific build commands within that job.
+- Artifacts from the mobile build should be stored for manual installation or further signing steps.
+
+## 4. Benefits
+
+- Reuse the same React components and data access code across web and mobile.
+- Keep mobile-specific configuration isolated under `mobile/`.
+- Parallel builds keep CI times reasonable and ensure the mobile app stays in sync with the web code.


### PR DESCRIPTION
## Summary
- document a plan for building a Capacitor mobile app in parallel with the Next.js project
- link to the new doc from README

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke` *(fails: Next.js compilation did not finish)*

------
https://chatgpt.com/codex/tasks/task_e_68694f28da8c832b86cb334cc0be2e62