### PR TITLE
chore: enforce no eslint disable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@ This repository is a Next.js TypeScript project using Vitest and Biome.
   `pnpm install @biomejs/cli-linux-x64 @rollup/rollup-linux-x64-gnu`.
 - Run `pnpm run format` before committing to apply Biome's auto-formatting.
 - Ensure `pnpm run lint` completes with no errors or warnings.
+- `eslint-disable` comments are forbidden. Update the code to satisfy the rule
+  instead of suppressing it. When `no-explicit-any` triggers, use proper
+  generics or type definitions rather than `any`.
 - If you edited any Markdown files, run `pnpm run lint:md` to check them before completing the task.
 - Do not introduce any new TypeScript errors. If you can quickly fix an error
   without side effects, include that fix in the same task.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:jobs": "node scripts/compileJobs.mjs",
     "build": "pnpm run build:jobs && pnpm run panda && next build",
     "start": "next start",
-    "lint": "pnpm run lint:env && pnpm run lint:md && biome check .",
+    "lint": "pnpm run lint:env && pnpm run lint:md && biome check . && pnpm exec eslint .",
     "lint:md": "markdownlint '**/*.md' --ignore node_modules",
     "format": "biome format . --write",
     "pretest": "pnpm run panda",


### PR DESCRIPTION
## Summary
- run ESLint alongside Biome during lint to reject eslint-disable directives
- document that eslint-disable comments are forbidden

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686d16ae3470832b98e1a404b8c884ec