### PR TITLE
Update inbox scanner to assign cases and send receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,9 +303,12 @@ INBOX_STATE_FILE=data/inbox.json
 ```
 
 Run `pnpm run scan:inbox` to start listening for new messages. Each email with
-one or more photo attachments becomes a new case. Multiple photos in the same
-email are added to that case before analysis and geocoding run in the
-background.
+one or more photo attachments becomes a new case. The sender's address is
+matched against existing user accounts and, when found, ownership is assigned to
+that user. A receipt is emailed back with a link to the case and a token in the
+subject like `[cid:123]`. If the user replies with additional photos and the
+token remains in the subject, those images are added to the same case before
+analysis and geocoding run in the background.
 
 ## Automated Cleanup
 

--- a/src/lib/userStore.ts
+++ b/src/lib/userStore.ts
@@ -32,6 +32,17 @@ export function getUser(id: string): UserRecord | null {
   return { ...row, image };
 }
 
+export function getUserByEmail(email: string): UserRecord | null {
+  const row = orm.select().from(users).where(eq(users.email, email)).get();
+  if (!row) return null;
+  const image = row.image?.trim()
+    ? row.image
+    : row.email
+      ? gravatarUrl(row.email)
+      : null;
+  return { ...row, image };
+}
+
 export function updateUser(
   id: string,
   updates: Partial<


### PR DESCRIPTION
## Summary
- associate inbox cases with users by email
- send receipt email after creating a case
- document the new workflow

## Testing
- `pnpm run lint`
- `pnpm run lint:md`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686af296e3d8832b83a0b9a3db3a3478