### PR TITLE
docs: document panda build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,16 @@ This stack is designed for performance, type safety, and complete control over h
 
 ## Getting Started
 
-Install dependencies and start the development server:
+Install dependencies and generate Panda styles before starting the development server:
 
 ```bash
 pnpm install
+pnpm run panda -- --watch # omit --watch in production
 pnpm run dev
 ```
+
+Run `pnpm run panda` at least once before type-checking or starting the server.
+The generated `styled-system` directory is excluded from version control.
 
 Use [`Biome`](https://biomejs.dev/) for consistent formatting and linting:
 


### PR DESCRIPTION
## Summary
- mention the Panda CSS generation step in the dev instructions
- call out that the generated `styled-system` directory is ignored by Git

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run panda`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`

------
https://chatgpt.com/codex/tasks/task_e_686bcb1c5af0832bba82c39e3fa8d526