### PR TITLE
Fix CaseChat styles after Panda migration

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5164,8 +5164,8 @@ packages:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
 
-  chromedriver@138.0.1:
-    resolution: {integrity: sha512-QS/Z1qB2OpKsPUlJjkfKmpf9lGw6ObB0dX5+dP3M0gdtbu80TUnS+EjXbtu6YkbMfr2/Qt8IfOONrawNW1GwhA==}
+  chromedriver@138.0.2:
+    resolution: {integrity: sha512-mmAtTCK0GHum+zbgcv3PYDX7tqNdTXDsd2t6WWI/Tm/Ts2xCGlc5XUcL3oxw1Dn/kmPJOurwrYJKO7vV4xkisA==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -13154,7 +13154,7 @@ snapshots:
     dependencies:
       '@axe-core/webdriverjs': 4.10.2(selenium-webdriver@4.22.0)
       axe-core: 4.10.3
-      chromedriver: 138.0.1
+      chromedriver: 138.0.2
       colors: 1.4.0
       commander: 9.5.0
       dotenv: 16.6.1
@@ -15799,9 +15799,7 @@ snapshots:
       source-map: 0.6.1
       string-length: 2.0.0
     transitivePeerDependencies:
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@jest/source-map@24.9.0':
     dependencies:
@@ -20078,7 +20076,7 @@ snapshots:
 
   chrome-trace-event@1.0.4: {}
 
-  chromedriver@138.0.1:
+  chromedriver@138.0.2:
     dependencies:
       '@testim/chrome-version': 1.1.4
       axios: 1.10.0
@@ -23705,9 +23703,7 @@ snapshots:
       pretty-format: 24.9.0
       throat: 4.1.0
     transitivePeerDependencies:
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   jest-leak-detector@24.9.0:
     dependencies:

--- a/src/app/cases/[id]/CaseChat.tsx
+++ b/src/app/cases/[id]/CaseChat.tsx
@@ -36,20 +36,41 @@ function CaseChatInner({ caseId }: { caseId: string }) {
   useVisualViewportHeight(open);
   return (
     <div
-      className={`${
+      className={cx(
+        css({ fontSize: "sm" }),
         expanded
-          ? "relative h-full"
+          ? css({ position: "relative", h: "full" })
           : open
-            ? "fixed inset-0 sm:bottom-4 sm:right-4 sm:inset-auto z-chat sm:[--case-chat-offset:1rem]"
-            : "fixed bottom-4 right-4 z-chat"
-      } text-sm`}
+            ? cx(
+                "z-chat",
+                css({
+                  position: "fixed",
+                  inset: 0,
+                  sm: { bottom: "4", right: "4", inset: "auto" },
+                }),
+              )
+            : cx("z-chat", css({ position: "fixed", bottom: "4", right: "4" })),
+      )}
+      style={
+        open && !expanded
+          ? ({ "--case-chat-offset": "1rem" } as React.CSSProperties)
+          : undefined
+      }
     >
       {open ? (
         <div
-          className={cx(
-            css({ bg: token("colors.surface"), shadow: "md", rounded: "md" }),
-            `flex flex-col${expanded ? " w-full h-full" : " w-screen sm:w-80 sm:max-h-[400px]"}`,
-          )}
+          className={css({
+            bg: token("colors.surface"),
+            shadow: "md",
+            rounded: "md",
+            display: "flex",
+            flexDirection: "column",
+            w: expanded ? "full" : "100vw",
+            h: expanded ? "full" : undefined,
+            sm: expanded
+              ? { w: "full", h: "full" }
+              : { w: "80", maxH: "400px" },
+          })}
           style={
             expanded
               ? undefined
@@ -68,7 +89,14 @@ function CaseChatInner({ caseId }: { caseId: string }) {
         <button
           type="button"
           onClick={handleOpen}
-          className="bg-blue-600 text-white px-3 py-1 rounded shadow"
+          className={css({
+            bg: "blue.600",
+            color: "white",
+            px: "3",
+            py: "1",
+            borderRadius: "md",
+            shadow: "md",
+          })}
         >
           Chat
         </button>

--- a/src/app/cases/[id]/CaseChatProvider.tsx
+++ b/src/app/cases/[id]/CaseChatProvider.tsx
@@ -20,6 +20,7 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
 import InlineTranslateButton from "../../components/InlineTranslateButton";
 import { useNotify } from "../../components/NotificationProvider";
 import useChatTranslate from "../../useChatTranslate";
@@ -573,7 +574,14 @@ export function CaseChatProvider({
                   router.push(act.href(caseId));
                 }
               }}
-              className="bg-blue-600 text-white px-2 py-1 rounded mx-1"
+              className={css({
+                bg: "blue.600",
+                color: "white",
+                px: "2",
+                py: "1",
+                borderRadius: "md",
+                mx: "1",
+              })}
             >
               {act.label}
             </button>
@@ -592,7 +600,14 @@ export function CaseChatProvider({
             key={`edit-${a.field}-${a.value}`}
             type="button"
             onClick={() => void handleEdit(a.field, a.value)}
-            className="bg-green-700 text-white px-2 py-1 rounded mx-1"
+            className={css({
+              bg: "green.700",
+              color: "white",
+              px: "2",
+              py: "1",
+              borderRadius: "md",
+              mx: "1",
+            })}
           >
             {label}
           </button>
@@ -605,7 +620,17 @@ export function CaseChatProvider({
               key={`photo-${a.photo}-${a.note}`}
               type="button"
               onClick={() => void handlePhotoNote(a.photo, a.note)}
-              className="bg-green-700 text-white px-1 py-1 rounded mx-1 flex items-center gap-1"
+              className={css({
+                bg: "green.700",
+                color: "white",
+                px: "1",
+                py: "1",
+                borderRadius: "md",
+                mx: "1",
+                display: "flex",
+                alignItems: "center",
+                gap: "1",
+              })}
             >
               <ThumbnailImage
                 src={getThumbnailUrl(url, 64)}
@@ -620,7 +645,18 @@ export function CaseChatProvider({
       }
       return null;
     });
-    return <div className="mt-1 flex flex-wrap gap-1">{buttons}</div>;
+    return (
+      <div
+        className={css({
+          mt: "1",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "1",
+        })}
+      >
+        {buttons}
+      </div>
+    );
   }
 
   function renderContent(m: Message) {

--- a/src/app/cases/[id]/ChatHeader.tsx
+++ b/src/app/cases/[id]/ChatHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useTranslation } from "react-i18next";
 import { FaCompressArrowsAlt, FaExpandArrowsAlt } from "react-icons/fa";
+import { css } from "styled-system/css";
 import { useCaseChat } from "./CaseChatProvider";
 
 export default function ChatHeader() {
@@ -16,13 +17,31 @@ export default function ChatHeader() {
   } = useCaseChat();
   const { t } = useTranslation();
   return (
-    <div className="flex items-center border-b p-2 gap-2">
-      <span className="font-semibold flex-none">{t("caseChat")}</span>
+    <div
+      className={css({
+        display: "flex",
+        alignItems: "center",
+        borderBottomWidth: "1px",
+        p: "2",
+        gap: "2",
+      })}
+    >
+      <span className={css({ fontWeight: "semibold", flex: "none" })}>
+        {t("caseChat")}
+      </span>
       <select
         aria-label={t("chatHistory")}
         value={sessionId ?? ""}
         onChange={(e) => selectSession(e.target.value)}
-        className="text-black dark:text-black text-xs flex-auto min-w-0 truncate"
+        className={css({
+          color: "black",
+          fontSize: "xs",
+          flex: "auto",
+          minW: 0,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        })}
       >
         <option value="new">{t("newChat")}</option>
         {!history.some((h) => h.id === sessionId) && sessionId && (
@@ -41,7 +60,12 @@ export default function ChatHeader() {
         type="button"
         onClick={toggleExpanded}
         aria-label={expanded ? t("collapseChat") : t("expandChat")}
-        className="text-xl leading-none flex-none hidden sm:block"
+        className={css({
+          fontSize: "xl",
+          lineHeight: "none",
+          flex: "none",
+          display: { base: "none", sm: "block" },
+        })}
       >
         {expanded ? <FaCompressArrowsAlt /> : <FaExpandArrowsAlt />}
       </button>
@@ -49,7 +73,7 @@ export default function ChatHeader() {
         type="button"
         onClick={handleClose}
         aria-label={t("closeChat")}
-        className="text-xl leading-none flex-none"
+        className={css({ fontSize: "xl", lineHeight: "none", flex: "none" })}
       >
         ×
       </button>

--- a/src/app/cases/[id]/ChatInput.tsx
+++ b/src/app/cases/[id]/ChatInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useTranslation } from "react-i18next";
-import { css, cx } from "styled-system/css";
+import { css } from "styled-system/css";
 import { token } from "styled-system/tokens";
 import { useCaseChat } from "./CaseChatProvider";
 
@@ -10,19 +10,30 @@ export default function ChatInput() {
   const { t } = useTranslation();
   return (
     <div
-      className="border-t p-2 flex flex-col gap-2"
+      className={css({
+        borderTopWidth: "1px",
+        p: "2",
+        display: "flex",
+        flexDirection: "column",
+        gap: "2",
+      })}
       style={{ paddingBottom: "calc(env(safe-area-inset-bottom,0) + 0.5rem)" }}
     >
       {showJump ? (
         <button
           type="button"
           onClick={scrollToBottom}
-          className="self-start text-blue-600 underline text-xs"
+          className={css({
+            alignSelf: "flex-start",
+            color: "blue.600",
+            textDecoration: "underline",
+            fontSize: "xs",
+          })}
         >
           {t("jumpToLatest")}
         </button>
       ) : null}
-      <div className="flex gap-2">
+      <div className={css({ display: "flex", gap: "2" })}>
         <input
           ref={inputRef}
           type="text"
@@ -34,17 +45,27 @@ export default function ChatInput() {
               void send();
             }
           }}
-          className={cx(
-            "flex-1 border rounded px-1 text-base",
-            css({ bg: token("colors.surface-subtle") }),
-          )}
+          className={css({
+            flex: "1",
+            borderWidth: "1px",
+            borderRadius: "md",
+            px: "1",
+            fontSize: "base",
+            bg: token("colors.surface-subtle"),
+          })}
           placeholder={t("askQuestion")}
         />
         <button
           type="button"
           onClick={send}
           disabled={loading}
-          className="bg-blue-600 text-white px-2 rounded disabled:opacity-50"
+          className={css({
+            bg: "blue.600",
+            color: "white",
+            px: "2",
+            borderRadius: "md",
+            _disabled: { opacity: 0.5 },
+          })}
         >
           {t("send")}
         </button>


### PR DESCRIPTION
## Summary
- migrate CaseChat components from Tailwind classes to Panda `css`
- keep lockfile up to date

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686e7dfac2e4832b92324caa226ab384