### PR TITLE
Refactor components to Panda CSS

### DIFF
--- a/src/app/components/AddImageMenu.tsx
+++ b/src/app/components/AddImageMenu.tsx
@@ -3,6 +3,8 @@ import * as Popover from "@radix-ui/react-popover";
 import Link from "next/link";
 import { type RefObject, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { css, cva } from "styled-system/css";
+import { token } from "styled-system/tokens";
 
 export default function AddImageMenu({
   caseId,
@@ -17,36 +19,66 @@ export default function AddImageMenu({
 }) {
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
+  const styles = {
+    trigger: css({
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      borderWidth: "1px",
+      borderRadius: "sm",
+      width: token("sizes.20"),
+      aspectRatio: token("aspectRatios.landscape"),
+      fontSize: "sm",
+      color: {
+        base: token("colors.gray.500"),
+        _dark: token("colors.gray.400"),
+      },
+      cursor: "pointer",
+      userSelect: "none",
+    }),
+    content: css({
+      bg: { base: "white", _dark: "gray.900" },
+      borderWidth: "1px",
+      borderRadius: "sm",
+      boxShadow: "md",
+      color: { base: "black", _dark: "white" },
+    }),
+  };
+
+  const menuItem = cva({
+    base: {
+      display: "block",
+      px: "4",
+      py: "2",
+      w: "full",
+      textAlign: "left",
+      _hover: { bg: { base: "gray.100", _dark: "gray.700" } },
+    },
+  });
   return (
     <>
       <Popover.Root open={open} onOpenChange={setOpen}>
         <Popover.Trigger asChild>
-          <button
-            type="button"
-            className="flex items-center justify-center border rounded w-20 aspect-[4/3] text-sm text-gray-500 dark:text-gray-400 cursor-pointer select-none"
-          >
+          <button type="button" className={styles.trigger}>
             {t("addImage")}
           </button>
         </Popover.Trigger>
         <Popover.Portal>
-          <Popover.Content
-            sideOffset={4}
-            className="bg-white dark:bg-gray-900 border rounded shadow text-black dark:text-white"
-          >
+          <Popover.Content sideOffset={4} className={styles.content}>
             <button
               type="button"
               onClick={() => {
                 setOpen(false);
                 fileInputRef.current?.click();
               }}
-              className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+              className={menuItem()}
             >
               {t("uploadImage")}
             </button>
             {hasCamera ? (
               <Link
                 href={`/point?case=${caseId}`}
-                className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 w-full text-left"
+                className={menuItem()}
                 onClick={() => setOpen(false)}
               >
                 {t("takePhoto")}
@@ -61,7 +93,7 @@ export default function AddImageMenu({
         accept="image/*"
         multiple
         onChange={onChange}
-        className="hidden"
+        className={css({ display: "none" })}
       />
     </>
   );

--- a/src/app/components/CaseJobList.tsx
+++ b/src/app/components/CaseJobList.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
+import { token } from "styled-system/tokens";
 import useEventSource from "../hooks/useEventSource";
 
 interface JobInfo {
@@ -27,6 +29,29 @@ export default function CaseJobList({
   const [updatedAt, setUpdatedAt] = useState<number>(0);
   const { t } = useTranslation();
 
+  const styles = {
+    container: css({
+      bg: { base: "gray.100", _dark: "gray.800" },
+      p: "4",
+      borderRadius: "sm",
+      display: "flex",
+      flexDirection: "column",
+      gap: "2",
+      fontSize: "sm",
+    }),
+    heading: css({ fontWeight: "semibold" }),
+    list: css({ display: "grid", gap: "1" }),
+    item: css({ display: "flex", justifyContent: "space-between" }),
+    type: css({ fontFamily: "mono", mr: "2" }),
+    footer: css({
+      fontSize: "xs",
+      color: {
+        base: token("colors.gray.600"),
+        _dark: token("colors.gray.400"),
+      },
+    }),
+  };
+
   useEventSource<JobResponse>(
     `${isPublic ? "/api/public/cases" : "/api/cases"}/${encodeURIComponent(caseId)}/jobs/stream`,
     (data) => {
@@ -41,17 +66,17 @@ export default function CaseJobList({
   }
 
   return (
-    <div className="bg-gray-100 dark:bg-gray-800 p-4 rounded flex flex-col gap-2 text-sm">
-      <h2 className="font-semibold">{t("activeJobs")}</h2>
-      <ul className="grid gap-1">
+    <div className={styles.container}>
+      <h2 className={styles.heading}>{t("activeJobs")}</h2>
+      <ul className={styles.list}>
         {jobs.map((j) => (
-          <li key={j.id} className="flex justify-between">
-            <span className="font-mono mr-2">{j.type}</span>
+          <li key={j.id} className={styles.item}>
+            <span className={styles.type}>{j.type}</span>
             {new Date(j.startedAt).toLocaleString()}
           </li>
         ))}
       </ul>
-      <p className="text-xs text-gray-600 dark:text-gray-400">
+      <p className={styles.footer}>
         {t("lastAudit")}{" "}
         {auditedAt ? new Date(auditedAt).toLocaleString() : "n/a"}
         {" | "}

--- a/src/app/components/ConfirmDialog.tsx
+++ b/src/app/components/ConfirmDialog.tsx
@@ -1,6 +1,8 @@
 "use client";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useTranslation } from "react-i18next";
+import { css, cva } from "styled-system/css";
+import { token } from "styled-system/tokens";
 
 export default function ConfirmDialog({
   open,
@@ -14,19 +16,62 @@ export default function ConfirmDialog({
   onCancel: () => void;
 }) {
   const { t } = useTranslation();
+  const styles = {
+    overlay: css({
+      position: "fixed",
+      inset: 0,
+      bg: "rgba(0,0,0,0.5)",
+    }),
+    content: css({
+      position: "fixed",
+      inset: 0,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      p: "4",
+    }),
+    dialog: css({
+      bg: { base: "white", _dark: "gray.900" },
+      borderRadius: "sm",
+      boxShadow: "md",
+      maxW: "sm",
+      w: "full",
+    }),
+    footer: css({
+      display: "flex",
+      justifyContent: "flex-end",
+      gap: "2",
+      p: "4",
+    }),
+    message: css({ p: "4" }),
+  };
+
+  const actionButton = cva({
+    base: {
+      px: "2",
+      py: "1",
+      borderRadius: "sm",
+    },
+    variants: {
+      variant: {
+        cancel: { bg: { base: "gray.200", _dark: "gray.700" } },
+        confirm: { bg: "blue.600", color: "white" },
+      },
+    },
+  });
   return (
     <Dialog.Root open={open} onOpenChange={(o) => !o && onCancel()}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-modal" />
-        <Dialog.Content className="fixed inset-0 flex items-center justify-center p-4 z-modal">
-          <div className="bg-white dark:bg-gray-900 rounded shadow max-w-sm w-full">
-            <p className="p-4">{message}</p>
-            <div className="flex justify-end gap-2 p-4">
+        <Dialog.Overlay className={`z-modal ${styles.overlay}`} />
+        <Dialog.Content className={`z-modal ${styles.content}`}>
+          <div className={styles.dialog}>
+            <p className={styles.message}>{message}</p>
+            <div className={styles.footer}>
               <Dialog.Close asChild>
                 <button
                   type="button"
                   onClick={onCancel}
-                  className="bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded"
+                  className={actionButton({ variant: "cancel" })}
                 >
                   {t("close")}
                 </button>
@@ -35,7 +80,7 @@ export default function ConfirmDialog({
                 <button
                   type="button"
                   onClick={onConfirm}
-                  className="bg-blue-600 text-white px-2 py-1 rounded"
+                  className={actionButton({ variant: "confirm" })}
                 >
                   {t("save")}
                 </button>

--- a/src/app/components/MultiCaseToolbar.tsx
+++ b/src/app/components/MultiCaseToolbar.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
+import { css, cva } from "styled-system/css";
 
 export default function MultiCaseToolbar({
   caseIds,
@@ -22,19 +23,47 @@ export default function MultiCaseToolbar({
   const idsParam = caseIds.join(",");
   const first = caseIds[0];
   const { t } = useTranslation();
+  const styles = {
+    container: css({
+      bg: { base: "gray.100", _dark: "gray.800" },
+      px: "8",
+      py: "2",
+      display: "flex",
+      justifyContent: "flex-end",
+    }),
+    trigger: css({
+      cursor: "pointer",
+      userSelect: "none",
+      bg: { base: "gray.300", _dark: "gray.700" },
+      px: "2",
+      py: "1",
+      borderRadius: "sm",
+    }),
+    menu: css({ mt: "1" }),
+  };
+
+  const menuLink = cva({
+    base: {
+      w: "full",
+      textAlign: "left",
+      px: "4",
+      py: "2",
+      _hover: { bg: { base: "gray.100", _dark: "gray.700" } },
+    },
+  });
   return (
-    <div className="bg-gray-100 dark:bg-gray-800 px-8 py-2 flex justify-end">
+    <div className={styles.container}>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            className="cursor-pointer select-none bg-gray-300 dark:bg-gray-700 px-2 py-1 rounded"
+            className={styles.trigger}
             aria-label={t("caseActionsMenu")}
           >
             {t("actions")}
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="mt-1">
+        <DropdownMenuContent align="end" className={styles.menu}>
           <DropdownMenuItem asChild>
             <button
               type="button"
@@ -48,7 +77,7 @@ export default function MultiCaseToolbar({
                 );
                 window.location.reload();
               }}
-              className="w-full text-left"
+              className={menuLink()}
             >
               {t("rerunAnalysis")}
             </button>
@@ -68,7 +97,7 @@ export default function MultiCaseToolbar({
                 );
                 window.location.reload();
               }}
-              className="w-full text-left"
+              className={menuLink()}
             >
               {t("archiveCase")}
             </button>
@@ -78,7 +107,7 @@ export default function MultiCaseToolbar({
               <DropdownMenuItem asChild>
                 <Link
                   href={`/cases/${first}/compose?ids=${idsParam}`}
-                  className="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                  className={menuLink()}
                 >
                   {t("draftEmail")}
                 </Link>
@@ -87,7 +116,7 @@ export default function MultiCaseToolbar({
                 <DropdownMenuItem asChild>
                   <Link
                     href={`/cases/${first}/ownership?ids=${idsParam}`}
-                    className="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    className={menuLink()}
                   >
                     {t("requestOwnershipInfo")}
                   </Link>
@@ -97,7 +126,7 @@ export default function MultiCaseToolbar({
                 <DropdownMenuItem asChild>
                   <Link
                     href={`/cases/${first}/notify-owner?ids=${idsParam}`}
-                    className="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    className={menuLink()}
                   >
                     {t("notifyRegisteredOwner")}
                   </Link>
@@ -123,7 +152,7 @@ export default function MultiCaseToolbar({
                 }
               }}
               data-testid="delete-cases-button"
-              className="w-full text-left"
+              className={menuLink()}
             >
               {t("deleteCase")}
             </button>


### PR DESCRIPTION
## Summary
- replace Tailwind classes with Panda `css` in AddImageMenu, ConfirmDialog, CaseJobList and MultiCaseToolbar
- define reusable `cva` variants for menu items and buttons

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686c2da42880832b91cbf6a4abc2a415