### PR TITLE
Introduce overlay and default shadow tokens

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -12,7 +12,16 @@ export default defineConfig({
 
   // Useful for theme customization
   theme: {
-    extend: {},
+    extend: {
+      tokens: {
+        colors: {
+          overlay: { value: "rgba(0,0,0,0.5)" },
+        },
+        shadows: {
+          default: { value: "{shadows.md}" },
+        },
+      },
+    },
   },
 
   // The output directory for your css system

--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -145,7 +145,7 @@ export default function ClientCasesPage({
     dropOverlay: css({
       position: "absolute",
       inset: 0,
-      backgroundColor: "rgba(0,0,0,0.5)",
+      backgroundColor: token("colors.overlay"),
       color: "white",
       display: "flex",
       alignItems: "center",

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -66,7 +66,7 @@ function ClientCasePage({
     overlay: css({
       position: "absolute",
       inset: 0,
-      backgroundColor: "rgba(0,0,0,0.5)",
+      backgroundColor: token("colors.overlay"),
       color: "white",
       display: "flex",
       alignItems: "center",

--- a/src/app/components/AddImageMenu.tsx
+++ b/src/app/components/AddImageMenu.tsx
@@ -40,7 +40,7 @@ export default function AddImageMenu({
       bg: { base: "white", _dark: "gray.900" },
       borderWidth: "1px",
       borderRadius: "sm",
-      boxShadow: "md",
+      boxShadow: token("shadows.default"),
       color: { base: "black", _dark: "white" },
     }),
   };

--- a/src/app/components/ConfirmDialog.tsx
+++ b/src/app/components/ConfirmDialog.tsx
@@ -20,7 +20,7 @@ export default function ConfirmDialog({
     overlay: css({
       position: "fixed",
       inset: 0,
-      bg: "rgba(0,0,0,0.5)",
+      bg: token("colors.overlay"),
     }),
     content: css({
       position: "fixed",
@@ -33,7 +33,7 @@ export default function ConfirmDialog({
     dialog: css({
       bg: { base: "white", _dark: "gray.900" },
       borderRadius: "sm",
-      boxShadow: "md",
+      boxShadow: token("shadows.default"),
       maxW: "sm",
       w: "full",
     }),

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -148,7 +148,7 @@ export default function NavBar() {
       bg: { base: "white", _dark: "gray.900" },
       borderWidth: "1px",
       borderRadius: token("radii.md"),
-      boxShadow: token("shadows.md"),
+      boxShadow: token("shadows.default"),
       fontSize: "sm",
     }),
     menuItem: css({
@@ -303,7 +303,7 @@ export default function NavBar() {
                   bg: { base: "gray.100", _dark: "gray.900" },
                   borderWidth: "1px",
                   borderRadius: token("radii.md"),
-                  boxShadow: token("shadows.md"),
+                  boxShadow: token("shadows.default"),
                   p: "4",
                 })}
               >

--- a/src/app/public/users/[id]/PublicProfileClient.tsx
+++ b/src/app/public/users/[id]/PublicProfileClient.tsx
@@ -40,7 +40,7 @@ export default function PublicProfileClient({
         _dark: token("colors.gray.800"),
       },
       borderRadius: token("radii.lg"),
-      boxShadow: token("shadows.md"),
+      boxShadow: token("shadows.default"),
     }),
     avatarImg: css({
       width: "6rem",


### PR DESCRIPTION
## Summary
- define `colors.overlay` and `shadows.default` in `panda.config.ts`
- use `colors.overlay` wherever overlays were using `rgba(0,0,0,0.5)`
- use `shadows.default` instead of `boxShadow: "md"` or `token("shadows.md")`

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c39ce9280832bb204d8be72595a2d