### PR TITLE
Use design tokens for spacing and radii

### DIFF
--- a/src/app/LoggedOutLandingClient.tsx
+++ b/src/app/LoggedOutLandingClient.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { space } from "@/styleTokens";
 import { useTranslation } from "react-i18next";
 import { css } from "styled-system/css";
 import { token } from "styled-system/tokens";
@@ -25,7 +26,7 @@ export default function LoggedOutLandingClient({
   const { t } = useTranslation();
   const styles = {
     main: css({
-      p: "8",
+      p: space.container,
       display: "flex",
       flexDirection: "column",
       alignItems: "center",
@@ -40,7 +41,7 @@ export default function LoggedOutLandingClient({
     grid: css({
       display: "grid",
       gridTemplateColumns: { base: "1fr", sm: "repeat(2, 1fr)" },
-      gap: "4",
+      gap: space.gap,
       mt: "4",
     }),
     card: css({

--- a/src/app/admin/AdminPageClient.tsx
+++ b/src/app/admin/AdminPageClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useSession } from "@/app/useSession";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { space } from "@/styleTokens";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -69,7 +70,7 @@ export default function AdminPageClient({
     tabsList: css({
       mb: "4",
       display: "flex",
-      gap: "4",
+      gap: space.gap,
       borderBottomWidth: "1px",
     }),
   };

--- a/src/app/admin/AppConfigurationTab.tsx
+++ b/src/app/admin/AppConfigurationTab.tsx
@@ -2,6 +2,7 @@
 import { apiFetch } from "@/apiClient";
 import { useSession } from "@/app/useSession";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { space } from "@/styleTokens";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -156,7 +157,7 @@ export default function AppConfigurationTab() {
   });
 
   const styles = {
-    tabs: css({ display: "flex", gap: "4" }),
+    tabs: css({ display: "flex", gap: space.gap }),
     tabsList: css({
       display: "flex",
       flexDirection: "column",
@@ -174,7 +175,7 @@ export default function AppConfigurationTab() {
       mb: "4",
     }),
     list: css({ display: "grid", gap: "2" }),
-    item: css({ display: "flex", alignItems: "center", gap: "4" }),
+    item: css({ display: "flex", alignItems: "center", gap: space.gap }),
     flex1: css({ flex: "1" }),
     toggleOn: css({
       bg: "green.500",

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,6 +2,7 @@ import { getCasbinRules, listUsers } from "@/lib/adminStore";
 import { authOptions } from "@/lib/authOptions";
 import { withAuthorization } from "@/lib/authz";
 import { log } from "@/lib/logger";
+import { space } from "@/styleTokens";
 import { getServerSession } from "next-auth/next";
 import type { ReactElement } from "react";
 import { css } from "styled-system/css";
@@ -42,7 +43,7 @@ const handler = withAuthorization<
       tab === "config" || (tab === "status" && isSuperadmin)
         ? (tab as "config" | "status")
         : "users";
-    const styles = { wrapper: css({ p: "8" }) };
+    const styles = { wrapper: css({ p: space.container }) };
     return (
       <div className={styles.wrapper}>
         <AdminPageClient

--- a/src/app/cases/ClientCasesPage.tsx
+++ b/src/app/cases/ClientCasesPage.tsx
@@ -5,6 +5,7 @@ import CaseCard from "@/components/CaseCard";
 import type { Case } from "@/lib/caseStore";
 import { getOfficialCaseGps } from "@/lib/caseUtils";
 import { distanceBetween } from "@/lib/distance";
+import { space } from "@/styleTokens";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
@@ -126,9 +127,14 @@ export default function ClientCasesPage({
   });
 
   const styles = {
-    container: css({ p: "8", position: "relative", h: "full" }),
+    container: css({ p: space.container, position: "relative", h: "full" }),
     heading: css({ fontSize: "xl", fontWeight: "bold", mb: "4" }),
-    controls: css({ mb: "4", display: "flex", alignItems: "center", gap: "4" }),
+    controls: css({
+      mb: "4",
+      display: "flex",
+      alignItems: "center",
+      gap: space.gap,
+    }),
     label: css({ mr: "2" }),
     select: css({
       borderWidth: "1px",
@@ -140,7 +146,7 @@ export default function ClientCasesPage({
       },
     }),
     filterLabel: css({ display: "flex", alignItems: "center", gap: "1" }),
-    grid: css({ display: "grid", gap: "4" }),
+    grid: css({ display: "grid", gap: space.gap }),
     link: css({ display: "block", textAlign: "left" }),
     dropOverlay: css({
       position: "absolute",

--- a/src/app/cases/[id]/ClientCasePage.tsx
+++ b/src/app/cases/[id]/ClientCasePage.tsx
@@ -7,6 +7,7 @@ import CaseProgressGraph from "@/app/components/CaseProgressGraph";
 import DebugWrapper from "@/app/components/DebugWrapper";
 import { useSession } from "@/app/useSession";
 import type { Case } from "@/lib/caseStore";
+import { space } from "@/styleTokens";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { css } from "styled-system/css";
@@ -40,10 +41,10 @@ function ClientCasePage({
 
   const styles = {
     loadingWrapper: css({
-      p: "8",
+      p: space.container,
       display: "flex",
       flexDirection: "column",
-      gap: "4",
+      gap: space.gap,
     }),
     loadingHeading: css({ fontSize: "xl", fontWeight: "semibold" }),
     loadingText: css({

--- a/src/app/components/AddImageMenu.tsx
+++ b/src/app/components/AddImageMenu.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { radii } from "@/styleTokens";
 import * as Popover from "@radix-ui/react-popover";
 import Link from "next/link";
 import { type RefObject, useState } from "react";
@@ -25,7 +26,7 @@ export default function AddImageMenu({
       alignItems: "center",
       justifyContent: "center",
       borderWidth: "1px",
-      borderRadius: "sm",
+      borderRadius: radii.default,
       width: token("sizes.20"),
       aspectRatio: token("aspectRatios.landscape"),
       fontSize: "sm",
@@ -39,7 +40,7 @@ export default function AddImageMenu({
     content: css({
       bg: { base: "white", _dark: "gray.900" },
       borderWidth: "1px",
-      borderRadius: "sm",
+      borderRadius: radii.default,
       boxShadow: token("shadows.default"),
       color: { base: "black", _dark: "white" },
     }),

--- a/src/app/components/CaseJobList.tsx
+++ b/src/app/components/CaseJobList.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { radii } from "@/styleTokens";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { css } from "styled-system/css";
@@ -33,7 +34,7 @@ export default function CaseJobList({
     container: css({
       bg: { base: "gray.100", _dark: "gray.800" },
       p: "4",
-      borderRadius: "sm",
+      borderRadius: radii.default,
       display: "flex",
       flexDirection: "column",
       gap: "2",

--- a/src/app/components/CaseLayout.tsx
+++ b/src/app/components/CaseLayout.tsx
@@ -1,3 +1,4 @@
+import { space } from "@/styleTokens";
 import type { ReactNode } from "react";
 import { css } from "styled-system/css";
 import { token } from "styled-system/tokens";
@@ -15,10 +16,10 @@ export default function CaseLayout({
 }) {
   const styles = {
     wrapper: css({
-      p: "8",
+      p: space.container,
       display: "flex",
       flexDirection: "column",
-      gap: "4",
+      gap: space.gap,
     }),
     header: css({
       position: "sticky",
@@ -32,9 +33,9 @@ export default function CaseLayout({
     grid: css({
       display: "grid",
       gridTemplateColumns: { base: "1fr", md: "35% 65%", lg: "30% 70%" },
-      gap: { base: "4", md: "6" },
+      gap: { base: space.gap, md: "6" },
     }),
-    right: css({ display: "flex", flexDirection: "column", gap: "4" }),
+    right: css({ display: "flex", flexDirection: "column", gap: space.gap }),
   };
   return (
     <div className={styles.wrapper}>

--- a/src/app/components/ConfirmDialog.tsx
+++ b/src/app/components/ConfirmDialog.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { radii } from "@/styleTokens";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useTranslation } from "react-i18next";
 import { css, cva } from "styled-system/css";
@@ -32,7 +33,7 @@ export default function ConfirmDialog({
     }),
     dialog: css({
       bg: { base: "white", _dark: "gray.900" },
-      borderRadius: "sm",
+      borderRadius: radii.default,
       boxShadow: token("shadows.default"),
       maxW: "sm",
       w: "full",
@@ -50,7 +51,7 @@ export default function ConfirmDialog({
     base: {
       px: "2",
       py: "1",
-      borderRadius: "sm",
+      borderRadius: radii.default,
     },
     variants: {
       variant: {

--- a/src/app/components/MultiCaseToolbar.tsx
+++ b/src/app/components/MultiCaseToolbar.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { radii } from "@/styleTokens";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
 import { css, cva } from "styled-system/css";
@@ -37,7 +38,7 @@ export default function MultiCaseToolbar({
       bg: { base: "gray.300", _dark: "gray.700" },
       px: "2",
       py: "1",
-      borderRadius: "sm",
+      borderRadius: radii.default,
     }),
     menu: css({ mt: "1" }),
   };

--- a/src/app/public/users/[id]/PublicProfileClient.tsx
+++ b/src/app/public/users/[id]/PublicProfileClient.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { space } from "@/styleTokens";
 import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import { FaUserCircle } from "react-icons/fa";
@@ -32,7 +33,7 @@ export default function PublicProfileClient({
       display: "flex",
       flexDirection: "column",
       alignItems: "center",
-      gap: "4",
+      gap: space.gap,
       textAlign: "center",
       maxWidth: "32rem",
       backgroundColor: {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,6 +3,7 @@ import { apiFetch } from "@/apiClient";
 import { useSession } from "@/app/useSession";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { US_STATES } from "@/lib/usStates";
+import { space } from "@/styleTokens";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -73,13 +74,13 @@ export default function UserSettingsPage() {
   const [status, setStatus] = useState<string | undefined>(undefined);
   const [notes, setNotes] = useState<string | null | undefined>(undefined);
   const styles = {
-    container: css({ p: "8" }),
+    container: css({ p: space.container }),
     heading: css({
       fontSize: token("fontSizes.xl"),
       fontWeight: "700",
       mb: "4",
     }),
-    tabsList: css({ mb: "4", display: "flex", gap: "4" }),
+    tabsList: css({ mb: "4", display: "flex", gap: space.gap }),
     form: css({ display: "grid", gap: "2", maxWidth: token("sizes.md") }),
     label: css({ display: "flex", flexDirection: "column" }),
     input: css({ borderWidth: "1px", p: "1" }),

--- a/src/styleTokens.ts
+++ b/src/styleTokens.ts
@@ -1,0 +1,10 @@
+import { token } from "styled-system/tokens";
+
+export const radii = {
+  default: token("radii.md"),
+};
+
+export const space = {
+  container: "8",
+  gap: "4",
+};


### PR DESCRIPTION
## Summary
- add shared styleTokens file
- use radii.default and spacing tokens across components

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_686c39c63b88832b844adb661cf9180b