### PR TITLE
Fix panda styles import

### DIFF
--- a/src/app/panda.css
+++ b/src/app/panda.css
@@ -1,1 +1,2 @@
+@import "../../styled-system/styles.css";
 @layer base, tokens, recipes, utilities;


### PR DESCRIPTION
## Summary
- ensure Panda stylesheets are imported

## Testing
- `pnpm run panda`
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke` *(fails: Next.js dev server didn't finish)*

------
https://chatgpt.com/codex/tasks/task_e_686b30681458832babfa4f9e980cc17b