### PR TITLE
Fix Storybook styled-system alias

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -24,6 +24,7 @@ const config: StorybookConfig = {
         ".storybook",
         "NextAuthStub.tsx",
       ),
+      "styled-system": path.resolve(process.cwd(), "styled-system"),
       "@": path.resolve(process.cwd(), "src"),
     };
     config.resolve.fallback = {

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "paths": {
-      "@/lib/stats": ["./StatsStub.ts"]
+      "@/lib/stats": ["./StatsStub.ts"],
+      "styled-system/*": ["../styled-system/*"]
     }
   },
   "include": ["../src/**/*.ts", "../src/**/*.tsx", "./**/*.ts"],

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,14 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": [".next", "coverage", "dist", "data", "styled-system"]
+    "ignore": [
+      ".next",
+      "coverage",
+      "dist",
+      "data",
+      "styled-system",
+      "storybook-static"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "styled-system/*": ["./styled-system/*"]
     },
     "types": ["vitest"]
   },


### PR DESCRIPTION
## Summary
- alias `styled-system` in Storybook webpack config
- add `styled-system` paths to tsconfigs
- ignore Storybook build output for Biome

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`
- `pnpm run build-storybook`

------
https://chatgpt.com/codex/tasks/task_e_686c36ebb2b4832b84e2ccb5aca03179