### PR TITLE
Improve Panda profile styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   },
   "packageManager": "pnpm@9.15.4",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "pnpm panda --watch & next dev --turbopack",
     "build:jobs": "node scripts/compileJobs.mjs",
-    "build": "pnpm run build:jobs && next build",
+    "build": "pnpm run build:jobs && pnpm panda && next build",
     "start": "next start",
     "lint": "pnpm run lint:env && pnpm run lint:md && biome check .",
     "lint:md": "markdownlint '**/*.md' --ignore node_modules",
@@ -36,7 +36,7 @@
     "squash:migrations": "ts-node --transpile-only scripts/squashMigrations.ts",
     "website": "ts-node --transpile-only scripts/generateWebsiteImages.ts && eleventy",
     "panda": "panda",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "pnpm panda && tsc --noEmit"
   },
   "dependencies": {
     "@anatine/zod-openapi": "^2.2.8",

--- a/src/app/public/users/[id]/PublicProfileClient.tsx
+++ b/src/app/public/users/[id]/PublicProfileClient.tsx
@@ -30,6 +30,10 @@ export default function PublicProfileClient({
       alignItems: "center",
       gap: "1rem",
       textAlign: "center",
+      borderWidth: "1px",
+      borderRadius: "0.5rem",
+      background: "var(--background)",
+      boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
     }),
     avatarImg: css({
       width: "6rem",


### PR DESCRIPTION
## Summary
- add Panda CSS build steps
- add border and card styling for public profile page

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686b2bfc6708832bb3808dd858e53f41