### PR TITLE
Migrate case list and case view to Panda CSS

### DIFF
--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -10,6 +10,8 @@ import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { type RefObject, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
+import { token } from "styled-system/tokens";
 import { useNotify } from "../components/NotificationProvider";
 import { caseQueryKey } from "../hooks/useCase";
 import useEventSource from "../hooks/useEventSource";
@@ -123,6 +125,54 @@ export default function ClientCasesPage({
     setDropCase(null);
   });
 
+  const styles = {
+    container: css({ p: "8", position: "relative", h: "full" }),
+    heading: css({ fontSize: "xl", fontWeight: "bold", mb: "4" }),
+    controls: css({ mb: "4", display: "flex", alignItems: "center", gap: "4" }),
+    label: css({ mr: "2" }),
+    select: css({
+      borderWidth: "1px",
+      borderRadius: token("radii.md"),
+      p: "1",
+      backgroundColor: {
+        base: token("colors.white"),
+        _dark: token("colors.gray.900"),
+      },
+    }),
+    filterLabel: css({ display: "flex", alignItems: "center", gap: "1" }),
+    grid: css({ display: "grid", gap: "4" }),
+    link: css({ display: "block", textAlign: "left" }),
+    dropOverlay: css({
+      position: "absolute",
+      inset: 0,
+      backgroundColor: "rgba(0,0,0,0.5)",
+      color: "white",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      pointerEvents: "none",
+      fontSize: "xl",
+      zIndex: "var(--z-nav)",
+    }),
+    listItem: (selected: boolean, dropping: boolean) =>
+      css({
+        borderWidth: "1px",
+        borderRadius: token("radii.md"),
+        p: "2",
+        mb: "4",
+        _last: { mb: 0 },
+        ringWidth: selected || dropping ? "2px" : "1px",
+        ringColor: selected
+          ? token("colors.blue.500")
+          : dropping
+            ? token("colors.green.500")
+            : "transparent",
+        backgroundColor: selected
+          ? { base: token("colors.gray.100"), _dark: token("colors.gray.800") }
+          : undefined,
+      }),
+  };
+
   async function uploadFilesToCase(id: string, files: FileList) {
     const results = await Promise.all(
       Array.from(files).map((file) => {
@@ -144,7 +194,7 @@ export default function ClientCasesPage({
   return (
     <div
       ref={scrollElement ? undefined : localScrollRef}
-      className="p-8 relative h-full"
+      className={styles.container}
       onDragOver={(e) => e.preventDefault()}
       onDragEnter={(e) => {
         e.preventDefault();
@@ -168,22 +218,22 @@ export default function ClientCasesPage({
         setDropCase(null);
       }}
     >
-      <h1 className="text-xl font-bold mb-4">{t("nav.cases")}</h1>
-      <div className="mb-4 flex items-center gap-4">
-        <label className="mr-2" htmlFor="order">
+      <h1 className={styles.heading}>{t("nav.cases")}</h1>
+      <div className={styles.controls}>
+        <label className={styles.label} htmlFor="order">
           {t("orderBy")}
         </label>
         <select
           id="order"
           value={orderBy}
           onChange={(e) => setOrderBy(e.target.value as Order)}
-          className="border rounded p-1 bg-white dark:bg-gray-900"
+          className={styles.select}
         >
           <option value="createdAt">{t("creationDate")}</option>
           <option value="updatedAt">{t("lastUpdated")}</option>
           <option value="distance">{t("distanceFromMe")}</option>
         </select>
-        <label className="flex items-center gap-1" htmlFor="case-states">
+        <label className={styles.filterLabel} htmlFor="case-states">
           <span>{t("show")}</span>
           <select
             id="case-states"
@@ -194,7 +244,7 @@ export default function ClientCasesPage({
                 Array.from(e.target.selectedOptions).map((o) => o.value),
               )
             }
-            className="border rounded p-1 bg-white dark:bg-gray-900"
+            className={styles.select}
           >
             <option value="open">{t("open")}</option>
             <option value="archived">{t("archived")}</option>
@@ -224,13 +274,10 @@ export default function ClientCasesPage({
                     setDropCase(null);
                   }
                 }}
-                className={`border rounded p-2 mb-4 last:mb-0${
-                  selectedIds.includes(c.id)
-                    ? " bg-gray-100 dark:bg-gray-800 ring-2 ring-blue-500"
-                    : dropCase === c.id
-                      ? " ring-2 ring-green-500"
-                      : " ring-1 ring-transparent"
-                }`}
+                className={styles.listItem(
+                  selectedIds.includes(c.id),
+                  dropCase === c.id,
+                )}
                 style={{
                   position: "absolute",
                   top: 0,
@@ -248,7 +295,7 @@ export default function ClientCasesPage({
                       router.push(`/cases?ids=${ids.join(",")}`);
                     }
                   }}
-                  className="block text-left"
+                  className={styles.link}
                 >
                   <CaseCard caseData={c} />
                 </Link>
@@ -257,7 +304,7 @@ export default function ClientCasesPage({
           })}
         </div>
       ) : (
-        <ul className="grid gap-4">
+        <ul className={styles.grid}>
           {filteredCases.map((c) => (
             <li
               key={c.id}
@@ -270,13 +317,10 @@ export default function ClientCasesPage({
                   setDropCase(null);
                 }
               }}
-              className={`border rounded p-2${
-                selectedIds.includes(c.id)
-                  ? " bg-gray-100 dark:bg-gray-800 ring-2 ring-blue-500"
-                  : dropCase === c.id
-                    ? " ring-2 ring-green-500"
-                    : " ring-1 ring-transparent"
-              }`}
+              className={styles.listItem(
+                selectedIds.includes(c.id),
+                dropCase === c.id,
+              )}
             >
               <Link
                 href={session ? `/cases/${c.id}` : `/public/cases/${c.id}`}
@@ -287,7 +331,7 @@ export default function ClientCasesPage({
                     router.push(`/cases?ids=${ids.join(",")}`);
                   }
                 }}
-                className="block text-left"
+                className={styles.link}
               >
                 <CaseCard caseData={c} />
               </Link>
@@ -296,7 +340,7 @@ export default function ClientCasesPage({
         </ul>
       )}
       {dragging ? (
-        <div className="absolute inset-0 bg-black/50 text-white flex items-center justify-center pointer-events-none text-xl z-nav">
+        <div className={styles.dropOverlay} data-testid="drag-overlay">
           {dropCase
             ? t("addPhotosToCase", { id: dropCase })
             : t("dropPhotosToCreateCase")}

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -9,6 +9,8 @@ import { useSession } from "@/app/useSession";
 import type { Case } from "@/lib/caseStore";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
+import { token } from "styled-system/tokens";
 import { CaseProvider, useCaseContext } from "./CaseContext";
 import CaseDetails from "./components/CaseDetails";
 import CaseExtraInfo from "./components/CaseExtraInfo";
@@ -36,32 +38,69 @@ function ClientCasePage({
     if (stored) setPreview(stored);
   }, [caseId]);
 
+  const styles = {
+    loadingWrapper: css({
+      p: "8",
+      display: "flex",
+      flexDirection: "column",
+      gap: "4",
+    }),
+    loadingHeading: css({ fontSize: "xl", fontWeight: "semibold" }),
+    loadingText: css({
+      fontSize: "sm",
+      color: {
+        base: token("colors.gray.500"),
+        _dark: token("colors.gray.400"),
+      },
+    }),
+    container: (expanded: boolean) =>
+      css({
+        position: "relative",
+        h: "full",
+        display: expanded ? { md: "grid" } : undefined,
+        gridTemplateColumns: expanded ? { md: "1fr 1fr" } : undefined,
+        gap: expanded ? "4" : undefined,
+        overflow: expanded ? "hidden" : undefined,
+      }),
+    col: css({ h: "full", overflowY: "auto" }),
+    overlay: css({
+      position: "absolute",
+      inset: 0,
+      backgroundColor: "rgba(0,0,0,0.5)",
+      color: "white",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      pointerEvents: "none",
+      fontSize: "xl",
+      zIndex: "var(--z-nav)",
+    }),
+  };
+
   const showClaimBanner = Boolean(
     caseData?.sessionId && !session?.user && !hideClaimBanner,
   );
 
   if (!caseData) {
     return (
-      <div className="p-8 flex flex-col gap-4">
-        <h1 className="text-xl font-semibold">{t("uploading")}</h1>
+      <div className={styles.loadingWrapper}>
+        <h1 className={styles.loadingHeading}>{t("uploading")}</h1>
         {preview ? (
           <img
             src={preview}
             alt="preview"
-            className="max-w-full"
+            className={css({ maxW: "full" })}
             loading="lazy"
           />
         ) : null}
-        <p className="text-sm text-gray-500 dark:text-gray-400">
-          {t("uploadingPhoto")}
-        </p>
+        <p className={styles.loadingText}>{t("uploadingPhoto")}</p>
       </div>
     );
   }
 
   return (
     <div
-      className={`relative h-full ${chatExpanded ? "md:grid md:grid-cols-2 gap-4 overflow-hidden" : ""}`}
+      className={styles.container(chatExpanded)}
       onDragOver={readOnly ? undefined : (e) => e.preventDefault()}
       onDragEnter={
         readOnly
@@ -93,18 +132,18 @@ function ClientCasePage({
       <ClaimBanner
         show={showClaimBanner}
         onDismiss={() => setHideClaimBanner(true)}
-        className={chatExpanded ? "md:col-span-2" : undefined}
+        className={
+          chatExpanded ? css({ md: { gridColumn: "span 2" } }) : undefined
+        }
       />
       <PublicViewBanner
         caseId={caseId}
         show={readOnly}
-        className={chatExpanded ? "md:col-span-2" : undefined}
-      />
-      <div
         className={
-          chatExpanded ? "md:col-span-1 h-full overflow-y-auto" : undefined
+          chatExpanded ? css({ md: { gridColumn: "span 2" } }) : undefined
         }
-      >
+      />
+      <div className={chatExpanded ? styles.col : undefined}>
         <CaseLayout
           header={<CaseHeader caseId={caseId} readOnly={readOnly} />}
           left={<CaseProgressGraph caseData={caseData} />}
@@ -121,16 +160,12 @@ function ClientCasePage({
         </CaseLayout>
       </div>
       {readOnly || !dragging ? null : (
-        <div className="absolute inset-0 bg-black/50 text-white flex items-center justify-center pointer-events-none text-xl z-nav">
+        <div className={styles.overlay} data-testid="drag-overlay">
           {t("dropToAddPhotos")}
         </div>
       )}
       {readOnly ? null : (
-        <div
-          className={
-            chatExpanded ? "md:col-span-1 h-full overflow-y-auto" : undefined
-          }
-        >
+        <div className={chatExpanded ? styles.col : undefined}>
           <CaseChat
             caseId={caseId}
             expanded={chatExpanded}

--- a/src/app/cases/[id]/components/CaseHeader.tsx
+++ b/src/app/cases/[id]/components/CaseHeader.tsx
@@ -10,6 +10,8 @@ import {
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
 import { FaArrowLeft, FaShare } from "react-icons/fa";
+import { css } from "styled-system/css";
+import { token } from "styled-system/tokens";
 import { useCaseContext } from "../CaseContext";
 import useCaseActions from "../useCaseActions";
 import useCaseProgress from "../useCaseProgress";
@@ -37,17 +39,35 @@ export default function CaseHeader({
   const ownershipRequestLink = ownershipRequested
     ? getLatestOwnershipRequestLink(caseData)
     : null;
+  const styles = {
+    wrapper: css({
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+    }),
+    left: css({ display: "flex", alignItems: "center", gap: "2" }),
+    backLink: css({
+      display: { md: "none" },
+      fontSize: "xl",
+      p: "2",
+      color: "blue.500",
+      _hover: { color: "blue.700" },
+    }),
+    heading: css({ fontSize: "xl", fontWeight: "semibold" }),
+    shareButton: css({ color: "blue.500", _hover: { color: "blue.700" } }),
+    copied: css({ fontSize: "sm", color: "green.600" }),
+  };
   return (
-    <div className="flex items-center justify-between">
-      <div className="flex items-center gap-2">
+    <div className={styles.wrapper}>
+      <div className={styles.left}>
         <Link
           href="/cases"
           aria-label={t("backToCases")}
-          className="md:hidden text-xl p-2 text-blue-500 hover:text-blue-700"
+          className={styles.backLink}
         >
           <FaArrowLeft />
         </Link>
-        <h1 className="text-xl font-semibold">
+        <h1 className={styles.heading}>
           {t("caseLabel", { id: caseData.id })}
         </h1>
         {caseData.public ? (
@@ -55,14 +75,12 @@ export default function CaseHeader({
             type="button"
             onClick={copyPublicUrl}
             aria-label={t("copyPublicLink")}
-            className="text-blue-500 hover:text-blue-700"
+            className={styles.shareButton}
           >
             <FaShare />
           </button>
         ) : null}
-        {copied ? (
-          <span className="text-sm text-green-600">{t("copied")}</span>
-        ) : null}
+        {copied ? <span className={styles.copied}>{t("copied")}</span> : null}
       </div>
       <CaseToolbar
         caseId={caseId}

--- a/src/app/cases/__tests__/dragOverlayPosition.test.tsx
+++ b/src/app/cases/__tests__/dragOverlayPosition.test.tsx
@@ -53,7 +53,7 @@ describe("drag overlays", () => {
     );
     const target = container.firstElementChild as HTMLElement;
     fireEvent.dragEnter(target);
-    const overlay = container.querySelector("div.absolute.inset-0");
+    const overlay = container.querySelector('[data-testid="drag-overlay"]');
     expect(overlay).toBeInTheDocument();
   });
 
@@ -65,7 +65,7 @@ describe("drag overlays", () => {
     );
     const target = container.firstElementChild as HTMLElement;
     fireEvent.dragEnter(target);
-    const overlay = container.querySelector("div.absolute.inset-0");
+    const overlay = container.querySelector('[data-testid="drag-overlay"]');
     expect(overlay).toBeInTheDocument();
   });
 });

--- a/src/app/components/CaseLayout.tsx
+++ b/src/app/components/CaseLayout.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from "react";
+import { css } from "styled-system/css";
+import { token } from "styled-system/tokens";
 
 export default function CaseLayout({
   header,
@@ -11,14 +13,35 @@ export default function CaseLayout({
   right: ReactNode;
   children?: ReactNode;
 }) {
+  const styles = {
+    wrapper: css({
+      p: "8",
+      display: "flex",
+      flexDirection: "column",
+      gap: "4",
+    }),
+    header: css({
+      position: "sticky",
+      top: 0,
+      backgroundColor: {
+        base: token("colors.white"),
+        _dark: token("colors.gray.900"),
+      },
+      zIndex: "var(--z-sticky)",
+    }),
+    grid: css({
+      display: "grid",
+      gridTemplateColumns: { base: "1fr", md: "35% 65%", lg: "30% 70%" },
+      gap: { base: "4", md: "6" },
+    }),
+    right: css({ display: "flex", flexDirection: "column", gap: "4" }),
+  };
   return (
-    <div className="p-8 flex flex-col gap-4">
-      <div className="sticky top-0 bg-white dark:bg-gray-900 z-sticky">
-        {header}
-      </div>
-      <div className="grid grid-cols-1 md:grid-cols-[35%_65%] lg:grid-cols-[30%_70%] gap-4 md:gap-6">
+    <div className={styles.wrapper}>
+      <div className={styles.header}>{header}</div>
+      <div className={styles.grid}>
         <div>{left}</div>
-        <div className="flex flex-col gap-4">{right}</div>
+        <div className={styles.right}>{right}</div>
       </div>
       {children}
     </div>

--- a/src/components/CaseCard.tsx
+++ b/src/components/CaseCard.tsx
@@ -7,6 +7,8 @@ import {
   getRepresentativePhoto,
 } from "@/lib/caseUtils";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
+import { token } from "styled-system/tokens";
 
 export interface CaseCardProps {
   caseData: Case;
@@ -24,24 +26,80 @@ export default function CaseCard({ caseData, className }: CaseCardProps) {
     : caseData.closed
       ? t("closed")
       : t("open");
+  const styles = {
+    container: css({
+      display: "grid",
+      gridTemplateColumns: "auto auto 1fr",
+      alignItems: "center",
+      gap: "2",
+    }),
+    imageWrapper: css({
+      position: "relative",
+      width: token("sizes.16"),
+      height: token("sizes.12"),
+      flexShrink: 0,
+    }),
+    photo: css({ objectFit: "cover", width: "100%", height: "100%" }),
+    badge: css({
+      position: "absolute",
+      bottom: "1",
+      right: "1",
+      backgroundColor: "rgba(0,0,0,0.75)",
+      color: "white",
+      fontSize: "xs",
+      borderRadius: token("radii.sm"),
+      px: "1",
+    }),
+    map: css({
+      width: token("sizes.16"),
+      aspectRatio: token("aspectRatios.landscape"),
+    }),
+    details: css({
+      display: "flex",
+      flexDirection: "column",
+      fontSize: "xs",
+      gap: "0.5",
+      overflow: "hidden",
+    }),
+    label: css({
+      fontWeight: "semibold",
+      fontSize: "sm",
+      textOverflow: "ellipsis",
+      overflow: "hidden",
+      whiteSpace: "nowrap",
+    }),
+    meta: css({
+      color: {
+        base: token("colors.gray.500"),
+        _dark: token("colors.gray.400"),
+      },
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap",
+    }),
+    status: css({
+      color: {
+        base: token("colors.gray.500"),
+        _dark: token("colors.gray.400"),
+      },
+    }),
+    updating: css({ color: token("colors.gray.400") }),
+  };
+
   return (
-    <div
-      className={`grid grid-cols-[auto_auto_1fr] items-center gap-2 ${className ?? ""}`}
-    >
+    <div className={`${styles.container} ${className ?? ""}`}>
       {photo ? (
-        <div className="relative w-16 h-12 shrink-0">
+        <div className={styles.imageWrapper}>
           <img
             src={`/uploads/${photo}`}
             alt={t("casePreview")}
             width={64}
             height={48}
-            className="object-cover w-full h-full"
+            className={styles.photo}
             loading="lazy"
           />
           {caseData.photos.length > 1 ? (
-            <span className="absolute bottom-1 right-1 bg-black/75 text-white text-xs rounded px-1">
-              {caseData.photos.length}
-            </span>
+            <span className={styles.badge}>{caseData.photos.length}</span>
           ) : null}
         </div>
       ) : null}
@@ -51,25 +109,27 @@ export default function CaseCard({ caseData, className }: CaseCardProps) {
           lon={location.lon}
           width={96}
           height={72}
-          className="w-16 aspect-[4/3]"
+          className={styles.map}
         />
       ) : null}
-      <div className="flex flex-col text-xs gap-0.5 overflow-hidden">
-        <span className="font-semibold text-sm truncate">
+      <div className={styles.details}>
+        <span className={styles.label}>
           {t("caseLabel", { id: caseData.id })}
         </span>
         {caseData.analysis?.violationType ? (
-          <span className="truncate">{caseData.analysis.violationType}</span>
+          <span className={css({ truncate: true })}>
+            {caseData.analysis.violationType}
+          </span>
         ) : null}
         {plateNumber || plateState ? (
-          <span className="text-gray-500 dark:text-gray-400 truncate">
+          <span className={`${styles.meta} ${css({ truncate: true })}`}>
             {plateState ? `${plateState} ` : ""}
             {plateNumber}
           </span>
         ) : null}
-        <span className="text-gray-500 dark:text-gray-400">{status}</span>
+        <span className={styles.status}>{status}</span>
         {caseData.analysisStatus === "pending" ? (
-          <span className="text-gray-400">{t("updatingAnalysis")}</span>
+          <span className={styles.updating}>{t("updatingAnalysis")}</span>
         ) : null}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- migrate case list and single case pages from Tailwind to Panda
- update CaseCard and CaseLayout styling
- adjust CaseHeader to use Panda
- update drag overlay tests

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c19a18978832b891350023ba8218c