### PR TITLE
feat: migrate profile page styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@react-aria/listbox": "^3.14.6",
     "@react-aria/textfield": "^3.17.5",
     "@react-stately/combobox": "^3.10.6",
+    "@stylexjs/stylex": "^0.14.1",
     "@tanstack/react-query": "^5.81.2",
     "@tanstack/react-query-devtools": "^5.81.2",
     "@tanstack/react-virtual": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@react-stately/combobox':
         specifier: ^3.10.6
         version: 3.10.6(react@19.1.0)
+      '@stylexjs/stylex':
+        specifier: ^0.14.1
+        version: 0.14.1
       '@tanstack/react-query':
         specifier: ^5.81.2
         version: 5.81.5(react@19.1.0)
@@ -3448,6 +3451,9 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
+  '@stylexjs/stylex@0.14.1':
+    resolution: {integrity: sha512-UlAGhGUHTqZoMThHdpLUFhO0fjWxJ3VDFRsGK0mNwCD4IEe2EPkIjtZTjHZepidDAbUcNoXlTQoK/y1fcd5f/w==}
+
   '@svgr/babel-plugin-add-jsx-attribute@4.2.0':
     resolution: {integrity: sha512-j7KnilGyZzYr/jhcrSYS3FGWMZVaqyCG0vzMCwzvei0coIkczuYMcniK07nI0aHJINciujjH11T72ICW5eL5Ig==}
     engines: {node: '>=8'}
@@ -5556,6 +5562,9 @@ packages:
         optional: true
       webpack:
         optional: true
+
+  css-mediaquery@0.1.2:
+    resolution: {integrity: sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==}
 
   css-prefers-color-scheme@3.1.1:
     resolution: {integrity: sha512-MTu6+tMs9S3EUqzmqLXEcgNRbNkkD/TGFvowpeoWJn5Vfq7FMgsmRQs9X5NXAURiOBmOxm/lLjsDNXDE6k9bhg==}
@@ -11615,6 +11624,9 @@ packages:
     resolution: {integrity: sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==}
     engines: {node: '>=6.9.0'}
 
+  styleq@0.2.1:
+    resolution: {integrity: sha512-L0TR0NQb+X4/ktDEKmjWyp27gla+LUYi/by5k5SjKXf6/pvZP7wbwEB5J+tqxdFVPgzbsuz+d4RTScO/QZquBw==}
+
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
@@ -15541,9 +15553,7 @@ snapshots:
       source-map: 0.6.1
       string-length: 2.0.0
     transitivePeerDependencies:
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@jest/source-map@24.9.0':
     dependencies:
@@ -17575,6 +17585,12 @@ snapshots:
   '@storybook/theming@8.6.14(storybook@8.6.14(prettier@3.0.3))':
     dependencies:
       storybook: 8.6.14(prettier@3.0.3)
+
+  '@stylexjs/stylex@0.14.1':
+    dependencies:
+      css-mediaquery: 0.1.2
+      invariant: 2.2.4
+      styleq: 0.2.1
 
   '@svgr/babel-plugin-add-jsx-attribute@4.2.0': {}
 
@@ -20111,6 +20127,8 @@ snapshots:
       semver: 7.7.2
     optionalDependencies:
       webpack: 5.99.9(esbuild@0.25.5)
+
+  css-mediaquery@0.1.2: {}
 
   css-prefers-color-scheme@3.1.1:
     dependencies:
@@ -27715,6 +27733,8 @@ snapshots:
       browserslist: 4.25.1
       postcss: 7.0.39
       postcss-selector-parser: 3.1.2
+
+  styleq@0.2.1: {}
 
   stylis@4.3.6: {}
 

--- a/src/app/public/users/[id]/PublicProfileClient.tsx
+++ b/src/app/public/users/[id]/PublicProfileClient.tsx
@@ -1,4 +1,5 @@
 "use client";
+import * as stylex from "@stylexjs/stylex";
 import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import { FaUserCircle } from "react-icons/fa";
@@ -21,35 +22,78 @@ export default function PublicProfileClient({
   user: PublicUser;
 }) {
   const { t } = useTranslation();
+  const styles = stylex.create({
+    container: {
+      padding: "2rem",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      gap: "1rem",
+      textAlign: "center",
+    },
+    avatarImg: {
+      width: "6rem",
+      height: "6rem",
+      borderRadius: "9999px",
+      objectFit: "cover",
+    },
+    icon: {
+      width: "6rem",
+      height: "6rem",
+    },
+    heading: {
+      fontSize: "1.5rem",
+      fontWeight: 700,
+    },
+    bio: {
+      maxWidth: "65ch",
+      whiteSpace: "pre-line",
+    },
+    reviewText: {
+      fontSize: "0.875rem",
+      color: "#4b5563",
+    },
+    linksWrapper: {
+      display: "flex",
+      flexDirection: "column",
+      gap: "0.25rem",
+    },
+    link: {
+      color: "#2563eb",
+      textDecorationLine: "underline",
+    },
+  });
   const links = user.socialLinks?.split(/\n+/).filter(Boolean) ?? [];
   return (
-    <div className="p-8 flex flex-col items-center gap-4 text-center">
+    <div {...stylex.props(styles.container)}>
       {user.image ? (
         <Image
           src={user.image}
           alt="avatar"
           width={96}
           height={96}
-          className="w-24 h-24 rounded-full object-cover"
+          {...stylex.props(styles.avatarImg)}
         />
       ) : (
-        <FaUserCircle className="w-24 h-24" />
+        <FaUserCircle {...stylex.props(styles.icon)} />
       )}
-      <h1 className="text-2xl font-bold">{user.name ?? t("unknown")}</h1>
+      <h1 {...stylex.props(styles.heading)}>{user.name ?? t("unknown")}</h1>
       {user.profileStatus === "published" ? (
         user.bio ? (
-          <p className="max-w-prose whitespace-pre-line">{user.bio}</p>
+          <p {...stylex.props(styles.bio)}>{user.bio}</p>
         ) : null
       ) : (
-        <p className="text-sm text-gray-600">{t("profileStatusUnderReview")}</p>
+        <p {...stylex.props(styles.reviewText)}>
+          {t("profileStatusUnderReview")}
+        </p>
       )}
       {links.length ? (
-        <div className="flex flex-col gap-1">
+        <div {...stylex.props(styles.linksWrapper)}>
           {links.map((l) => (
             <a
               key={l}
               href={l}
-              className="text-blue-600 underline"
+              {...stylex.props(styles.link)}
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
## Summary
- add `@stylexjs/stylex` dependency
- rewrite public profile page with StyleX styles

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686af31efb6c832ba5218aae3650ff1b