### PR TITLE
Update docs for Panda CSS usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ that involves manual steps like mailing forms or payments.
 
 This stack is designed for performance, type safety, and complete control over hosting and infrastructure.
 
+## Styling with Panda CSS
+
+Panda generates static styles based on the tokens and `css` utilities used in the
+codebase. Run `pnpm run panda` whenever you modify tokens or add new components
+to keep the `styled-system` directory up to date.
+
 ## Getting Started
 
 Install dependencies and generate Panda styles before starting the development server:

--- a/docs/design-system-guidelines.md
+++ b/docs/design-system-guidelines.md
@@ -10,4 +10,7 @@ This project uses **Panda CSS** with shadcn/ui components. Follow these principl
 - Keep new components inside `src/components` and expose variant props so styles can be adjusted without editing CSS.
 - Avoid direct `z-index` values; use the utility classes provided in `globals.css` (`z-nav`, `z-sticky`, etc.).
 
+Run `pnpm run panda` after modifying tokens or creating new components so
+Panda can regenerate the static styles.
+
 Following these rules keeps the design consistent and eliminates the need to touch raw CSS files.

--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -14,6 +14,9 @@ const styles = {
 };
 ```
 
+Run `pnpm run panda` whenever you change tokens so the `styled-system` directory
+contains the latest CSS variables.
+
 When Panda runs it converts the tokens to CSS variables inside `styled-system/styles.css`.
 Many values map back to variables declared in `src/app/globals.css` such as
 `--color-background`, `--color-foreground` and the z-index utilities (`--z-nav`, `--z-sticky`, etc.).

--- a/src/app/components/AddImageMenu.tsx
+++ b/src/app/components/AddImageMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { radii } from "@/styleTokens";
 import { menuItem } from "@/components/ui/menuItem";
+import { radii } from "@/styleTokens";
 import * as Popover from "@radix-ui/react-popover";
 import Link from "next/link";
 import { type RefObject, useState } from "react";

--- a/src/app/components/MultiCaseToolbar.tsx
+++ b/src/app/components/MultiCaseToolbar.tsx
@@ -7,8 +7,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { radii } from "@/styleTokens";
 import { menuItem } from "@/components/ui/menuItem";
+import { radii } from "@/styleTokens";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
 import { css } from "styled-system/css";


### PR DESCRIPTION
## Summary
- mention Panda CSS generation in README and docs
- fix import order flagged by lint

## Testing
- `pnpm run lint`
- `pnpm run lint:md`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c588514b4832bb442acb450b18aea