### PR TITLE
Refactor: migrate some tailwind styles to panda

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import eslintComments from "eslint-plugin-eslint-comments";
 export default [
   {
     files: ["**/*.{js,ts,tsx,jsx}"],
+    ignores: ["styled-system/**/*"],
     languageOptions: {
       parser: tsParser,
     },

--- a/src/app/cases/[id]/camera/TakePhotoWidget.tsx
+++ b/src/app/cases/[id]/camera/TakePhotoWidget.tsx
@@ -2,6 +2,7 @@
 import useAddFilesToCase from "@/app/useAddFilesToCase";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
 import { ChatWidget, WidgetActions } from "../widgets";
 
 export default function TakePhotoWidget({
@@ -79,27 +80,37 @@ export default function TakePhotoWidget({
     }, "image/jpeg");
   }
 
+  const styles = {
+    wrapper: css({ w: "48" }),
+    video: css({ w: "full", h: "32", bg: "black", rounded: "md" }),
+    canvas: css({ display: "none" }),
+    error: css({ color: "red.200", textAlign: "center" }),
+    primary: css({
+      bg: "blue.800",
+      color: "white",
+      px: "1",
+      rounded: "md",
+      _disabled: { opacity: "50%" },
+    }),
+    secondary: css({ bg: "gray.200", color: "black", px: "1", rounded: "md" }),
+  };
   return (
-    <ChatWidget className="w-48">
-      <video ref={videoRef} className="w-full h-32 bg-black rounded">
+    <ChatWidget className={styles.wrapper}>
+      <video ref={videoRef} className={styles.video}>
         <track kind="captions" label="" />
       </video>
-      <canvas ref={canvasRef} className="hidden" />
-      {error && <div className="text-red-200 text-center">{error}</div>}
+      <canvas ref={canvasRef} className={styles.canvas} />
+      {error && <div className={styles.error}>{error}</div>}
       <WidgetActions centered>
         <button
           type="button"
           onClick={takePicture}
           disabled={uploading}
-          className="bg-blue-800 text-white px-1 rounded disabled:opacity-50"
+          className={styles.primary}
         >
           {uploading ? t("uploading") : t("takePicture")}
         </button>
-        <button
-          type="button"
-          onClick={onClose}
-          className="bg-gray-200 text-black px-1 rounded"
-        >
+        <button type="button" onClick={onClose} className={styles.secondary}>
           {t("close")}
         </button>
       </WidgetActions>

--- a/src/app/cases/[id]/components/PublicViewBanner.tsx
+++ b/src/app/cases/[id]/components/PublicViewBanner.tsx
@@ -2,6 +2,7 @@
 import { useSession } from "@/app/useSession";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
+import { css, cx } from "styled-system/css";
 import { useCaseContext } from "../CaseContext";
 
 export default function PublicViewBanner({
@@ -18,12 +19,23 @@ export default function PublicViewBanner({
   const { t } = useTranslation();
   const isMember = members.some((m) => m.userId === session?.user?.id);
   if (!show || !isMember) return null;
+  const styles = {
+    wrapper: css({
+      bg: "blue.100",
+      borderWidth: "1px",
+      borderColor: "blue.300",
+      color: "blue.800",
+      p: "2",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+    }),
+    link: css({ textDecorationLine: "underline" }),
+  };
   return (
-    <div
-      className={`bg-blue-100 border border-blue-300 text-blue-800 p-2 flex items-center justify-between ${className ?? ""}`}
-    >
+    <div className={cx(styles.wrapper, className)}>
       <span>{t("publicViewBanner.message")}</span>
-      <Link href={`/cases/${caseId}`} className="underline">
+      <Link href={`/cases/${caseId}`} className={styles.link}>
         {t("publicViewBanner.link")}
       </Link>
     </div>

--- a/src/app/cases/[id]/notify-owner/NotifyOwnerModal.tsx
+++ b/src/app/cases/[id]/notify-owner/NotifyOwnerModal.tsx
@@ -56,8 +56,25 @@ export default function NotifyOwnerModal({
   return (
     <Dialog.Root open onOpenChange={(o) => !o && onClose()}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-modal" />
-        <Dialog.Content className="fixed inset-0 flex items-center justify-center p-4 z-modal">
+        <Dialog.Overlay
+          className={css({
+            position: "fixed",
+            inset: "0",
+            bg: "overlay",
+            zIndex: "modal",
+          })}
+        />
+        <Dialog.Content
+          className={css({
+            position: "fixed",
+            inset: "0",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            p: "4",
+            zIndex: "modal",
+          })}
+        >
           <div
             className={cx(
               css({ bg: token("colors.surface"), rounded: "md", shadow: "md" }),
@@ -74,9 +91,15 @@ export default function NotifyOwnerModal({
                 availableMethods={data.availableMethods}
               />
             ) : (
-              <div className="p-8">{t("draftingEmail")}</div>
+              <div className={css({ p: "8" })}>{t("draftingEmail")}</div>
             )}
-            <div className="flex justify-end p-4">
+            <div
+              className={css({
+                display: "flex",
+                justifyContent: "flex-end",
+                p: "4",
+              })}
+            >
               <Dialog.Close asChild>
                 <button
                   type="button"

--- a/src/app/components/AnalysisInfo.tsx
+++ b/src/app/components/AnalysisInfo.tsx
@@ -2,6 +2,7 @@ import { getLocalizedText } from "@/lib/localizedText";
 import type { ViolationReport } from "@/lib/openai";
 import { US_STATES } from "@/lib/usStates";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
 import EditableText from "./EditableText";
 import InlineTranslateButton from "./InlineTranslateButton";
 
@@ -26,10 +27,26 @@ export default function AnalysisInfo({
     details,
     i18n.language,
   );
+  const styles = {
+    wrapper: css({
+      display: "flex",
+      flexDirection: "column",
+      gap: "1",
+      fontSize: "sm",
+    }),
+    innerWrapper: css({
+      pl: "4",
+      display: "flex",
+      flexDirection: "column",
+      gap: "1",
+    }),
+    plateRow: css({ display: "inline-flex", alignItems: "center", gap: "1" }),
+    bold: css({ fontWeight: "semibold" }),
+  };
   return (
-    <div className="flex flex-col gap-1 text-sm">
+    <div className={styles.wrapper}>
       <p>
-        <span className="font-semibold">Violation:</span> {violationType}
+        <span className={styles.bold}>Violation:</span> {violationType}
       </p>
       <p>
         {detailText}
@@ -42,16 +59,16 @@ export default function AnalysisInfo({
       </p>
       {location ? (
         <p>
-          <span className="font-semibold">Location clues:</span> {location}
+          <span className={styles.bold}>Location clues:</span> {location}
         </p>
       ) : null}
-      <div className="pl-4 flex flex-col gap-1">
+      <div className={styles.innerWrapper}>
         {vehicle.make ? <span>Make: {vehicle.make}</span> : null}
         {vehicle.model ? <span>Model: {vehicle.model}</span> : null}
         {vehicle.type ? <span>Type: {vehicle.type}</span> : null}
         {vehicle.color ? <span>Color: {vehicle.color}</span> : null}
         {onPlateChange || onStateChange ? (
-          <span className="inline-flex items-center gap-1">
+          <span className={styles.plateRow}>
             Plate:
             {onStateChange ? (
               <EditableText

--- a/src/app/components/CaseProgressGraph.tsx
+++ b/src/app/components/CaseProgressGraph.tsx
@@ -20,6 +20,7 @@ import {
 import dynamic from "next/dynamic";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
 
 const UPLOADED_PREVIEW_COUNT = 4;
 
@@ -528,8 +529,11 @@ export default function CaseProgressGraph({ caseData }: { caseData: Case }) {
     };
   }, [caseData]);
 
+  const styles = {
+    wrapper: css({ maxW: "full", overflowX: "auto" }),
+  };
   return (
-    <div className="max-w-full overflow-x-auto" ref={containerRef}>
+    <div className={styles.wrapper} ref={containerRef}>
       <Mermaid
         chart={chart}
         key={chart}

--- a/src/app/components/CaseSummary.tsx
+++ b/src/app/components/CaseSummary.tsx
@@ -35,15 +35,20 @@ export default function CaseSummary({ cases }: { cases: Case[] }) {
   const ids = cases.map((c) => c.id);
   const { t } = useTranslation();
 
+  const styles = {
+    wrapper: css({ display: "flex", flexDirection: "column" }),
+    inner: css({ p: "8", display: "flex", flexDirection: "column", gap: "2" }),
+    heading: css({ fontSize: "xl", fontWeight: "semibold" }),
+  };
   return (
-    <div className="flex flex-col">
+    <div className={styles.wrapper}>
       <MultiCaseToolbar
         caseIds={ids}
         disabled={actionsDisabled}
         hasOwner={hasOwnerAll}
       />
-      <div className="p-8 flex flex-col gap-2">
-        <h1 className="text-xl font-semibold">{t("caseSummary")}</h1>
+      <div className={styles.inner}>
+        <h1 className={styles.heading}>{t("caseSummary")}</h1>
         <p
           className={cx("text-sm", css({ color: token("colors.text-muted") }))}
         >

--- a/src/app/components/DebugWrapper.tsx
+++ b/src/app/components/DebugWrapper.tsx
@@ -4,6 +4,7 @@ import Tooltip from "@/components/ui/tooltip";
 import { getPublicEnv } from "@/publicEnv";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
+import { css } from "styled-system/css";
 
 function tokenize(json: string): ReactNode[] {
   const tokens: ReactNode[] = [];
@@ -60,18 +61,37 @@ export default function DebugWrapper({
   return (
     <Tooltip
       label={
-        <div className="text-xs bg-black/80 text-white p-2 rounded shadow max-w-sm max-h-60 overflow-auto relative space-y-1">
+        <div
+          className={css({
+            fontSize: "xs",
+            bg: "blackAlpha.800",
+            color: "white",
+            p: "2",
+            rounded: "md",
+            shadow: "md",
+            maxW: "sm",
+            maxH: "60",
+            overflow: "auto",
+            position: "relative",
+            display: "block",
+            "& > * + *": { mt: "1" },
+          })}
+        >
           {(availableActions?.length || unavailableActions?.length) && (
-            <div className="mb-1 space-y-1">
+            <div className={css({ mb: "1", "& > * + *": { mt: "1" } })}>
               {availableActions?.length ? (
                 <p>
-                  <span className="font-semibold">Available:</span>{" "}
+                  <span className={css({ fontWeight: "semibold" })}>
+                    Available:
+                  </span>{" "}
                   {availableActions.join(", ")}
                 </p>
               ) : null}
               {unavailableActions?.length ? (
                 <p>
-                  <span className="font-semibold">Unavailable:</span>{" "}
+                  <span className={css({ fontWeight: "semibold" })}>
+                    Unavailable:
+                  </span>{" "}
                   {unavailableActions.join(", ")}
                 </p>
               ) : null}
@@ -81,11 +101,24 @@ export default function DebugWrapper({
           <button
             type="button"
             onClick={() => navigator.clipboard.writeText(json)}
-            className="absolute top-1 right-1 underline"
+            className={css({
+              position: "absolute",
+              top: "1",
+              right: "1",
+              textDecorationLine: "underline",
+            })}
           >
             Copy
           </button>
-          <pre className="pt-4 whitespace-pre-wrap break-words">{tokens}</pre>
+          <pre
+            className={css({
+              pt: "4",
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+            })}
+          >
+            {tokens}
+          </pre>
         </div>
       }
       open={show}

--- a/src/app/components/EditableText.tsx
+++ b/src/app/components/EditableText.tsx
@@ -63,7 +63,7 @@ export default function EditableText({
               e.currentTarget.blur();
             }
           }}
-          className="border p-1 text-sm"
+          className={css({ borderWidth: "1px", p: "1", fontSize: "sm" })}
         />
         {options ? (
           <datalist id={listId}>
@@ -77,7 +77,13 @@ export default function EditableText({
   }
 
   return (
-    <span className="inline-flex items-center gap-1">
+    <span
+      className={css({
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "1",
+      })}
+    >
       <span>{value || placeholder}</span>
       <button
         type="button"

--- a/src/app/components/ImageHighlights.tsx
+++ b/src/app/components/ImageHighlights.tsx
@@ -2,6 +2,7 @@
 import { getLocalizedText } from "@/lib/localizedText";
 import type { ViolationReport } from "@/lib/openai";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
 import InlineTranslateButton from "./InlineTranslateButton";
 
 export default function ImageHighlights({
@@ -23,10 +24,19 @@ export default function ImageHighlights({
     info.context,
     i18n.language,
   );
+  const styles = {
+    wrapper: css({
+      display: "flex",
+      flexDirection: "column",
+      gap: "1",
+      fontSize: "sm",
+    }),
+    bold: css({ fontWeight: "semibold" }),
+  };
   return (
-    <div className="flex flex-col gap-1 text-sm">
+    <div className={styles.wrapper}>
       <span>
-        <span className="font-semibold">Image score:</span>{" "}
+        <span className={styles.bold}>Image score:</span>{" "}
         {info.representationScore.toFixed(2)}
       </span>
       {highlights ? (

--- a/src/app/components/InlineTranslateButton.tsx
+++ b/src/app/components/InlineTranslateButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { css } from "styled-system/css";
 import TranslateIcon from "./TranslateIcon";
 
 export default function InlineTranslateButton({
@@ -27,7 +28,11 @@ export default function InlineTranslateButton({
       type="button"
       onClick={handleClick}
       aria-label="translate"
-      className="ml-2 text-blue-500 hover:text-blue-700"
+      className={css({
+        ml: "2",
+        color: "blue.500",
+        _hover: { color: "blue.700" },
+      })}
     >
       <TranslateIcon
         lang={lang}

--- a/src/app/components/MapPreview.tsx
+++ b/src/app/components/MapPreview.tsx
@@ -1,4 +1,5 @@
 import { getPublicEnv } from "@/publicEnv";
+import { css, cx } from "styled-system/css";
 
 export default function MapPreview({
   lat,
@@ -19,15 +20,26 @@ export default function MapPreview({
   const url = key
     ? `https://maps.googleapis.com/maps/api/staticmap?center=${lat},${lon}&zoom=16&size=${width}x${height}&markers=color:red|${lat},${lon}&key=${key}`
     : `https://staticmap.openstreetmap.de/staticmap.php?center=${lat},${lon}&zoom=16&size=${width}x${height}&markers=${lat},${lon},red`;
+  const styles = {
+    wrapper: css({ position: "relative" }),
+    image: css({
+      objectFit: "cover",
+      position: "absolute",
+      inset: "0",
+      w: "full",
+      h: "full",
+    }),
+    link: css({ position: "absolute", inset: "0" }),
+  };
   return (
     <div
-      className={`relative ${className ?? ""}`}
+      className={cx(styles.wrapper, className)}
       style={{ aspectRatio: `${width} / ${height}` }}
     >
       <img
         src={url}
         alt={`Map preview at ${lat}, ${lon}`}
-        className="object-cover absolute inset-0 w-full h-full"
+        className={styles.image}
         loading="lazy"
       />
       {link ? (
@@ -35,7 +47,7 @@ export default function MapPreview({
           href={link}
           target="_blank"
           rel="noopener noreferrer"
-          className="absolute inset-0"
+          className={styles.link}
         >
           <span className="sr-only">View on map</span>
         </a>

--- a/src/app/components/SystemLanguageBanner.tsx
+++ b/src/app/components/SystemLanguageBanner.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useTranslation } from "react-i18next";
+import { css } from "styled-system/css";
 import { LANGUAGE_NAMES } from "./LanguageSwitcher";
 
 export default function SystemLanguageBanner({
@@ -13,20 +14,39 @@ export default function SystemLanguageBanner({
 }) {
   const { i18n } = useTranslation();
   const t = i18n.getFixedT(lang);
+  const styles = {
+    wrapper: css({
+      bg: "blue.100",
+      borderWidth: "1px",
+      borderColor: "blue.300",
+      color: "blue.800",
+      p: "2",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+    }),
+    actions: css({ display: "flex", alignItems: "center", gap: "2" }),
+    switchButton: css({ textDecorationLine: "underline" }),
+    dismissButton: css({ fontSize: "xl", lineHeight: "none" }),
+  };
   return (
-    <div className="bg-blue-100 border border-blue-300 text-blue-800 p-2 flex items-center justify-between">
+    <div className={styles.wrapper}>
       <span>
         {t("systemLanguagePrompt", { language: LANGUAGE_NAMES[lang] })}
       </span>
-      <div className="flex items-center gap-2">
-        <button type="button" onClick={onSwitch} className="underline">
+      <div className={styles.actions}>
+        <button
+          type="button"
+          onClick={onSwitch}
+          className={styles.switchButton}
+        >
           {t("switch")}
         </button>
         <button
           type="button"
           onClick={onDismiss}
           aria-label={t("claimBanner.dismiss")}
-          className="text-xl leading-none"
+          className={styles.dismissButton}
         >
           ×
         </button>

--- a/src/app/components/TranslateIcon.tsx
+++ b/src/app/components/TranslateIcon.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useMemo } from "react";
 import { FaArrowRight, FaSyncAlt } from "react-icons/fa";
+import { css, cx } from "styled-system/css";
 
 const FLAGS: Record<string, string> = {
   en: "\u{1F1FA}\u{1F1F8}",
@@ -19,21 +20,36 @@ export default function TranslateIcon({
 }) {
   const flag = useMemo(() => FLAGS[lang] ?? "\u{1F3F3}\u{FE0F}", [lang]);
   const ArrowIcon = error ? FaSyncAlt : FaArrowRight;
+  const styles = {
+    wrapper: css({
+      display: "inline-flex",
+      alignItems: "center",
+      fontSize: "xs",
+      position: "relative",
+    }),
+    icon: css({
+      mr: "0.5",
+      animationName: loading ? "translate-arrow" : undefined,
+    }),
+    flagWrapper: css({
+      position: "relative",
+      animationName: loading ? "translate-flag" : undefined,
+    }),
+    errorIcon: css({
+      position: "absolute",
+      inset: "0",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      color: "red.600",
+    }),
+  };
   return (
-    <span className="inline-flex items-center text-xs relative">
-      <ArrowIcon
-        className={`mr-0.5 ${loading ? "animate-translate-arrow" : ""}`}
-      />
-      <span
-        aria-label={lang}
-        className={`relative ${loading ? "animate-translate-flag" : ""}`}
-      >
+    <span className={styles.wrapper}>
+      <ArrowIcon className={styles.icon} />
+      <span aria-label={lang} className={styles.flagWrapper}>
         {flag}
-        {error ? (
-          <span className="absolute inset-0 flex items-center justify-center text-red-600">
-            ✖
-          </span>
-        ) : null}
+        {error ? <span className={styles.errorIcon}>✖</span> : null}
       </span>
     </span>
   );

--- a/src/app/ownership/IlFormDebug.stories.tsx
+++ b/src/app/ownership/IlFormDebug.stories.tsx
@@ -2,6 +2,7 @@ import type { OwnershipRequestInfo } from "@/lib/ownershipModules";
 import type { Meta, StoryObj } from "@storybook/react";
 import { PDFDocument } from "pdf-lib";
 import { useEffect, useState } from "react";
+import { css } from "styled-system/css";
 
 const pdfUrl = new URL("../../../forms/il/vsd375.pdf", import.meta.url);
 
@@ -86,7 +87,13 @@ function IlFormViewer(props: OwnershipRequestInfo) {
     void build();
   }, [props]);
   if (!url) return <div>Loading...</div>;
-  return <iframe src={url} className="w-full h-96 border" title="IL Form" />;
+  return (
+    <iframe
+      src={url}
+      className={css({ w: "full", h: "96", borderWidth: "1px" })}
+      title="IL Form"
+    />
+  );
 }
 
 const meta: Meta<typeof IlFormViewer> = {

--- a/src/app/point/page.tsx
+++ b/src/app/point/page.tsx
@@ -59,6 +59,7 @@ export default function PointAndShootPage() {
       objectFit: "cover",
       zIndex: 0,
     }),
+    canvas: css({ display: "none" }),
     uploading: css({
       position: "absolute",
       inset: 0,
@@ -247,7 +248,7 @@ export default function PointAndShootPage() {
       <video ref={videoRef} autoPlay muted playsInline className={styles.video}>
         <track kind="captions" label="" />
       </video>
-      <canvas ref={canvasRef} className="hidden" />
+      <canvas ref={canvasRef} className={styles.canvas} />
       {uploading ? (
         <div className={styles.uploading}>{t("uploadingPhoto")}</div>
       ) : null}


### PR DESCRIPTION
## Summary
- migrate various components from Tailwind CSS to Panda css utilities
- ignore generated styled-system types during linting

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_686e83fd59d4832bb7ebf4e4071b3a34