### PR TITLE
refactor: migrate notify owner editor styles to panda css

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import eslintComments from "eslint-plugin-eslint-comments";
 export default [
   {
     files: ["**/*.{js,ts,tsx,jsx}"],
+    ignores: ["styled-system/**"],
     languageOptions: {
       parser: tsParser,
     },

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerEditor.tsx
@@ -154,20 +154,18 @@ export default function NotifyOwnerEditor({
     <div className={styles.wrapper}>
       <h1 className={styles.title}>{t("ownerNotification")}</h1>
       <p>{t("photosAttachedAuto")}</p>
-      <div className="flex flex-col gap-2">
+      <div className={styles.list}>
         {contactInfo.email &&
           (disabledMethods.includes("email") ? (
-            <div className="flex items-center gap-2">
-              <span className="text-green-700">{t("sent")}</span>
+            <div className={styles.sentRow}>
+              <span className={styles.sentText}>{t("sent")}</span>
               <span>Email: {contactInfo.email}</span>
               {results.email?.status === "error" && (
-                <span className="text-red-600 text-sm">
-                  {results.email.error}
-                </span>
+                <span className={styles.errorText}>{results.email.error}</span>
               )}
             </div>
           ) : (
-            <label className="flex items-center gap-2">
+            <label className={styles.checkboxLabel}>
               <input
                 type="checkbox"
                 checked={methods.includes("email")}
@@ -181,26 +179,22 @@ export default function NotifyOwnerEditor({
               />
               <span>Email: {contactInfo.email}</span>
               {results.email?.status === "error" && (
-                <span className="text-red-600 text-sm">
-                  {results.email.error}
-                </span>
+                <span className={styles.errorText}>{results.email.error}</span>
               )}
             </label>
           ))}
         {contactInfo.phone && (
           <>
             {disabledMethods.includes("sms") ? (
-              <div className="flex items-center gap-2">
-                <span className="text-green-700">{t("sent")}</span>
+              <div className={styles.sentRow}>
+                <span className={styles.sentText}>{t("sent")}</span>
                 <span>SMS: {contactInfo.phone}</span>
                 {results.sms?.status === "error" && (
-                  <span className="text-red-600 text-sm">
-                    {results.sms.error}
-                  </span>
+                  <span className={styles.errorText}>{results.sms.error}</span>
                 )}
               </div>
             ) : (
-              <label className="flex items-center gap-2">
+              <label className={styles.checkboxLabel}>
                 <input
                   type="checkbox"
                   checked={methods.includes("sms")}
@@ -214,24 +208,22 @@ export default function NotifyOwnerEditor({
                 />
                 <span>SMS: {contactInfo.phone}</span>
                 {results.sms?.status === "error" && (
-                  <span className="text-red-600 text-sm">
-                    {results.sms.error}
-                  </span>
+                  <span className={styles.errorText}>{results.sms.error}</span>
                 )}
               </label>
             )}
             {disabledMethods.includes("whatsapp") ? (
-              <div className="flex items-center gap-2">
-                <span className="text-green-700">{t("sent")}</span>
+              <div className={styles.sentRow}>
+                <span className={styles.sentText}>{t("sent")}</span>
                 <span>WhatsApp: {contactInfo.phone}</span>
                 {results.whatsapp?.status === "error" && (
-                  <span className="text-red-600 text-sm">
+                  <span className={styles.errorText}>
                     {results.whatsapp.error}
                   </span>
                 )}
               </div>
             ) : (
-              <label className="flex items-center gap-2">
+              <label className={styles.checkboxLabel}>
                 <input
                   type="checkbox"
                   checked={methods.includes("whatsapp")}
@@ -245,24 +237,24 @@ export default function NotifyOwnerEditor({
                 />
                 <span>WhatsApp: {contactInfo.phone}</span>
                 {results.whatsapp?.status === "error" && (
-                  <span className="text-red-600 text-sm">
+                  <span className={styles.errorText}>
                     {results.whatsapp.error}
                   </span>
                 )}
               </label>
             )}
             {disabledMethods.includes("robocall") ? (
-              <div className="flex items-center gap-2">
-                <span className="text-green-700">{t("sent")}</span>
+              <div className={styles.sentRow}>
+                <span className={styles.sentText}>{t("sent")}</span>
                 <span>Robocall: {contactInfo.phone}</span>
                 {results.robocall?.status === "error" && (
-                  <span className="text-red-600 text-sm">
+                  <span className={styles.errorText}>
                     {results.robocall.error}
                   </span>
                 )}
               </div>
             ) : (
-              <label className="flex items-center gap-2">
+              <label className={styles.checkboxLabel}>
                 <input
                   type="checkbox"
                   checked={methods.includes("robocall")}
@@ -276,7 +268,7 @@ export default function NotifyOwnerEditor({
                 />
                 <span>Robocall: {contactInfo.phone}</span>
                 {results.robocall?.status === "error" && (
-                  <span className="text-red-600 text-sm">
+                  <span className={styles.errorText}>
                     {results.robocall.error}
                   </span>
                 )}
@@ -286,17 +278,17 @@ export default function NotifyOwnerEditor({
         )}
         {contactInfo.address &&
           (disabledMethods.includes("snailMail") ? (
-            <div className="flex items-center gap-2">
-              <span className="text-green-700">{t("sent")}</span>
+            <div className={styles.sentRow}>
+              <span className={styles.sentText}>{t("sent")}</span>
               <span>Snail Mail: {contactInfo.address}</span>
               {results.snailMail?.status === "error" && (
-                <span className="text-red-600 text-sm">
+                <span className={styles.errorText}>
                   {results.snailMail.error}
                 </span>
               )}
             </div>
           ) : (
-            <label className="flex items-center gap-2">
+            <label className={styles.checkboxLabel}>
               <input
                 type="checkbox"
                 checked={methods.includes("snailMail")}
@@ -310,7 +302,7 @@ export default function NotifyOwnerEditor({
               />
               <span>Snail Mail: {contactInfo.address}</span>
               {results.snailMail?.status === "error" && (
-                <span className="text-red-600 text-sm">
+                <span className={styles.errorText}>
                   {results.snailMail.error}
                 </span>
               )}
@@ -318,17 +310,17 @@ export default function NotifyOwnerEditor({
           ))}
         {violationAddress &&
           (disabledMethods.includes("snailMailLocation") ? (
-            <div className="flex items-center gap-2">
-              <span className="text-green-700">{t("sent")}</span>
+            <div className={styles.sentRow}>
+              <span className={styles.sentText}>{t("sent")}</span>
               <span>Mail to address of violation: {violationAddress}</span>
               {results.snailMailLocation?.status === "error" && (
-                <span className="text-red-600 text-sm">
+                <span className={styles.errorText}>
                   {results.snailMailLocation.error}
                 </span>
               )}
             </div>
           ) : (
-            <label className="flex items-center gap-2">
+            <label className={styles.checkboxLabel}>
               <input
                 type="checkbox"
                 checked={methods.includes("snailMailLocation")}
@@ -344,32 +336,32 @@ export default function NotifyOwnerEditor({
               />
               <span>Mail to address of violation: {violationAddress}</span>
               {results.snailMailLocation?.status === "error" && (
-                <span className="text-red-600 text-sm">
+                <span className={styles.errorText}>
                   {results.snailMailLocation.error}
                 </span>
               )}
             </label>
           ))}
       </div>
-      <label className="flex flex-col">
+      <label className={styles.inputLabel}>
         {t("subjectLabel")}
         <input
           type="text"
           value={subject}
           onChange={(e) => setSubject(e.target.value)}
-          className="border p-1"
+          className={styles.input}
         />
       </label>
-      <label className="flex flex-col">
+      <label className={styles.inputLabel}>
         {t("bodyLabel")}
         <textarea
           value={body}
           onChange={(e) => setBody(e.target.value)}
           rows={10}
-          className="border p-1"
+          className={styles.input}
         />
       </label>
-      <div className="flex gap-2 flex-wrap">
+      <div className={styles.attachments}>
         {attachments.map((p) => (
           <ThumbnailImage
             key={p}
@@ -385,7 +377,7 @@ export default function NotifyOwnerEditor({
         type="button"
         onClick={sendNotification}
         disabled={sending}
-        className="bg-blue-500 text-white px-2 py-1 rounded disabled:opacity-50"
+        className={styles.button}
       >
         {sending ? t("sending") : t("sendNotification")}
       </button>
@@ -394,7 +386,7 @@ export default function NotifyOwnerEditor({
           href={threadUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-blue-500 underline mt-2 text-sm"
+          className={styles.link}
         >
           {t("viewThread")}
         </a>


### PR DESCRIPTION
## Summary
- switch NotifyOwnerEditor component to Panda `css()` styles
- ignore Panda's generated folder in ESLint

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686e83fd59d4832bb7ebf4e4071b3a34