### PR TITLE
feat: migrate casbin editor to panda css

### DIFF
--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -4,6 +4,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
+import { token } from "styled-system/tokens";
 import SystemStatusClient from "../system-status/SystemStatusClient";
 import AppConfigurationTab from "./AppConfigurationTab";
 import InviteUserForm from "./components/InviteUserForm";
@@ -53,6 +55,19 @@ export default function AdminPageClient({
   );
   const { t } = useTranslation();
 
+  const styles = {
+    heading: css({
+      fontSize: token("fontSizes.xl"),
+      fontWeight: "700",
+      mb: "4",
+    }),
+    subHeading: css({
+      fontSize: token("fontSizes.xl"),
+      fontWeight: "700",
+      my: "4",
+    }),
+  };
+
   return (
     <Tabs
       value={tab}
@@ -70,10 +85,10 @@ export default function AdminPageClient({
       </TabsList>
       <TabsContent value="users">
         <>
-          <h1 className="text-xl font-bold mb-4">{t("admin.users")}</h1>
+          <h1 className={styles.heading}>{t("admin.users")}</h1>
           <InviteUserForm hooks={userHooks} />
           <UsersTable hooks={userHooks} />
-          <h1 className="text-xl font-bold my-4">{t("admin.casbinRules")}</h1>
+          <h1 className={styles.subHeading}>{t("admin.casbinRules")}</h1>
           <RulesTable hooks={ruleHooks} />
         </>
       </TabsContent>

--- a/src/app/admin/components/RuleRow.tsx
+++ b/src/app/admin/components/RuleRow.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { css } from "styled-system/css";
+import { token } from "styled-system/tokens";
 import type { CasbinRule } from "../AdminPageClient";
 import type { GroupOptions, PolicyOptions } from "../hooks/useCasbinRules";
 
@@ -31,13 +33,34 @@ export default function RuleRow({
       ? (policyOptions[rule.v0][rule.v1] ?? [])
       : [];
 
+  const styles = {
+    cell: css({ borderWidth: "1px" }),
+    select: css({
+      width: "100%",
+      p: "1",
+      backgroundColor: { base: "white", _dark: token("colors.gray.900") },
+    }),
+    input: css({
+      width: "100%",
+      p: "1",
+      backgroundColor: { base: "white", _dark: token("colors.gray.900") },
+    }),
+    deleteBtn: css({
+      bg: "red.500",
+      color: "white",
+      px: "2",
+      py: "1",
+      borderRadius: token("radii.md"),
+    }),
+  };
+
   return (
     <tr>
-      <td className="border">
+      <td className={styles.cell}>
         <select
           value={rule.ptype}
           onChange={(e) => onChange("ptype", e.target.value)}
-          className="w-full p-1 bg-white dark:bg-gray-900"
+          className={styles.select}
         >
           {ptypeOptions.map((o) => (
             <option key={o} value={o}>
@@ -46,11 +69,11 @@ export default function RuleRow({
           ))}
         </select>
       </td>
-      <td className="border">
+      <td className={styles.cell}>
         <select
           value={rule.v0 ?? ""}
           onChange={(e) => onChange("v0", e.target.value)}
-          className="w-full p-1 bg-white dark:bg-gray-900"
+          className={styles.select}
         >
           {v0Options.map((o) => (
             <option key={o} value={o}>
@@ -59,11 +82,11 @@ export default function RuleRow({
           ))}
         </select>
       </td>
-      <td className="border">
+      <td className={styles.cell}>
         <select
           value={rule.v1 ?? ""}
           onChange={(e) => onChange("v1", e.target.value)}
-          className="w-full p-1 bg-white dark:bg-gray-900"
+          className={styles.select}
         >
           {v1Options.map((o) => (
             <option key={o} value={o}>
@@ -72,11 +95,11 @@ export default function RuleRow({
           ))}
         </select>
       </td>
-      <td className="border">
+      <td className={styles.cell}>
         <select
           value={rule.v2 ?? ""}
           onChange={(e) => onChange("v2", e.target.value)}
-          className="w-full p-1 bg-white dark:bg-gray-900"
+          className={styles.select}
         >
           {v2Options.map((o) => (
             <option key={o} value={o}>
@@ -85,33 +108,29 @@ export default function RuleRow({
           ))}
         </select>
       </td>
-      <td className="border">
+      <td className={styles.cell}>
         <input
           value={rule.v3 ?? ""}
           onChange={(e) => onChange("v3", e.target.value)}
-          className="w-full p-1 bg-white dark:bg-gray-900"
+          className={styles.input}
         />
       </td>
-      <td className="border">
+      <td className={styles.cell}>
         <input
           value={rule.v4 ?? ""}
           onChange={(e) => onChange("v4", e.target.value)}
-          className="w-full p-1 bg-white dark:bg-gray-900"
+          className={styles.input}
         />
       </td>
-      <td className="border">
+      <td className={styles.cell}>
         <input
           value={rule.v5 ?? ""}
           onChange={(e) => onChange("v5", e.target.value)}
-          className="w-full p-1 bg-white dark:bg-gray-900"
+          className={styles.input}
         />
       </td>
-      <td className="border">
-        <button
-          type="button"
-          onClick={onRemove}
-          className="bg-red-500 text-white px-2 py-1 rounded"
-        >
+      <td className={styles.cell}>
+        <button type="button" onClick={onRemove} className={styles.deleteBtn}>
           Delete
         </button>
       </td>

--- a/src/app/admin/components/RulesTable.tsx
+++ b/src/app/admin/components/RulesTable.tsx
@@ -1,5 +1,7 @@
 "use client";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
+import { token } from "styled-system/tokens";
 import type { useCasbinRules } from "../hooks/useCasbinRules";
 import RuleRow from "./RuleRow";
 
@@ -17,19 +19,40 @@ export default function RulesTable({
     groupOptions,
   } = hooks;
   const { t } = useTranslation();
+
+  const styles = {
+    table: css({ mb: "2", borderCollapse: "collapse", width: "100%" }),
+    addWrapper: css({ display: "flex", gap: "2", mb: "2" }),
+    addBtn: css({
+      bg: "green.600",
+      color: "white",
+      px: "2",
+      py: "1",
+      borderRadius: token("radii.md"),
+    }),
+    saveBtn: css({
+      bg: "blue.600",
+      color: "white",
+      px: "2",
+      py: "1",
+      borderRadius: token("radii.md"),
+      _disabled: { opacity: 0.5 },
+    }),
+    headerCell: css({ borderWidth: "1px", px: "1" }),
+  };
   return (
     <div>
-      <table className="mb-2 border-collapse w-full">
+      <table className={styles.table}>
         <thead>
           <tr>
-            <th className="border px-1">ptype</th>
-            <th className="border px-1">v0</th>
-            <th className="border px-1">v1</th>
-            <th className="border px-1">v2</th>
-            <th className="border px-1">v3</th>
-            <th className="border px-1">v4</th>
-            <th className="border px-1">v5</th>
-            <th className="border px-1" />
+            <th className={styles.headerCell}>ptype</th>
+            <th className={styles.headerCell}>v0</th>
+            <th className={styles.headerCell}>v1</th>
+            <th className={styles.headerCell}>v2</th>
+            <th className={styles.headerCell}>v3</th>
+            <th className={styles.headerCell}>v4</th>
+            <th className={styles.headerCell}>v5</th>
+            <th className={styles.headerCell} />
           </tr>
         </thead>
         <tbody>
@@ -45,12 +68,8 @@ export default function RulesTable({
           ))}
         </tbody>
       </table>
-      <div className="flex gap-2 mb-2">
-        <button
-          type="button"
-          onClick={addRule}
-          className="bg-green-600 text-white px-2 py-1 rounded"
-        >
+      <div className={styles.addWrapper}>
+        <button type="button" onClick={addRule} className={styles.addBtn}>
           {t("admin.addRule")}
         </button>
       </div>
@@ -58,7 +77,7 @@ export default function RulesTable({
         type="button"
         onClick={() => saveRulesMutation.mutate()}
         disabled={!isSuperadmin}
-        className="bg-blue-600 text-white px-2 py-1 rounded disabled:opacity-50"
+        className={styles.saveBtn}
       >
         {t("admin.saveRules")}
       </button>


### PR DESCRIPTION
## Summary
- restyle Admin casbin editor components using Panda CSS

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c08c07848832b9fa85fb096fc648b