### PR TITLE
refactor: migrate select pages to panda css

### DIFF
--- a/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
@@ -4,9 +4,11 @@ import ThumbnailImage from "@/components/thumbnail-image";
 import type { EmailDraft } from "@/lib/caseReport";
 import type { Case } from "@/lib/caseStore";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
+import { space } from "@/styleTokens";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
 import { useNotify } from "../../../components/NotificationProvider";
 
 export default function NotifyOwnerEditor({
@@ -111,12 +113,46 @@ export default function NotifyOwnerEditor({
   }
 
   if (!initialDraft) {
-    return <div className="p-8">{t("draftingEmail")}</div>;
+    return (
+      <div className={css({ p: space.container })}>{t("draftingEmail")}</div>
+    );
   }
 
+  const styles = {
+    wrapper: css({
+      p: space.container,
+      display: "flex",
+      flexDirection: "column",
+      gap: space.gap,
+    }),
+    title: css({ fontSize: "xl", fontWeight: "semibold" }),
+    list: css({ display: "flex", flexDirection: "column", gap: "2" }),
+    sentRow: css({ display: "flex", alignItems: "center", gap: "2" }),
+    sentText: css({ color: "green.700" }),
+    errorText: css({ color: "red.600", fontSize: "sm" }),
+    checkboxLabel: css({ display: "flex", alignItems: "center", gap: "2" }),
+    inputLabel: css({ display: "flex", flexDirection: "column" }),
+    input: css({ borderWidth: "1px", p: "1" }),
+    attachments: css({ display: "flex", gap: "2", flexWrap: "wrap" }),
+    button: css({
+      bg: "blue.500",
+      color: "white",
+      px: "2",
+      py: "1",
+      rounded: "md",
+      _disabled: { opacity: 0.5 },
+    }),
+    link: css({
+      color: "blue.500",
+      textDecorationLine: "underline",
+      mt: "2",
+      fontSize: "sm",
+    }),
+  };
+
   return (
-    <div className="p-8 flex flex-col gap-4">
-      <h1 className="text-xl font-semibold">{t("ownerNotification")}</h1>
+    <div className={styles.wrapper}>
+      <h1 className={styles.title}>{t("ownerNotification")}</h1>
       <p>{t("photosAttachedAuto")}</p>
       <div className="flex flex-col gap-2">
         {contactInfo.email &&

--- a/src/app/cases/[id]/ownership/OwnershipEditor.tsx
+++ b/src/app/cases/[id]/ownership/OwnershipEditor.tsx
@@ -2,6 +2,7 @@
 import { apiFetch } from "@/apiClient";
 import type { OwnershipModule } from "@/lib/ownershipModules";
 import { US_STATES } from "@/lib/usStates";
+import { space } from "@/styleTokens";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -183,29 +184,49 @@ export default function OwnershipEditor({
     }
   }
 
+  const styles = {
+    wrapper: css({
+      p: space.container,
+      display: "flex",
+      flexDirection: "column",
+      gap: space.gap,
+    }),
+    title: css({ fontSize: "xl", fontWeight: "semibold" }),
+    pre: cx(
+      "p-2 whitespace-pre-wrap",
+      css({ bg: token("colors.surface-subtle") }),
+    ),
+    iframe: css({ w: "full", h: "96", borderWidth: "1px" }),
+    labelCol: css({ display: "flex", flexDirection: "column" }),
+    input: css({ borderWidth: "1px", p: "1" }),
+    checkboxLabel: css({
+      display: "flex",
+      alignItems: "center",
+      gap: "2",
+      mt: "2",
+    }),
+    button: css({
+      bg: "blue.500",
+      color: "white",
+      px: "2",
+      py: "1",
+      rounded: "md",
+    }),
+    error: css({ color: "red.600", fontSize: "sm" }),
+    success: css({ color: "green.700", fontSize: "sm" }),
+  };
   return (
-    <div className="p-8 flex flex-col gap-4">
-      <h1 className="text-xl font-semibold">{t("ownershipRequest")}</h1>
+    <div className={styles.wrapper}>
+      <h1 className={styles.title}>{t("ownershipRequest")}</h1>
       <p>
         {t("stateLabel")} {module.state}
       </p>
       <p>{t("sendCheckTo", { fee: total })}</p>
-      <pre
-        className={cx(
-          "p-2 whitespace-pre-wrap",
-          css({ bg: token("colors.surface-subtle") }),
-        )}
-      >
-        {module.address}
-      </pre>
+      <pre className={styles.pre}>{module.address}</pre>
       {showPdf ? (
-        <iframe
-          src={pdfUrl}
-          className="w-full h-96 border"
-          title="Ownership form"
-        />
+        <iframe src={pdfUrl} className={styles.iframe} title="Ownership form" />
       ) : null}
-      <label className="flex flex-col">
+      <label className={styles.labelCol}>
         Name
         <input
           type="text"
@@ -213,10 +234,10 @@ export default function OwnershipEditor({
           onChange={(e) =>
             setForm((f) => ({ ...f, requesterName: e.target.value }))
           }
-          className="border p-1"
+          className={styles.input}
         />
       </label>
-      <label className="flex flex-col">
+      <label className={styles.labelCol}>
         Email
         <input
           type="text"
@@ -224,10 +245,10 @@ export default function OwnershipEditor({
           onChange={(e) =>
             setForm((f) => ({ ...f, requesterEmailAddress: e.target.value }))
           }
-          className="border p-1"
+          className={styles.input}
         />
       </label>
-      <label className="flex flex-col">
+      <label className={styles.labelCol}>
         Address
         <input
           type="text"
@@ -235,10 +256,10 @@ export default function OwnershipEditor({
           onChange={(e) =>
             setForm((f) => ({ ...f, requesterAddress: e.target.value }))
           }
-          className="border p-1"
+          className={styles.input}
         />
       </label>
-      <label className="flex flex-col">
+      <label className={styles.labelCol}>
         City/State/Zip
         <input
           type="text"
@@ -246,10 +267,10 @@ export default function OwnershipEditor({
           onChange={(e) =>
             setForm((f) => ({ ...f, requesterCityStateZip: e.target.value }))
           }
-          className="border p-1"
+          className={styles.input}
         />
       </label>
-      <label className="flex flex-col">
+      <label className={styles.labelCol}>
         Daytime Phone
         <input
           type="text"
@@ -260,10 +281,10 @@ export default function OwnershipEditor({
               requesterDaytimePhoneNumber: e.target.value,
             }))
           }
-          className="border p-1"
+          className={styles.input}
         />
       </label>
-      <label className="flex flex-col">
+      <label className={styles.labelCol}>
         {t("driverLicenseNumberLabel")}
         <input
           type="text"
@@ -274,10 +295,10 @@ export default function OwnershipEditor({
               requesterDriverLicenseNumber: e.target.value,
             }))
           }
-          className="border p-1"
+          className={styles.input}
         />
       </label>
-      <label className="flex flex-col">
+      <label className={styles.labelCol}>
         {t("driverLicenseStateLabel")}
         <select
           value={form.requesterDriverLicenseState ?? "IL"}
@@ -287,7 +308,7 @@ export default function OwnershipEditor({
               requesterDriverLicenseState: e.target.value,
             }))
           }
-          className="border p-1"
+          className={styles.input}
         >
           {US_STATES.map((s) => (
             <option key={s} value={s}>
@@ -296,12 +317,12 @@ export default function OwnershipEditor({
           ))}
         </select>
       </label>
-      <label className="flex flex-col">
+      <label className={styles.labelCol}>
         Section 2
         <select
           value={option}
           onChange={(e) => setOption(e.target.value)}
-          className="border p-1"
+          className={styles.input}
         >
           <option value="titleSearch">Title Search — $5 each</option>
           <option value="registrationSearch">
@@ -315,7 +336,7 @@ export default function OwnershipEditor({
           </option>
         </select>
       </label>
-      <label className="flex items-center gap-2 mt-2">
+      <label className={styles.checkboxLabel}>
         <input
           type="checkbox"
           checked={microfilmWithSearchOption}
@@ -323,7 +344,7 @@ export default function OwnershipEditor({
         />
         <span>Microfilm Requested with any Search Option, no charge</span>
       </label>
-      <label className="flex items-center gap-2">
+      <label className={styles.checkboxLabel}>
         <input
           type="checkbox"
           checked={microfilmOnly}
@@ -331,30 +352,26 @@ export default function OwnershipEditor({
         />
         <span>Microfilm Only — $5</span>
       </label>
-      <label className="flex flex-col">
+      <label className={styles.labelCol}>
         {t("checkNumberLabel")}
         <input
           type="text"
           value={checkNumber}
           onChange={(e) => setCheckNumber(e.target.value)}
-          className="border p-1"
+          className={styles.input}
         />
       </label>
-      <button
-        type="button"
-        onClick={() => record()}
-        className="bg-blue-500 text-white px-2 py-1 rounded"
-      >
+      <button type="button" onClick={() => record()} className={styles.button}>
         {t("sendSnailMailRequest")}
       </button>
       {snailMailResult?.status === "error" && (
-        <span className="text-red-600 text-sm">{snailMailResult.error}</span>
+        <span className={styles.error}>{snailMailResult.error}</span>
       )}
       {checkResult?.status === "success" && (
-        <span className="text-green-700 text-sm">{t("checkGenerated")}</span>
+        <span className={styles.success}>{t("checkGenerated")}</span>
       )}
       {checkResult?.status === "error" && (
-        <span className="text-red-600 text-sm">
+        <span className={styles.error}>
           {t("checkGenerationFailed", { reason: checkResult.error })}
         </span>
       )}

--- a/src/app/cases/[id]/thread/ClientThreadPage.tsx
+++ b/src/app/cases/[id]/thread/ClientThreadPage.tsx
@@ -4,6 +4,7 @@ import SnailMailStatusIcon from "@/components/SnailMailStatusIcon";
 import ThumbnailImage from "@/components/thumbnail-image";
 import type { Case, SentEmail, ThreadImage } from "@/lib/caseStore";
 import { getThumbnailUrl } from "@/lib/clientThumbnails";
+import { space } from "@/styleTokens";
 import { useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
@@ -86,7 +87,7 @@ export default function ClientThreadPage({
   }
 
   if (!caseData) {
-    return <div className="p-8">{t("loading")}</div>;
+    return <div className={css({ p: space.container })}>{t("loading")}</div>;
   }
 
   const thread = buildThread(caseData, startId);
@@ -94,46 +95,146 @@ export default function ClientThreadPage({
     (i) => i.threadParent === startId,
   );
 
+  const styles = {
+    wrapper: css({
+      p: space.container,
+      display: "flex",
+      flexDirection: "column",
+      gap: space.gap,
+    }),
+    header: cx(
+      css({
+        position: "sticky",
+        top: "14",
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        borderBottomWidth: "1px",
+        pb: "2",
+        bg: token("colors.surface"),
+      }),
+    ),
+    headerRow: css({ display: "flex", alignItems: "center", gap: "2" }),
+    backLink: css({
+      fontSize: "xl",
+      p: "2",
+      color: "blue.500",
+      _hover: { color: "blue.700" },
+    }),
+    title: css({ fontSize: "xl", fontWeight: "semibold" }),
+    actions: css({ display: "flex", gap: "2", alignItems: "center" }),
+    uploadLabel: css({
+      bg: { base: "gray.200", _dark: "gray.700" },
+      px: "2",
+      py: "1",
+      rounded: "md",
+      cursor: "pointer",
+    }),
+    hiddenInput: css({ display: "none" }),
+    followupLink: css({
+      bg: "blue.500",
+      color: "white",
+      px: "2",
+      py: "1",
+      rounded: "md",
+    }),
+    list: css({ display: "flex", flexDirection: "column", gap: space.gap }),
+    listItem: css({ borderWidth: "1px", p: "2", rounded: "md" }),
+    preBody: css({ whiteSpace: "pre-wrap", fontSize: "sm" }),
+    attachmentsList: css({
+      mt: "2",
+      display: "flex",
+      flexDirection: "column",
+      gap: "1",
+    }),
+    attachmentItem: css({ display: "flex", alignItems: "center", gap: "2" }),
+    attachmentLink: css({
+      display: "flex",
+      alignItems: "center",
+      gap: "2",
+      color: "blue.500",
+      textDecorationLine: "underline",
+    }),
+    pdfIcon: css({ w: "8", h: "8", color: "red.600" }),
+    fileIcon: css({ w: "8", h: "8" }),
+    imageItem: css({
+      borderWidth: "1px",
+      p: "2",
+      rounded: "md",
+      display: "flex",
+      gap: "2",
+    }),
+    imageThumbnail: css({ cursor: "pointer" }),
+    imageInfo: css({
+      display: "flex",
+      flexDirection: "column",
+      gap: "2",
+      flex: "1",
+    }),
+    modal: css({
+      position: "fixed",
+      inset: "0",
+      bg: "black/50",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      p: "4",
+    }),
+    modalContent: cx(
+      css({ bg: token("colors.surface"), rounded: "md", shadow: "md" }),
+      "max-w-3xl w-full",
+    ),
+    modalImageWrapper: css({ position: "relative", w: "full", h: "80vh" }),
+    modalImage: css({
+      objectFit: "contain",
+      position: "absolute",
+      inset: "0",
+      w: "full",
+      h: "full",
+    }),
+    modalClose: css({ display: "flex", justifyContent: "end", p: "2" }),
+    closeButton: css({
+      bg: token("colors.surface-subtle"),
+      rounded: "md",
+      px: "2",
+      py: "1",
+    }),
+  };
   return (
-    <div className="p-8 flex flex-col gap-4">
-      <div
-        className={cx(
-          "sticky top-14 flex justify-between items-center border-b pb-2",
-          css({ bg: token("colors.surface") }),
-        )}
-      >
-        <div className="flex items-center gap-2">
+    <div className={styles.wrapper}>
+      <div className={styles.header}>
+        <div className={styles.headerRow}>
           <Link
             href={`/cases/${caseId}`}
             aria-label={t("backToCase")}
-            className="text-xl p-2 text-blue-500 hover:text-blue-700"
+            className={styles.backLink}
           >
             <FaArrowLeft />
           </Link>
-          <h1 className="text-xl font-semibold">{t("thread")}</h1>
+          <h1 className={styles.title}>{t("thread")}</h1>
         </div>
-        <div className="flex gap-2 items-center">
-          <label className="bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded cursor-pointer">
+        <div className={styles.actions}>
+          <label className={styles.uploadLabel}>
             {t("uploadScan")}
             <input
               ref={fileRef}
               type="file"
               accept="image/*"
               onChange={uploadScan}
-              className="hidden"
+              className={styles.hiddenInput}
             />
           </label>
           <Link
             href={`/cases/${caseId}/thread/${encodeURIComponent(startId)}?followup=1`}
-            className="bg-blue-500 text-white px-2 py-1 rounded"
+            className={styles.followupLink}
           >
             {t("followUp")}
           </Link>
         </div>
       </div>
-      <ul className="flex flex-col gap-4">
+      <ul className={styles.list}>
         {thread.map((mail) => (
-          <li key={mail.sentAt} className="border p-2 rounded">
+          <li key={mail.sentAt} className={styles.listItem}>
             <div
               className={cx(
                 "text-sm",
@@ -142,16 +243,20 @@ export default function ClientThreadPage({
             >
               {new Date(mail.sentAt).toLocaleString()} - To: {mail.to}
             </div>
-            <div className="font-semibold">{mail.subject}</div>
-            <pre className="whitespace-pre-wrap text-sm">{mail.body}</pre>
+            <div className={css({ fontWeight: "semibold" })}>
+              {mail.subject}
+            </div>
+            <pre className={styles.preBody}>{mail.body}</pre>
             {mail.snailMailStatus ? (
-              <div className="text-sm">
+              <div className={css({ fontSize: "sm" })}>
                 <SnailMailStatusIcon status={mail.snailMailStatus} />
               </div>
             ) : null}
             {mail.attachments && mail.attachments.length > 0 ? (
-              <ul className="mt-2 flex flex-col gap-1">
-                <li className="font-semibold">{t("attachments")}</li>
+              <ul className={styles.attachmentsList}>
+                <li className={css({ fontWeight: "semibold" })}>
+                  {t("attachments")}
+                </li>
                 {mail.attachments.map((att) => {
                   const ext = att.toLowerCase().split(".").pop() ?? "";
                   const isImage = [
@@ -163,12 +268,12 @@ export default function ClientThreadPage({
                   ].includes(ext);
                   const isPdf = ext === "pdf";
                   return (
-                    <li key={att} className="flex items-center gap-2">
+                    <li key={att} className={styles.attachmentItem}>
                       <a
                         href={`/uploads/${att}`}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="flex items-center gap-2 text-blue-500 underline"
+                        className={styles.attachmentLink}
                       >
                         {isImage ? (
                           <ThumbnailImage
@@ -179,9 +284,9 @@ export default function ClientThreadPage({
                             imgClassName="object-contain"
                           />
                         ) : isPdf ? (
-                          <FaFilePdf className="w-8 h-8 text-red-600" />
+                          <FaFilePdf className={styles.pdfIcon} />
                         ) : (
-                          <FaFileAlt className="w-8 h-8" />
+                          <FaFileAlt className={styles.fileIcon} />
                         )}
                         <span>{att}</span>
                       </a>
@@ -193,17 +298,17 @@ export default function ClientThreadPage({
           </li>
         ))}
         {images.map((img) => (
-          <li key={img.id} className="border p-2 rounded flex gap-2">
+          <li key={img.id} className={styles.imageItem}>
             <ThumbnailImage
               src={getThumbnailUrl(img.url, 256)}
               alt="scan"
               width={150}
               height={100}
-              className="cursor-pointer"
+              className={styles.imageThumbnail}
               imgClassName="object-contain"
               onClick={() => setViewImage(`/uploads/${img.url}`)}
             />
-            <div className="flex flex-col gap-2 flex-1">
+            <div className={styles.imageInfo}>
               <button
                 type="button"
                 onClick={() => attachEvidence(img.url)}
@@ -221,8 +326,13 @@ export default function ClientThreadPage({
               {img.ocrText ? (
                 <pre
                   className={cx(
-                    "whitespace-pre-wrap text-sm rounded",
-                    css({ bg: token("colors.surface-subtle"), p: "2" }),
+                    css({
+                      whiteSpace: "pre-wrap",
+                      fontSize: "sm",
+                      rounded: "md",
+                      bg: token("colors.surface-subtle"),
+                      p: "2",
+                    }),
                   )}
                 >
                   {img.ocrText}
@@ -233,33 +343,21 @@ export default function ClientThreadPage({
         ))}
       </ul>
       {viewImage ? (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-modal">
-          <div
-            className={cx(
-              css({ bg: token("colors.surface"), rounded: "md", shadow: "md" }),
-              "max-w-3xl w-full",
-            )}
-          >
-            <div className="relative w-full h-[80vh]">
+        <div className={styles.modal}>
+          <div className={styles.modalContent}>
+            <div className={styles.modalImageWrapper}>
               <img
                 src={viewImage}
                 alt="scan full size"
-                className="object-contain absolute inset-0 w-full h-full"
+                className={styles.modalImage}
                 loading="lazy"
               />
             </div>
-            <div className="flex justify-end p-2">
+            <div className={styles.modalClose}>
               <button
                 type="button"
                 onClick={() => setViewImage(null)}
-                className={cx(
-                  css({
-                    bg: token("colors.surface-subtle"),
-                    rounded: "md",
-                    px: "2",
-                    py: "1",
-                  }),
-                )}
+                className={styles.closeButton}
               >
                 {t("close")}
               </button>

--- a/src/app/components/AddImageMenu.tsx
+++ b/src/app/components/AddImageMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { radii } from "@/styleTokens";
 import { menuItem } from "@/components/ui/menuItem";
+import { radii } from "@/styleTokens";
 import * as Popover from "@radix-ui/react-popover";
 import Link from "next/link";
 import { type RefObject, useState } from "react";

--- a/src/app/components/MultiCaseToolbar.tsx
+++ b/src/app/components/MultiCaseToolbar.tsx
@@ -7,8 +7,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { radii } from "@/styleTokens";
 import { menuItem } from "@/components/ui/menuItem";
+import { radii } from "@/styleTokens";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
 import { css } from "styled-system/css";

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,15 +1,23 @@
 "use client";
 import { withBasePath } from "@/basePath";
+import { space } from "@/styleTokens";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
 
 export default function NotFound() {
   const { t } = useTranslation();
+  const styles = {
+    wrapper: css({ p: space.container, textAlign: "center" }),
+    title: css({ fontSize: "2xl", fontWeight: "bold", mb: "4" }),
+    message: css({ mb: "4" }),
+    link: css({ textDecorationLine: "underline" }),
+  };
   return (
-    <div className="p-8 text-center">
-      <h1 className="text-2xl font-bold mb-4">{t("notFound.title")}</h1>
-      <p className="mb-4">{t("notFound.message")}</p>
-      <Link href={withBasePath("/")} className="underline">
+    <div className={styles.wrapper}>
+      <h1 className={styles.title}>{t("notFound.title")}</h1>
+      <p className={styles.message}>{t("notFound.message")}</p>
+      <Link href={withBasePath("/")} className={styles.link}>
         {t("notFound.back")}
       </Link>
     </div>

--- a/src/app/snail-mail/SnailMailPageClient.tsx
+++ b/src/app/snail-mail/SnailMailPageClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import SnailMailStatusIcon from "@/components/SnailMailStatusIcon";
+import { space } from "@/styleTokens";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useState } from "react";
@@ -25,11 +26,27 @@ export default function SnailMailPageClient() {
   const { data: caseData } = useCase(caseId ?? "");
   const violation = caseData?.analysis?.violationType ?? null;
 
+  const styles = {
+    wrapper: css({ p: space.container }),
+    title: css({ fontSize: "xl", fontWeight: "bold", mb: "4" }),
+    controls: css({ display: "flex", gap: space.gap, mb: "4" }),
+    checkboxLabel: css({ display: "flex", alignItems: "center", gap: "1" }),
+    caseInfo: css({ mb: "4" }),
+    caseTitle: css({ fontWeight: "semibold" }),
+    table: css({
+      width: "100%",
+      borderWidth: "1px",
+      borderCollapse: "collapse",
+    }),
+    th: css({ borderWidth: "1px", px: "2", py: "1", textAlign: "left" }),
+    td: css({ borderWidth: "1px", px: "2", py: "1" }),
+    link: css({ color: "blue.500", textDecorationLine: "underline" }),
+  };
   return (
-    <div className="p-8">
-      <h1 className="text-xl font-bold mb-4">{t("nav.snailMail")}</h1>
-      <div className="flex gap-4 mb-4">
-        <label className="flex items-center gap-1">
+    <div className={styles.wrapper}>
+      <h1 className={styles.title}>{t("nav.snailMail")}</h1>
+      <div className={styles.controls}>
+        <label className={styles.checkboxLabel}>
           <input
             type="checkbox"
             checked={openOnly}
@@ -37,7 +54,7 @@ export default function SnailMailPageClient() {
           />
           {t("open")}
         </label>
-        <label className="flex items-center gap-1">
+        <label className={styles.checkboxLabel}>
           <input
             type="checkbox"
             checked={hideDelivered}
@@ -47,8 +64,8 @@ export default function SnailMailPageClient() {
         </label>
       </div>
       {caseId ? (
-        <div className="mb-4">
-          <h2 className="font-semibold">{t("caseLabel", { id: caseId })}</h2>
+        <div className={styles.caseInfo}>
+          <h2 className={styles.caseTitle}>{t("caseLabel", { id: caseId })}</h2>
           <p
             className={cx(
               "text-sm",
@@ -62,38 +79,35 @@ export default function SnailMailPageClient() {
       {mails.length === 0 ? (
         <p>{t("noSnailMail")}</p>
       ) : (
-        <table className="min-w-full border border-collapse">
+        <table className={styles.table}>
           <thead>
-            <tr className="text-left">
-              <th className="border px-2 py-1">Case</th>
-              <th className="border px-2 py-1">{t("subjectLabel")}</th>
-              <th className="border px-2 py-1">{t("status")}</th>
-              <th className="border px-2 py-1">{t("sent")}</th>
-              <th className="border px-2 py-1">{t("thread")}</th>
+            <tr className={css({ textAlign: "left" })}>
+              <th className={styles.th}>Case</th>
+              <th className={styles.th}>{t("subjectLabel")}</th>
+              <th className={styles.th}>{t("status")}</th>
+              <th className={styles.th}>{t("sent")}</th>
+              <th className={styles.th}>{t("thread")}</th>
             </tr>
           </thead>
           <tbody>
             {mails.map((m) => (
               <tr key={`${m.caseId}-${m.sentAt}`}>
-                <td className="border px-2 py-1">
-                  <Link
-                    href={`/cases/${m.caseId}`}
-                    className="text-blue-500 underline"
-                  >
+                <td className={styles.td}>
+                  <Link href={`/cases/${m.caseId}`} className={styles.link}>
                     {t("caseLabel", { id: m.caseId })}
                   </Link>
                 </td>
-                <td className="border px-2 py-1">{m.subject}</td>
-                <td className="border px-2 py-1">
+                <td className={styles.td}>{m.subject}</td>
+                <td className={styles.td}>
                   <SnailMailStatusIcon status={m.status} />
                 </td>
-                <td className="border px-2 py-1">
+                <td className={styles.td}>
                   {new Date(m.sentAt).toLocaleString()}
                 </td>
-                <td className="border px-2 py-1">
+                <td className={styles.td}>
                   <Link
                     href={`/cases/${m.caseId}/thread/${encodeURIComponent(m.sentAt)}`}
-                    className="text-blue-500 underline"
+                    className={styles.link}
                   >
                     {t("viewThread")}
                   </Link>

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -2,7 +2,9 @@
 
 import useAddFilesToCase from "@/app/useAddFilesToCase";
 import useNewCaseFromFiles from "@/app/useNewCaseFromFiles";
+import { space } from "@/styleTokens";
 import { useSearchParams } from "next/navigation";
+import { css } from "styled-system/css";
 
 export default function UploadPage() {
   const params = useSearchParams();
@@ -11,7 +13,7 @@ export default function UploadPage() {
   const newCase = useNewCaseFromFiles();
   const uploadCase = caseId ? addFiles : newCase;
   return (
-    <div className="p-8">
+    <div className={css({ p: space.container })}>
       <input
         type="file"
         accept="image/*"


### PR DESCRIPTION
## Summary
- replace Tailwind classes with Panda `css()`
- update imports to maintain sorted order

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c5865e87c832b977945f3649d2eb4