### PR TITLE
Add check PDF generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,10 @@ RETURN_ADDRESS=
 SNAIL_MAIL_PROVIDER=mock
 SNAIL_MAIL_OUT_DIR=
 
+# Check configuration
+CHECK_ACCOUNT_NUMBER=
+CHECK_ROUTING_NUMBER=
+
 # Twilio configuration for SMS, WhatsApp, and robocalls
 TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=

--- a/README.md
+++ b/README.md
@@ -250,6 +250,17 @@ Snail mail provider health is stored in `data/snailMailProviders.json` (overrida
 via `SNAIL_MAIL_PROVIDER_FILE`). The active provider and failure counts can be
 viewed on the Settings page.
 
+## Check Writer
+
+Checks mailed with ownership requests use these settings:
+
+```bash
+CHECK_ACCOUNT_NUMBER=123456789
+CHECK_ROUTING_NUMBER=987654321
+```
+
+If these variables are not set, check generation fails.
+
 ## Twilio Integration
 
 Configure Twilio credentials to enable SMS, WhatsApp, and robocall

--- a/src/app/api/cases/[id]/ownership-request/route.ts
+++ b/src/app/api/cases/[id]/ownership-request/route.ts
@@ -71,6 +71,19 @@ export const POST = withCaseAuthorization(
         );
       }
     }
+    if (mod?.requiresCheck) {
+      const { createCheckPdf } = await import("@/lib/check");
+      try {
+        const checkPath = await createCheckPdf({
+          payee: mod.payee,
+          amount: mod.fee,
+          checkNumber: checkNumber ?? null,
+        });
+        attachments.push(checkPath);
+      } catch (err) {
+        console.error("Failed to create check", err);
+      }
+    }
     const results: Record<string, { success: boolean; error?: string }> = {};
     let snailMailStatus: SentEmail["snailMailStatus"];
     if (snailMail && mod?.address) {

--- a/src/lib/__tests__/check.test.ts
+++ b/src/lib/__tests__/check.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(process.cwd(), "check-"));
+  vi.spyOn(process, "cwd").mockReturnValue(tmpDir);
+  process.env.CHECK_ACCOUNT_NUMBER = "123456789";
+  process.env.CHECK_ROUTING_NUMBER = "987654321";
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  process.env.CHECK_ACCOUNT_NUMBER = undefined;
+  process.env.CHECK_ROUTING_NUMBER = undefined;
+});
+
+describe("createCheckPdf", () => {
+  it("creates a PDF file", async () => {
+    vi.resetModules();
+    const { createCheckPdf } = await import("@/lib/check");
+    const file = await createCheckPdf({
+      payee: "State",
+      amount: 12,
+      checkNumber: "42",
+    });
+    expect(fs.existsSync(file)).toBe(true);
+  });
+
+  it("fails without config", async () => {
+    process.env.CHECK_ACCOUNT_NUMBER = "";
+    process.env.CHECK_ROUTING_NUMBER = "";
+    vi.resetModules();
+    await expect(
+      (async () => {
+        const { createCheckPdf } = await import("@/lib/check");
+        await createCheckPdf({ payee: "x", amount: 1 });
+      })(),
+    ).rejects.toThrow();
+  });
+});

--- a/src/lib/check.ts
+++ b/src/lib/check.ts
@@ -1,0 +1,44 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { PDFDocument, StandardFonts } from "pdf-lib";
+import { config } from "./config";
+
+export interface CheckOptions {
+  payee: string;
+  amount: number;
+  checkNumber?: string | null;
+  memo?: string | null;
+  date?: string | null;
+}
+
+export async function createCheckPdf(options: CheckOptions): Promise<string> {
+  const account = config.CHECK_ACCOUNT_NUMBER;
+  const routing = config.CHECK_ROUTING_NUMBER;
+  if (!account || !routing) {
+    throw new Error("Check account not configured");
+  }
+  const pdf = await PDFDocument.create();
+  const page = pdf.addPage([612, 792]);
+  const font = await pdf.embedFont(StandardFonts.Helvetica);
+  const fontSize = 12;
+  let y = 742;
+  const lines = [
+    `Date: ${options.date ?? new Date().toLocaleDateString("en-US")}`,
+    `Check Number: ${options.checkNumber ?? ""}`,
+    `Pay to the Order Of: ${options.payee}`,
+    `Amount: $${options.amount.toFixed(2)}`,
+    `Memo: ${options.memo ?? ""}`,
+    `Routing Number: ${routing}`,
+    `Account Number: ${account}`,
+  ];
+  for (const line of lines) {
+    page.drawText(line, { x: 50, y, size: fontSize, font });
+    y -= fontSize * 1.5;
+  }
+  const outDir = path.join(process.cwd(), "data", "checks");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, `${crypto.randomUUID()}.pdf`);
+  fs.writeFileSync(outPath, await pdf.save());
+  return outPath;
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -43,6 +43,8 @@ const envSchema = z
     RETURN_ADDRESS: z.string().optional(),
     SNAIL_MAIL_PROVIDER: z.string().default("mock"),
     SNAIL_MAIL_OUT_DIR: z.string().optional(),
+    CHECK_ACCOUNT_NUMBER: z.string().optional(),
+    CHECK_ROUTING_NUMBER: z.string().optional(),
     TWILIO_ACCOUNT_SID: z.string().optional(),
     TWILIO_AUTH_TOKEN: z.string().optional(),
     TWILIO_FROM_NUMBER: z.string().optional(),

--- a/src/lib/ownershipModules.ts
+++ b/src/lib/ownershipModules.ts
@@ -67,6 +67,7 @@ export interface OwnershipModule {
   address: string;
   fee: number;
   requiresCheck: boolean;
+  payee: string;
   requestVin?: (info: OwnershipRequestInfo) => Promise<void>;
   requestContactInfo?: (info: OwnershipRequestInfo) => Promise<void>;
   /**
@@ -202,6 +203,7 @@ export const ownershipModules: Record<string, OwnershipModule> = {
       "Driver Records Unit\n2701 S. Dirksen Pkwy.\nSpringfield, IL 62723",
     fee: 12,
     requiresCheck: true,
+    payee: "Secretary of State",
     async generateForms(info) {
       const pdfPath = await fillIlForm(info);
       return pdfPath;
@@ -222,6 +224,7 @@ export const ownershipModules: Record<string, OwnershipModule> = {
       "DMV Vehicle History Section\nP.O. Box 944247\nSacramento, CA 94244-2470",
     fee: 5,
     requiresCheck: true,
+    payee: "DMV",
   },
 };
 


### PR DESCRIPTION
## Summary
- generate full-page check PDFs with routing/account numbers
- expose check settings via env var config
- attach a generated check when submitting a VSD form
- document check settings in README
- test check PDF creation

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686a66cedd04832bb7231868ff74707d