### PR TITLE
Add design token docs

### DIFF
--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -1,0 +1,23 @@
+# Design Tokens
+
+This project uses Panda CSS to manage design tokens. The tokens live in the generated directory `styled-system/tokens`.
+You can pull token values into components with Panda's `token` function:
+
+```ts
+import { token } from "styled-system/tokens";
+
+const styles = {
+  heading: {
+    fontSize: token("fontSizes.xl"),
+    color: token("colors.blue.600"),
+  },
+};
+```
+
+When Panda runs it converts the tokens to CSS variables inside `styled-system/styles.css`.
+Many values map back to variables declared in `src/app/globals.css` such as
+`--color-background`, `--color-foreground` and the z-index utilities (`--z-nav`, `--z-sticky`, etc.).
+Updating those variables will cascade through the tokens so components stay in sync.
+
+Available token categories include colors, font sizes, spacing, radii and shadows.
+See `styled-system/tokens/index.mjs` for the complete list.


### PR DESCRIPTION
## Summary
- document Panda design tokens

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke` *(fails: Next.js build hangs in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_686c454ec84c832bbef099d63bbf7d8b