### PR TITLE
Add button recipe and refactor admin components

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "@pandacss/dev";
+import { buttonRecipe } from "./src/recipes/button";
 
 export default defineConfig({
   // Disable the built-in reset to avoid conflicts with Tailwind
@@ -20,6 +21,9 @@ export default defineConfig({
         shadows: {
           default: { value: "{shadows.md}" },
         },
+      },
+      recipes: {
+        button: buttonRecipe,
       },
     },
   },

--- a/src/app/admin/components/InviteUserForm.tsx
+++ b/src/app/admin/components/InviteUserForm.tsx
@@ -2,6 +2,7 @@
 import { type FormEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { css } from "styled-system/css";
+import { button } from "styled-system/recipes";
 import { token } from "styled-system/tokens";
 import type { useUsers } from "../hooks/useUsers";
 
@@ -26,13 +27,7 @@ export default function InviteUserForm({
       p: "1",
       backgroundColor: { base: "white", _dark: token("colors.gray.900") },
     }),
-    button: css({
-      bg: "blue.600",
-      color: "white",
-      px: "2",
-      py: "1",
-      borderRadius: token("radii.md"),
-    }),
+    button: button({ variant: "primary" }),
   };
 
   return (

--- a/src/app/admin/components/RuleRow.tsx
+++ b/src/app/admin/components/RuleRow.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { css } from "styled-system/css";
+import { button } from "styled-system/recipes";
 import { token } from "styled-system/tokens";
 import type { CasbinRule } from "../AdminPageClient";
 import type { GroupOptions, PolicyOptions } from "../hooks/useCasbinRules";
@@ -45,13 +46,7 @@ export default function RuleRow({
       p: "1",
       backgroundColor: { base: "white", _dark: token("colors.gray.900") },
     }),
-    deleteBtn: css({
-      bg: "red.500",
-      color: "white",
-      px: "2",
-      py: "1",
-      borderRadius: token("radii.md"),
-    }),
+    deleteBtn: button({ variant: "danger" }),
   };
 
   return (

--- a/src/app/admin/components/RulesTable.tsx
+++ b/src/app/admin/components/RulesTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useTranslation } from "react-i18next";
-import { css } from "styled-system/css";
+import { css, cx } from "styled-system/css";
+import { button } from "styled-system/recipes";
 import { token } from "styled-system/tokens";
 import type { useCasbinRules } from "../hooks/useCasbinRules";
 import RuleRow from "./RuleRow";
@@ -23,21 +24,11 @@ export default function RulesTable({
   const styles = {
     table: css({ mb: "2", borderCollapse: "collapse", width: "100%" }),
     addWrapper: css({ display: "flex", gap: "2", mb: "2" }),
-    addBtn: css({
-      bg: "green.600",
-      color: "white",
-      px: "2",
-      py: "1",
-      borderRadius: token("radii.md"),
-    }),
-    saveBtn: css({
-      bg: "blue.600",
-      color: "white",
-      px: "2",
-      py: "1",
-      borderRadius: token("radii.md"),
-      _disabled: { opacity: 0.5 },
-    }),
+    addBtn: button({ variant: "primary" }),
+    saveBtn: cx(
+      button({ variant: "primary" }),
+      css({ _disabled: { opacity: 0.5 } }),
+    ),
     headerCell: css({ borderWidth: "1px", px: "1" }),
   };
   return (

--- a/src/app/admin/components/UsersTable.tsx
+++ b/src/app/admin/components/UsersTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useTranslation } from "react-i18next";
 import { css } from "styled-system/css";
+import { button } from "styled-system/recipes";
 import { token } from "styled-system/tokens";
 import type { UserRecord } from "../AdminPageClient";
 import type { useUsers } from "../hooks/useUsers";
@@ -21,20 +22,8 @@ export default function UsersTable({
       p: "1",
       backgroundColor: { base: "white", _dark: token("colors.gray.900") },
     }),
-    disableBtn: css({
-      bg: "yellow.500",
-      color: "white",
-      px: "2",
-      py: "1",
-      borderRadius: token("radii.md"),
-    }),
-    deleteBtn: css({
-      bg: "red.500",
-      color: "white",
-      px: "2",
-      py: "1",
-      borderRadius: token("radii.md"),
-    }),
+    disableBtn: button({ variant: "warning" }),
+    deleteBtn: button({ variant: "danger" }),
   };
 
   return (

--- a/src/recipes/button.ts
+++ b/src/recipes/button.ts
@@ -1,0 +1,22 @@
+import { defineRecipe } from "@pandacss/dev";
+
+export const buttonRecipe = defineRecipe({
+  className: "button",
+  base: {
+    px: "2",
+    py: "1",
+    borderRadius: "{radii.md}",
+  },
+  variants: {
+    variant: {
+      primary: { bg: "blue.600", color: "white" },
+      danger: { bg: "red.600", color: "white" },
+      warning: { bg: "orange.600", color: "black" },
+      neutral: {
+        bg: { base: "gray.200", _dark: "gray.700" },
+        color: { base: "black", _dark: "white" },
+      },
+    },
+  },
+  defaultVariants: { variant: "primary" },
+});


### PR DESCRIPTION
## Summary
- extend Panda theme with a `button` recipe
- use the new recipe in several admin UI components

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c39e0e148832ba1d25736d270e345