### PR TITLE
Fix tests failing due to missing CSS modules

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -30,6 +30,14 @@ vi.mock("next/image", () => ({
     React.createElement("img", props),
 }));
 
+vi.mock("styled-system/css", () => ({
+  css: () => "",
+}));
+
+vi.mock("styled-system/tokens", () => ({
+  token: (path: string) => path,
+}));
+
 let originalGetUserMedia:
   | ((constraints: MediaStreamConstraints) => Promise<MediaStream>)
   | undefined;


### PR DESCRIPTION
## Summary
- stub out `styled-system` CSS/tokens modules for Vitest

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke` *(fails in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_686c11e870d0832b8b916b784bcaa34f