### PR TITLE
Run Panda before builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - run: pnpm run lint
+      - run: pnpm run panda
       - run: pnpm run typecheck
 
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV NEXT_PUBLIC_BASE_PATH=$NEXT_PUBLIC_BASE_PATH
 ENV NEXT_PUBLIC_APP_VERSION=$NEXT_PUBLIC_APP_VERSION
 ENV NEXT_PUBLIC_APP_COMMIT=$NEXT_PUBLIC_APP_COMMIT
 ENV NEXT_PUBLIC_DEPLOY_TIME=$NEXT_PUBLIC_DEPLOY_TIME
-RUN pnpm run build && pnpm prune --prod
+RUN pnpm run panda && pnpm run build && pnpm prune --prod
 
 # Runtime image
 FROM node:22-bookworm AS runner

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build:jobs": "node scripts/compileJobs.mjs",
-    "build": "pnpm run build:jobs && next build",
+    "build": "pnpm run build:jobs && pnpm run panda && next build",
     "start": "next start",
     "lint": "pnpm run lint:env && pnpm run lint:md && biome check .",
     "lint:md": "markdownlint '**/*.md' --ignore node_modules",


### PR DESCRIPTION
## Summary
- run `pnpm run panda` in CI before typecheck
- ensure `pnpm run build` runs Panda first
- build Panda styles in Docker

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run panda`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_686bcb0381d4832b9f34585912fb0687