### PR TITLE
Fix remaining Tailwind styles

### DIFF
--- a/src/app/cases/CasesLayoutClient.tsx
+++ b/src/app/cases/CasesLayoutClient.tsx
@@ -2,6 +2,7 @@
 import type { Case } from "@/lib/caseStore";
 import { useParams } from "next/navigation";
 import { type ReactNode, useRef } from "react";
+import { css } from "styled-system/css";
 import ClientCasesPage from "./ClientCasesPage";
 
 export default function CasesLayoutClient({
@@ -14,17 +15,30 @@ export default function CasesLayoutClient({
   const params = useParams<{ id?: string }>();
   const hasCase = Boolean(params.id);
   const listRef = useRef<HTMLDivElement>(null);
+  const styles = {
+    container: css({
+      h: "calc(100vh - 4rem)",
+      display: { lg: "grid" },
+      gridTemplateColumns: { lg: "20% 80%" },
+    }),
+    list: (show: boolean) =>
+      css({
+        overflowY: "auto",
+        borderRightWidth: "1px",
+        display: show ? "block" : { base: "none", lg: "block" },
+      }),
+    content: (show: boolean) =>
+      css({
+        overflowY: "auto",
+        display: show ? { base: "none", lg: "block" } : "block",
+      }),
+  };
   return (
-    <div className="lg:grid lg:grid-cols-[20%_80%] h-[calc(100vh-4rem)]">
-      <div
-        ref={listRef}
-        className={`${hasCase ? "hidden lg:block" : ""} border-r overflow-y-auto`}
-      >
+    <div className={styles.container}>
+      <div ref={listRef} className={styles.list(!hasCase)}>
         <ClientCasesPage initialCases={initialCases} scrollElement={listRef} />
       </div>
-      <div className={`${hasCase ? "" : "hidden lg:block"} overflow-y-auto`}>
-        {children}
-      </div>
+      <div className={styles.content(!hasCase)}>{children}</div>
     </div>
   );
 }

--- a/src/app/cases/[id]/ChatMessages.tsx
+++ b/src/app/cases/[id]/ChatMessages.tsx
@@ -1,6 +1,7 @@
 "use client";
 import DebugWrapper from "@/app/components/DebugWrapper";
 import { useTranslation } from "react-i18next";
+import { css, cx } from "styled-system/css";
 import styles from "./CaseChat.module.css";
 import { useCaseChat } from "./CaseChatProvider";
 import TakePhotoWidget from "./camera/TakePhotoWidget";
@@ -35,17 +36,33 @@ export default function ChatMessages({ caseId }: { caseId: string }) {
         available: availableActions,
         unavailable: unavailableActions,
       }}
-      className="flex flex-col flex-1 min-h-0"
+      className={css({
+        display: "flex",
+        flexDirection: "column",
+        flex: "1",
+        minH: 0,
+      })}
     >
-      <div ref={scrollRef} className="flex-1 overflow-y-auto p-2 space-y-2">
+      <div
+        ref={scrollRef}
+        data-testid="chat-scroll"
+        className={css({
+          flex: "1",
+          overflowY: "auto",
+          p: "2",
+          display: "flex",
+          flexDirection: "column",
+          gap: "2",
+        })}
+      >
         {messages.map((m) => (
           <div
             key={m.id}
-            className={
-              m.role === "user"
-                ? "flex flex-col items-end"
-                : "flex flex-col items-start"
-            }
+            className={css({
+              display: "flex",
+              flexDirection: "column",
+              alignItems: m.role === "user" ? "flex-end" : "flex-start",
+            })}
           >
             <span
               className={`${styles.bubble} ${m.role === "user" ? styles.user : styles.assistant}`}
@@ -78,19 +95,21 @@ export default function ChatMessages({ caseId }: { caseId: string }) {
           </div>
         ))}
         {loading && (
-          <div className="text-left" key="typing">
+          <div className={css({ textAlign: "left" })} key="typing">
             <span
               className={`${styles.bubble} ${styles.assistant} ${styles.typing}`}
             />
           </div>
         )}
         {draftLoading && (
-          <div className="text-left" key="draft-loading">
-            <span className="text-sm">{t("draftingEmail")}</span>
+          <div className={css({ textAlign: "left" })} key="draft-loading">
+            <span className={css({ fontSize: "sm" })}>
+              {t("draftingEmail")}
+            </span>
           </div>
         )}
         {chatError && (
-          <div className="text-left" key="chat-error">
+          <div className={css({ textAlign: "left" })} key="chat-error">
             <span className={`${styles.bubble} ${styles.error}`}>
               {chatError}
             </span>

--- a/src/app/cases/[id]/components/CaseExtraInfo.tsx
+++ b/src/app/cases/[id]/components/CaseExtraInfo.tsx
@@ -28,7 +28,13 @@ export default function CaseExtraInfo({ caseId }: { caseId: string }) {
     ...paperworkScans,
   ];
   return (
-    <div className="grid gap-4 md:grid-cols-2">
+    <div
+      className={css({
+        display: "grid",
+        gap: "4",
+        md: { gridTemplateColumns: "repeat(2, 1fr)" },
+      })}
+    >
       {caseData.sentEmails && caseData.sentEmails.length > 0 ? (
         <div
           className={cx(

--- a/src/app/cases/__tests__/caseChatScrollButton.test.tsx
+++ b/src/app/cases/__tests__/caseChatScrollButton.test.tsx
@@ -20,7 +20,9 @@ describe("CaseChat scroll button", () => {
       <CaseChat caseId="1" />,
     );
     fireEvent.click(getByText("Chat"));
-    const scroll = container.querySelector(".overflow-y-auto") as HTMLElement;
+    const scroll = container.querySelector(
+      '[data-testid="chat-scroll"]',
+    ) as HTMLElement;
     Object.defineProperty(scroll, "scrollHeight", {
       value: 200,
       configurable: true,
@@ -42,7 +44,9 @@ describe("CaseChat scroll button", () => {
       <CaseChat caseId="1" />,
     );
     fireEvent.click(getByText("Chat"));
-    const scroll = container.querySelector(".overflow-y-auto") as HTMLElement;
+    const scroll = container.querySelector(
+      '[data-testid="chat-scroll"]',
+    ) as HTMLElement;
     Object.defineProperty(scroll, "scrollHeight", {
       value: 200,
       configurable: true,

--- a/src/app/cases/page.tsx
+++ b/src/app/cases/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import CaseSummary from "@/app/components/CaseSummary";
 import type { Case } from "@/lib/caseStore";
 import { getCase } from "@/lib/caseStore";
+import { css } from "styled-system/css";
 
 export default async function CasesPage({
   searchParams,
@@ -16,8 +17,10 @@ export default async function CasesPage({
     return <CaseSummary cases={cases} />;
   }
   return (
-    <div className="p-8">
-      <h1 className="text-xl font-bold mb-4">Cases</h1>
+    <div className={css({ p: "8" })}>
+      <h1 className={css({ fontSize: "xl", fontWeight: "bold", mb: "4" })}>
+        Cases
+      </h1>
       <p>Select a case to view details.</p>
     </div>
   );

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
 
 export default function GlobalError({
   error,
@@ -15,16 +16,24 @@ export default function GlobalError({
   }, [error]);
   const { t } = useTranslation();
   return (
-    <div className="p-8 text-center">
-      <h1 className="text-2xl font-bold mb-4">{t("error.title")}</h1>
-      <p className="mb-4">{t("error.message")}</p>
-      <div className="flex gap-4 justify-center">
-        <button type="button" onClick={reset} className="underline">
+    <div className={css({ p: "8", textAlign: "center" })}>
+      <h1 className={css({ fontSize: "2xl", fontWeight: "bold", mb: "4" })}>
+        {t("error.title")}
+      </h1>
+      <p className={css({ mb: "4" })}>{t("error.message")}</p>
+      <div
+        className={css({ display: "flex", gap: "4", justifyContent: "center" })}
+      >
+        <button
+          type="button"
+          onClick={reset}
+          className={css({ textDecoration: "underline" })}
+        >
           {t("error.retry")}
         </button>
         <Link
           href="https://github.com/antialias/photo-to-citation/issues"
-          className="underline"
+          className={css({ textDecoration: "underline" })}
         >
           {t("error.reportIssue")}
         </Link>

--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -6,6 +6,7 @@ import { Map as PigeonMap, Marker as PigeonMarker } from "pigeon-maps";
 import { osm } from "pigeon-maps/providers";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
+import { css, cx } from "styled-system/css";
 
 function MarkerIcon() {
   return (
@@ -94,12 +95,27 @@ export default function MapPageClient({ cases }: { cases: MapCase[] }) {
             width={25}
             onClick={() => router.push(`/cases/${c.id}`)}
           >
-            <div style={{ pointerEvents: "auto" }} className="group relative">
+            <div
+              style={{ pointerEvents: "auto" }}
+              className={cx(css({ position: "relative" }), "group")}
+            >
               <MarkerIcon />
-              <div className="absolute left-1/2 -translate-x-1/2 -translate-y-full hidden group-hover:block">
+              <div
+                className={css({
+                  position: "absolute",
+                  left: "50%",
+                  transform: "translateX(-50%) translateY(-100%)",
+                  display: "none",
+                  _groupHover: { display: "block" },
+                })}
+              >
                 <a
                   href={`/cases/${c.id}`}
-                  className="w-40 cursor-pointer block"
+                  className={css({
+                    width: "40",
+                    cursor: "pointer",
+                    display: "block",
+                  })}
                   onClick={(e) => {
                     e.preventDefault();
                     router.push(`/cases/${c.id}`);

--- a/src/app/system-status/SystemStatusClient.tsx
+++ b/src/app/system-status/SystemStatusClient.tsx
@@ -39,11 +39,13 @@ export default function SystemStatusClient() {
   const types = Array.from(new Set(jobs.map((j) => j.type)));
 
   return (
-    <div className="p-8">
-      <h1 className="text-xl font-bold mb-4">{t("nav.systemStatus")}</h1>
+    <div className={css({ p: "8" })}>
+      <h1 className={css({ fontSize: "xl", fontWeight: "bold", mb: "4" })}>
+        {t("nav.systemStatus")}
+      </h1>
       <p
         className={cx(
-          "mb-2 text-sm",
+          css({ mb: "2", fontSize: "sm" }),
           css({ color: token("colors.text-muted") }),
         )}
       >
@@ -53,12 +55,12 @@ export default function SystemStatusClient() {
         {t("lastUpdate")}{" "}
         {updatedAt ? new Date(updatedAt).toLocaleString() : "n/a"}
       </p>
-      <label className="block mb-4">
-        <span className="mr-2">{t("jobType")}</span>
+      <label className={css({ display: "block", mb: "4" })}>
+        <span className={css({ mr: "2" })}>{t("jobType")}</span>
         <select
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
-          className="border p-1"
+          className={css({ borderWidth: "1px", p: "1" })}
         >
           <option value="">{t("all")}</option>
           {types.map((t) => (
@@ -71,14 +73,16 @@ export default function SystemStatusClient() {
       {jobs.length === 0 ? (
         <p>{t("noActiveJobs")}</p>
       ) : (
-        <ul className="grid gap-2">
+        <ul className={css({ display: "grid", gap: "2" })}>
           {jobs.map((j) => (
-            <li key={j.id} className="border p-2">
-              <span className="font-mono mr-2">{j.type}</span>
+            <li key={j.id} className={css({ borderWidth: "1px", p: "2" })}>
+              <span className={css({ fontFamily: "mono", mr: "2" })}>
+                {j.type}
+              </span>
               {j.caseId ? (
                 <span
                   className={cx(
-                    "mr-2",
+                    css({ mr: "2" }),
                     css({ color: token("colors.text-muted") }),
                   )}
                 >

--- a/src/app/triage/page.tsx
+++ b/src/app/triage/page.tsx
@@ -12,6 +12,8 @@ import { reportModules } from "@/lib/reportModules";
 import { getServerSession } from "next-auth/next";
 import { cookies, headers } from "next/headers";
 import Link from "next/link";
+import { css } from "styled-system/css";
+import { token } from "styled-system/tokens";
 import i18n, { initI18n } from "../../i18n.server";
 
 export const dynamic = "force-dynamic";
@@ -67,13 +69,15 @@ export default async function TriagePage() {
   }
   await initI18n(lang);
   if (!session) {
-    return <div className="p-8">{i18n.t("notLoggedIn")}</div>;
+    return <div className={css({ p: "8" })}>{i18n.t("notLoggedIn")}</div>;
   }
   const cases = getCases();
   if (cases.length === 0) {
     return (
-      <div className="p-8">
-        <h1 className="text-xl font-bold mb-4">{i18n.t("caseTriage")}</h1>
+      <div className={css({ p: "8" })}>
+        <h1 className={css({ fontSize: "xl", fontWeight: "bold", mb: "4" })}>
+          {i18n.t("caseTriage")}
+        </h1>
         <p>{i18n.t("noCasesAvailable")}</p>
       </div>
     );
@@ -84,19 +88,31 @@ export default async function TriagePage() {
     .sort((a, b) => b.severity - a.severity)
     .slice(0, 5);
   return (
-    <div className="p-8">
-      <h1 className="text-xl font-bold mb-4">{i18n.t("caseTriage")}</h1>
+    <div className={css({ p: "8" })}>
+      <h1 className={css({ fontSize: "xl", fontWeight: "bold", mb: "4" })}>
+        {i18n.t("caseTriage")}
+      </h1>
       {triage.length === 0 ? (
         <p>{i18n.t("noOpenViolations")}</p>
       ) : (
-        <ul className="grid gap-4">
+        <ul className={css({ display: "grid", gap: "4" })}>
           {triage.map(({ case: c, severity }) => (
             <li key={c.id}>
               <Link
                 href={`/cases/${c.id}`}
-                className="block border p-4 hover:bg-gray-50 dark:hover:bg-gray-800"
+                className={css({
+                  display: "block",
+                  borderWidth: "1px",
+                  p: "4",
+                  _hover: {
+                    backgroundColor: {
+                      base: token("colors.gray.50"),
+                      _dark: token("colors.gray.800"),
+                    },
+                  },
+                })}
               >
-                <p className="font-semibold">
+                <p className={css({ fontWeight: "semibold" })}>
                   {i18n.t("caseLabel", { id: c.id })}
                 </p>
                 {c.analysis?.violationType ? (
@@ -111,7 +127,7 @@ export default async function TriagePage() {
                     severity: (severity * 100).toFixed(0),
                   })}
                 </p>
-                <p className="mt-2">{nextAction(c)}</p>
+                <p className={css({ mt: "2" })}>{nextAction(c)}</p>
               </Link>
             </li>
           ))}

--- a/src/components/SnailMailStatusIcon.tsx
+++ b/src/components/SnailMailStatusIcon.tsx
@@ -6,6 +6,7 @@ import {
   FaFileAlt,
   FaMoneyBillAlt,
 } from "react-icons/fa";
+import { css, cx } from "styled-system/css";
 
 export default function SnailMailStatusIcon({
   status,
@@ -36,8 +37,13 @@ export default function SnailMailStatusIcon({
       Icon = FaClock;
   }
   return (
-    <span className={`inline-flex items-center gap-1 ${color}`}>
-      <Icon className="w-4 h-4" />
+    <span
+      className={cx(
+        css({ display: "inline-flex", alignItems: "center", gap: "1" }),
+        color,
+      )}
+    >
+      <Icon className={css({ w: "4", h: "4" })} />
       {t(
         status === "queued"
           ? "snailMailQueued"

--- a/src/components/thumbnail-image.tsx
+++ b/src/components/thumbnail-image.tsx
@@ -1,4 +1,5 @@
 import { type ImgHTMLAttributes, useEffect, useState } from "react";
+import { css, cx } from "styled-system/css";
 
 export interface ThumbnailImageProps
   extends Omit<
@@ -33,11 +34,33 @@ export default function ThumbnailImage({
   return (
     <div
       style={{ width, height }}
-      className={`relative overflow-hidden ${className ?? ""}`}
+      className={cx(
+        css({ position: "relative", overflow: "hidden" }),
+        className,
+      )}
     >
       {!ready && (
-        <div className="absolute inset-0 flex items-center justify-center bg-gray-200 dark:bg-gray-800">
-          <div className="w-6 h-6 border-2 border-gray-500 border-t-transparent rounded-full animate-spin" />
+        <div
+          className={css({
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: { base: "gray.200", _dark: "gray.800" },
+          })}
+        >
+          <div
+            className={css({
+              width: "6",
+              height: "6",
+              borderWidth: "2px",
+              borderColor: "gray.500",
+              borderTopColor: "transparent",
+              borderRadius: "full",
+              animation: "spin",
+            })}
+          />
         </div>
       )}
       {/* biome-ignore lint/a11y/useAltText: alt text provided via props */}
@@ -48,7 +71,11 @@ export default function ThumbnailImage({
         height={height}
         onLoad={() => setReady(true)}
         onError={() => setReady(false)}
-        className={`object-cover max-w-full max-h-full ${imgClassName ?? ""} ${ready ? "" : "invisible"}`}
+        className={cx(
+          css({ objectFit: "cover", maxW: "full", maxH: "full" }),
+          imgClassName,
+          !ready ? css({ visibility: "hidden" }) : undefined,
+        )}
         loading="lazy"
         {...props}
       />

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -15,6 +15,7 @@ import {
 } from "@floating-ui/react";
 import { type ReactElement, cloneElement } from "react";
 import { useState } from "react";
+import { css } from "styled-system/css";
 
 export default function Tooltip({
   label,
@@ -70,7 +71,16 @@ export default function Tooltip({
             ref={refs.setFloating}
             style={floatingStyles}
             {...getFloatingProps()}
-            className="z-tooltip rounded bg-black/80 px-2 py-1 text-xs text-white shadow"
+            className={css({
+              zIndex: "var(--z-tooltip)",
+              borderRadius: "md",
+              backgroundColor: "rgba(0,0,0,0.8)",
+              px: "2",
+              py: "1",
+              fontSize: "xs",
+              color: "white",
+              shadow: "md",
+            })}
           >
             {label}
           </div>


### PR DESCRIPTION
## Summary
- replace legacy Tailwind grid and utility classes with Panda css
- update tests to use new data attributes

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686e754e71ac832b87befbf336309029