### PR TITLE
feat: add server context for session and language

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -1,13 +1,10 @@
 import Home from "@/app/page";
-import { getServerSession } from "next-auth/next";
 import { headers } from "next/headers";
 import { type Mock, beforeAll, describe, expect, it, vi } from "vitest";
+import { SessionContext } from "../server-context";
 
 vi.mock("next/headers", () => ({
   headers: vi.fn(),
-}));
-vi.mock("next-auth/next", () => ({
-  getServerSession: vi.fn(),
 }));
 vi.mock("@/lib/authOptions", () => ({ authOptions: {} }));
 
@@ -23,7 +20,9 @@ describe("Home page", () => {
   });
 
   it("redirects mobile users to /point when signed in", async () => {
-    (getServerSession as Mock).mockResolvedValueOnce({ user: {} });
+    (SessionContext as unknown as { _currentValue: unknown })._currentValue = {
+      user: {},
+    };
     (headers as Mock).mockReturnValueOnce(
       Promise.resolve(
         new Headers({
@@ -42,7 +41,8 @@ describe("Home page", () => {
   });
 
   it("renders landing page when logged out", async () => {
-    (getServerSession as Mock).mockResolvedValueOnce(null);
+    (SessionContext as unknown as { _currentValue: unknown })._currentValue =
+      null;
     (headers as Mock).mockReturnValueOnce(
       Promise.resolve(
         new Headers({ "user-agent": "Mozilla/5.0 (X11; Linux x86_64)" }),

--- a/src/app/admin/__tests__/AdminPage.test.tsx
+++ b/src/app/admin/__tests__/AdminPage.test.tsx
@@ -1,10 +1,6 @@
 import AdminPage from "@/app/admin/page";
-import { getServerSession } from "next-auth/next";
 import { expect, it, vi } from "vitest";
-
-vi.mock("next-auth/next", () => ({
-  getServerSession: vi.fn(),
-}));
+import { SessionContext } from "../../server-context";
 
 vi.mock("@/lib/authOptions", () => ({
   authOptions: {},
@@ -15,11 +11,9 @@ vi.mock("@/lib/authz", () => ({
 }));
 
 it("returns 403 for non-admin", async () => {
-  (
-    getServerSession as unknown as { mockResolvedValue: (v: unknown) => void }
-  ).mockResolvedValue({
+  (SessionContext as unknown as { _currentValue: unknown })._currentValue = {
     user: { role: "user" },
-  });
+  };
   const res = (await AdminPage({
     searchParams: Promise.resolve({}),
   })) as Response;

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,11 +1,10 @@
 import { getCasbinRules, listUsers } from "@/lib/adminStore";
-import { authOptions } from "@/lib/authOptions";
 import { withAuthorization } from "@/lib/authz";
 import { log } from "@/lib/logger";
 import { space } from "@/styleTokens";
-import { getServerSession } from "next-auth/next";
 import type { ReactElement } from "react";
 import { css } from "styled-system/css";
+import { SessionContext } from "../server-context";
 import AdminDeploymentInfo from "./AdminDeploymentInfo";
 import AdminPageClient from "./AdminPageClient";
 
@@ -30,7 +29,7 @@ const handler = withAuthorization<
       searchParams?: Promise<{ tab?: string }>;
     },
   ) => {
-    const s = session ?? (await getServerSession(authOptions));
+    const s = session ?? SessionContext.read();
     log("admin page session", s?.user?.role);
     if (s?.user?.role !== "admin" && s?.user?.role !== "superadmin") {
       return new Response(null, { status: 403 });
@@ -62,7 +61,7 @@ export default async function AdminPage({
 }: {
   searchParams?: Promise<{ tab?: string }>;
 }) {
-  const session = await getServerSession(authOptions);
+  const session = SessionContext.read();
   return handler(new Request("http://localhost"), {
     params: Promise.resolve({}),
     session: session ?? undefined,

--- a/src/app/cases/[id]/draft/page.tsx
+++ b/src/app/cases/[id]/draft/page.tsx
@@ -1,10 +1,8 @@
-import { authOptions } from "@/lib/authOptions";
 import { getAuthorizedCase } from "@/lib/caseAccess";
 import { draftEmail } from "@/lib/caseReport";
 import { reportModules } from "@/lib/reportModules";
-import { getServerSession } from "next-auth/next";
-import { cookies, headers } from "next/headers";
 import { notFound } from "next/navigation";
+import { LanguageContext, SessionContext } from "../../../server-context";
 import DraftEditor from "./DraftEditor";
 
 export const dynamic = "force-dynamic";
@@ -16,25 +14,11 @@ export default async function DraftPage({
   const c = await getAuthorizedCase(id);
   if (!c) notFound();
   const reportModule = reportModules["oak-park"];
-  const session = await getServerSession(authOptions);
+  const session = SessionContext.read();
   const sender = session?.user
     ? { name: session.user.name ?? null, email: session.user.email ?? null }
     : undefined;
-  const cookieStore = await cookies();
-  let lang = cookieStore.get("language")?.value;
-  if (!lang) {
-    const headerList = await headers();
-    const accept = headerList.get("accept-language") ?? "";
-    const supported = ["en", "es", "fr"];
-    for (const part of accept.split(",")) {
-      const code = part.split(";")[0].trim().toLowerCase().split("-")[0];
-      if (supported.includes(code)) {
-        lang = code;
-        break;
-      }
-    }
-    lang = lang ?? "en";
-  }
+  const lang = LanguageContext.read();
   const email = await draftEmail(c, reportModule, sender, lang);
   return (
     <DraftEditor

--- a/src/app/cases/layout.tsx
+++ b/src/app/cases/layout.tsx
@@ -1,7 +1,6 @@
-import { authOptions } from "@/lib/authOptions";
 import { getCases } from "@/lib/caseStore";
-import { getServerSession } from "next-auth/next";
 import type { ReactNode } from "react";
+import { SessionContext } from "../server-context";
 import CasesLayoutClient from "./CasesLayoutClient";
 
 export const dynamic = "force-dynamic";
@@ -14,7 +13,7 @@ export default async function CasesLayout({
   params: Promise<{ id?: string }>;
 }) {
   await params;
-  const session = await getServerSession(authOptions);
+  const session = SessionContext.read();
   const list = getCases();
   const cases = session ? list : list.filter((c) => c.public);
   return <CasesLayoutClient initialCases={cases}>{children}</CasesLayoutClient>;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import NavBar from "./components/NavBar";
 import NotificationProvider from "./components/NotificationProvider";
 import I18nProvider from "./i18n-provider";
 import QueryProvider from "./query-provider";
+import { LanguageContext, SessionContext } from "./server-context";
 import { UnleashProvider } from "./unleash-provider";
 import "./globals.css";
 import "./panda.css";
@@ -68,18 +69,22 @@ export default async function RootLayout({
             __html: `window.PUBLIC_ENV=${JSON.stringify(publicEnv)};`,
           }}
         />
-        <QueryProvider>
-          <UnleashProvider>
-            <I18nProvider lang={storedLang}>
-              <NotificationProvider>
-                <AuthProvider session={session}>
-                  <NavBar />
-                  {children}
-                </AuthProvider>
-              </NotificationProvider>
-            </I18nProvider>
-          </UnleashProvider>
-        </QueryProvider>
+        <SessionContext.Provider value={session}>
+          <LanguageContext.Provider value={storedLang}>
+            <QueryProvider>
+              <UnleashProvider>
+                <I18nProvider lang={storedLang}>
+                  <NotificationProvider>
+                    <AuthProvider session={session}>
+                      <NavBar />
+                      {children}
+                    </AuthProvider>
+                  </NotificationProvider>
+                </I18nProvider>
+              </UnleashProvider>
+            </QueryProvider>
+          </LanguageContext.Provider>
+        </SessionContext.Provider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,14 @@
 export { dynamic } from "./cases/page";
 import { withBasePath } from "@/basePath";
-import { authOptions } from "@/lib/authOptions";
 import { log } from "@/lib/logger";
 import isMobile from "is-mobile";
-import { getServerSession } from "next-auth/next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import LoggedOutLanding from "./LoggedOutLanding";
+import { SessionContext } from "./server-context";
 
 export default async function Home() {
-  const session = await getServerSession(authOptions);
+  const session = SessionContext.read();
   log("home session", !!session);
   const ua = (await headers()).get("user-agent") ?? "";
   const isMobileBrowser = isMobile({ ua });

--- a/src/app/server-context.ts
+++ b/src/app/server-context.ts
@@ -1,0 +1,22 @@
+import type { Session } from "next-auth";
+import { createContext, use } from "react";
+
+function createServerContext<T>(defaultValue: T) {
+  const ctx = createContext<T>(defaultValue);
+  return Object.assign(ctx, {
+    read(): T {
+      try {
+        // @ts-ignore React 19 server hook
+        return use(ctx);
+      } catch {
+        return (
+          (ctx as unknown as { _currentValue?: T })._currentValue ??
+          defaultValue
+        );
+      }
+    },
+  });
+}
+
+export const SessionContext = createServerContext<Session | null>(null);
+export const LanguageContext = createServerContext<string>("en");

--- a/src/app/snail-mail/page.tsx
+++ b/src/app/snail-mail/page.tsx
@@ -1,6 +1,5 @@
-import { authOptions } from "@/lib/authOptions";
 import { withAuthorization } from "@/lib/authz";
-import { getServerSession } from "next-auth/next";
+import { SessionContext } from "../server-context";
 import SnailMailPageClient from "./SnailMailPageClient";
 
 export const dynamic = "force-dynamic";
@@ -10,7 +9,7 @@ const handler = withAuthorization({ obj: "cases" }, async () => {
 });
 
 export default async function SnailMailPage() {
-  const session = await getServerSession(authOptions);
+  const session = SessionContext.read();
   return handler(new Request("http://localhost"), {
     params: Promise.resolve({}),
     session: session ?? undefined,

--- a/src/app/system-status/__tests__/SystemStatusPage.test.tsx
+++ b/src/app/system-status/__tests__/SystemStatusPage.test.tsx
@@ -1,10 +1,6 @@
 import SystemStatusPage from "@/app/system-status/page";
-import { getServerSession } from "next-auth/next";
 import { expect, it, vi } from "vitest";
-
-vi.mock("next-auth/next", () => ({
-  getServerSession: vi.fn(),
-}));
+import { SessionContext } from "../../server-context";
 
 vi.mock("@/lib/authOptions", () => ({
   authOptions: {},
@@ -27,21 +23,17 @@ vi.mock("@/lib/authz", () => ({
 }));
 
 it("returns 403 for non-superadmin", async () => {
-  (
-    getServerSession as unknown as { mockResolvedValue: (v: unknown) => void }
-  ).mockResolvedValue({
+  (SessionContext as unknown as { _currentValue: unknown })._currentValue = {
     user: { role: "admin" },
-  });
+  };
   const res = (await SystemStatusPage()) as Response;
   expect(res.status).toBe(403);
 });
 
 it("renders for superadmin", async () => {
-  (
-    getServerSession as unknown as { mockResolvedValue: (v: unknown) => void }
-  ).mockResolvedValue({
+  (SessionContext as unknown as { _currentValue: unknown })._currentValue = {
     user: { role: "superadmin" },
-  });
+  };
   const res = await SystemStatusPage();
   expect(res).not.toBeInstanceOf(Response);
 });

--- a/src/app/system-status/page.tsx
+++ b/src/app/system-status/page.tsx
@@ -1,6 +1,5 @@
-import { authOptions } from "@/lib/authOptions";
 import { withAuthorization } from "@/lib/authz";
-import { getServerSession } from "next-auth/next";
+import { SessionContext } from "../server-context";
 import SystemStatusClient from "./SystemStatusClient";
 
 export const dynamic = "force-dynamic";
@@ -13,7 +12,7 @@ const handler = withAuthorization(
 );
 
 export default async function SystemStatusPage() {
-  const session = await getServerSession(authOptions);
+  const session = SessionContext.read();
   return handler(new Request("http://localhost"), {
     params: Promise.resolve({}),
     session: session ?? undefined,

--- a/src/app/triage/page.tsx
+++ b/src/app/triage/page.tsx
@@ -1,4 +1,3 @@
-import { authOptions } from "@/lib/authOptions";
 import type { Case } from "@/lib/caseStore";
 import { getCases } from "@/lib/caseStore";
 import {
@@ -9,12 +8,11 @@ import {
   hasCaseViolation,
 } from "@/lib/caseUtils";
 import { reportModules } from "@/lib/reportModules";
-import { getServerSession } from "next-auth/next";
-import { cookies, headers } from "next/headers";
 import Link from "next/link";
 import { css } from "styled-system/css";
 import { token } from "styled-system/tokens";
 import i18n, { initI18n } from "../../i18n.server";
+import { LanguageContext, SessionContext } from "../server-context";
 
 export const dynamic = "force-dynamic";
 
@@ -52,21 +50,8 @@ function nextAction(c: Case): string {
 }
 
 export default async function TriagePage() {
-  const session = await getServerSession(authOptions);
-  const cookieStore = await cookies();
-  let lang = cookieStore.get("language")?.value;
-  if (!lang) {
-    const accept = (await headers()).get("accept-language") ?? "";
-    const supported = ["en", "es", "fr"];
-    for (const part of accept.split(",")) {
-      const code = part.split(";")[0].trim().toLowerCase().split("-")[0];
-      if (supported.includes(code)) {
-        lang = code;
-        break;
-      }
-    }
-    lang = lang ?? "en";
-  }
+  const session = SessionContext.read();
+  const lang = LanguageContext.read();
   await initI18n(lang);
   if (!session) {
     return <div className={css({ p: "8" })}>{i18n.t("notLoggedIn")}</div>;


### PR DESCRIPTION
## Summary
- add `server-context.ts` providing `SessionContext` and `LanguageContext`
- use contexts in `layout` and server pages
- update server tests to use the new contexts

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke` *(fails: SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_686e82a041a8832bab0f41c0789e5bc3