### PR TITLE
feat: add overlay color token

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -12,7 +12,13 @@ export default defineConfig({
 
   // Useful for theme customization
   theme: {
-    extend: {},
+    extend: {
+      tokens: {
+        colors: {
+          overlay: { value: "rgba(0,0,0,0.5)" },
+        },
+      },
+    },
   },
 
   // The output directory for your css system

--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -145,7 +145,7 @@ export default function ClientCasesPage({
     dropOverlay: css({
       position: "absolute",
       inset: 0,
-      backgroundColor: "rgba(0,0,0,0.5)",
+      backgroundColor: token("colors.overlay"),
       color: "white",
       display: "flex",
       alignItems: "center",

--- a/src/app/components/ConfirmDialog.tsx
+++ b/src/app/components/ConfirmDialog.tsx
@@ -20,7 +20,7 @@ export default function ConfirmDialog({
     overlay: css({
       position: "fixed",
       inset: 0,
-      bg: "rgba(0,0,0,0.5)",
+      bg: token("colors.overlay"),
     }),
     content: css({
       position: "fixed",


### PR DESCRIPTION
## Summary
- add `colors.overlay` to Panda theme
- use the overlay token in `ConfirmDialog`
- use the overlay token for drag overlays

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` *(fails: AssertionError in AdminPageClient.test.tsx)*
- `pnpm run e2e:smoke` *(incomplete output due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_686c39de0084832b93fa2345f8653f60