### PR TITLE
Convert LoggedOut landing to Panda CSS

### DIFF
--- a/src/app/LoggedOutLandingClient.tsx
+++ b/src/app/LoggedOutLandingClient.tsx
@@ -1,5 +1,7 @@
 "use client";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
+import { token } from "styled-system/tokens";
 
 export interface LandingStats {
   casesLastWeek: number;
@@ -21,38 +23,70 @@ export default function LoggedOutLandingClient({
   stats: LandingStats;
 }) {
   const { t } = useTranslation();
+  const styles = {
+    main: css({
+      p: "8",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      textAlign: "center",
+      gap: "6",
+    }),
+    heading: css({
+      fontSize: token("fontSizes.3xl"),
+      fontWeight: "700",
+    }),
+    description: css({ fontSize: "lg", maxWidth: token("sizes.xl") }),
+    grid: css({
+      display: "grid",
+      gridTemplateColumns: { base: "1fr", sm: "repeat(2, 1fr)" },
+      gap: "4",
+      mt: "4",
+    }),
+    card: css({
+      bg: { base: "gray.100", _dark: "gray.800" },
+      borderRadius: token("radii.md"),
+      p: "4",
+      boxShadow: token("shadows.sm"),
+    }),
+    stat: css({ fontSize: token("fontSizes.2xl"), fontWeight: "semibold" }),
+    label: css({ fontSize: "sm" }),
+    signInWrapper: css({ mt: "4" }),
+    signInLink: css({
+      color: token("colors.blue.600"),
+      textDecorationLine: "underline",
+    }),
+  };
   return (
-    <main className="p-8 flex flex-col items-center text-center gap-6">
-      <h1 className="text-3xl font-bold">{t("title")}</h1>
-      <p className="text-lg max-w-xl">{t("landingDescription")}</p>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
-        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
-          <div className="text-2xl font-semibold">
-            {formatCount(stats.casesLastWeek)}
-          </div>
-          <div className="text-sm">{t("casesLastWeek")}</div>
+    <main className={styles.main}>
+      <h1 className={styles.heading}>{t("title")}</h1>
+      <p className={styles.description}>{t("landingDescription")}</p>
+      <div className={styles.grid}>
+        <div className={styles.card}>
+          <div className={styles.stat}>{formatCount(stats.casesLastWeek)}</div>
+          <div className={styles.label}>{t("casesLastWeek")}</div>
         </div>
-        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
-          <div className="text-2xl font-semibold">
+        <div className={styles.card}>
+          <div className={styles.stat}>
             {formatCount(stats.authorityNotifications)}
           </div>
-          <div className="text-sm">{t("authorityNotifications")}</div>
+          <div className={styles.label}>{t("authorityNotifications")}</div>
         </div>
-        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
-          <div className="text-2xl font-semibold">
+        <div className={styles.card}>
+          <div className={styles.stat}>
             {`<${Math.ceil(stats.avgDaysToNotification)} days`}
           </div>
-          <div className="text-sm">{t("avgTimeToNotify")}</div>
+          <div className={styles.label}>{t("avgTimeToNotify")}</div>
         </div>
-        <div className="bg-gray-100 dark:bg-gray-800 rounded p-4 shadow">
-          <div className="text-2xl font-semibold">
+        <div className={styles.card}>
+          <div className={styles.stat}>
             {`>${Math.floor(stats.notificationSuccessRate * 100)}%`}
           </div>
-          <div className="text-sm">{t("casesWithNotification")}</div>
+          <div className={styles.label}>{t("casesWithNotification")}</div>
         </div>
       </div>
-      <p className="mt-4">
-        <a href="/signin" className="text-blue-600 underline">
+      <p className={styles.signInWrapper}>
+        <a href="/signin" className={styles.signInLink}>
           {t("signIn")}
         </a>
       </p>


### PR DESCRIPTION
## Summary
- switch LoggedOut landing page from Tailwind to Panda CSS
- import Panda's css helper

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c3933958c832b852bc17a5504e87f