### PR TITLE
Add surface and muted color tokens

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -12,7 +12,21 @@ export default defineConfig({
 
   // Useful for theme customization
   theme: {
-    extend: {},
+    extend: {
+      semanticTokens: {
+        colors: {
+          "surface-default": {
+            value: { base: "{colors.white}", _dark: "{colors.gray.900}" },
+          },
+          "surface-subtle": {
+            value: { base: "{colors.gray.100}", _dark: "{colors.gray.800}" },
+          },
+          "text-muted": {
+            value: { base: "{colors.gray.500}", _dark: "{colors.gray.400}" },
+          },
+        },
+      },
+    },
   },
 
   // The output directory for your css system

--- a/src/app/components/CaseLayout.tsx
+++ b/src/app/components/CaseLayout.tsx
@@ -23,10 +23,7 @@ export default function CaseLayout({
     header: css({
       position: "sticky",
       top: 0,
-      backgroundColor: {
-        base: token("colors.white"),
-        _dark: token("colors.gray.900"),
-      },
+      backgroundColor: token("colors.surface-default"),
       zIndex: "var(--z-sticky)",
     }),
     grid: css({

--- a/src/components/CaseCard.tsx
+++ b/src/components/CaseCard.tsx
@@ -69,21 +69,15 @@ export default function CaseCard({ caseData, className }: CaseCardProps) {
       whiteSpace: "nowrap",
     }),
     meta: css({
-      color: {
-        base: token("colors.gray.500"),
-        _dark: token("colors.gray.400"),
-      },
+      color: token("colors.text-muted"),
       overflow: "hidden",
       textOverflow: "ellipsis",
       whiteSpace: "nowrap",
     }),
     status: css({
-      color: {
-        base: token("colors.gray.500"),
-        _dark: token("colors.gray.400"),
-      },
+      color: token("colors.text-muted"),
     }),
-    updating: css({ color: token("colors.gray.400") }),
+    updating: css({ color: token("colors.text-muted") }),
   };
 
   return (


### PR DESCRIPTION
## Summary
- extend Panda config with `surface-default`, `surface-subtle`, and `text-muted` semantic tokens
- use these tokens in `CaseLayout` and `CaseCard`

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c39e91e04832bb0e3503a710c5065