### PR TITLE
feat: scaffold in-process job queue

### DIFF
--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -1,0 +1,59 @@
+import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+
+interface Job<T> {
+  id: string;
+  data: T;
+  priority: number;
+}
+
+type Worker<T> = (data: T) => Promise<void> | void;
+
+const emitter = new EventEmitter();
+const queue: Job<unknown>[] = [];
+let worker: Worker<unknown> | undefined;
+let running = false;
+
+function processQueue(): void {
+  if (running || !worker) return;
+  const job = queue.shift();
+  if (!job) {
+    emitter.emit("idle");
+    return;
+  }
+  running = true;
+  emitter.emit("start", job.data);
+  Promise.resolve(worker(job.data))
+    .then(() => {
+      emitter.emit("done", job.data);
+    })
+    .catch((err) => {
+      emitter.emit("error", err);
+    })
+    .finally(() => {
+      running = false;
+      processQueue();
+    });
+}
+
+export function enqueue<T>(data: T, priority = 0): string {
+  const job: Job<T> = { id: randomUUID(), data, priority };
+  const idx = queue.findIndex((j) => priority > j.priority);
+  if (idx === -1) queue.push(job);
+  else queue.splice(idx, 0, job);
+  emitter.emit("enqueue", data);
+  processQueue();
+  return job.id;
+}
+
+export function registerWorker<T>(fn: Worker<T>): void {
+  worker = fn as Worker<unknown>;
+  processQueue();
+}
+
+export function on(
+  event: string,
+  listener: (...args: unknown[]) => void,
+): void {
+  emitter.on(event, listener);
+}

--- a/task-list.md
+++ b/task-list.md
@@ -1,50 +1,46 @@
 # Task List
 
-1. Scaffold an in-process job-queue module under `src/lib/queue.ts`.
-   Provide FIFO + priority behavior using an in-memory array. Expose
-   `enqueue()`, `registerWorker()` and `on(event, cb)` functions. Add a
-   Jest unit test proving enqueue/consume order.
-2. Add a persistent jobs table and startup recovery. Create a Drizzle
+1. Add a persistent jobs table and startup recovery. Create a Drizzle
    migration for jobs with columns id, caseId, photoId, type, status,
    payload, attempts, error and timestamps. On server boot, reload jobs
    where status is `queued` or `running` and re-enqueue them.
-3. Refactor analysis into per-photo jobs. Introduce an `analyzePhoto`
+2. Refactor analysis into per-photo jobs. Introduce an `analyzePhoto`
    job type. `analyzeCase` should enqueue each photo job plus a
    `summarizeCase` job that runs after all photos complete. Remove the
    old monolithic logic and keep existing tests passing.
-4. Implement an explicit case and photo state machine. Add a status
+3. Implement an explicit case and photo state machine. Add a status
    column to cases and case_photos with enum values pending → analysing
    → complete/failed/canceled. Guard API mutations with checks and add
    unit tests for transitions.
-5. Emit progress events and an SSE endpoint. The queue should emit
+4. Emit progress events and an SSE endpoint. The queue should emit
    job:start/progress/done/fail events. Add `/api/cases/[id]/events` to
    stream SSE. Create a React hook to listen and update a progress bar.
    Provide a manual demo script.
-6. Build a resilient OpenAI wrapper with Zod retry. `lib/openai.ts`
+5. Build a resilient OpenAI wrapper with Zod retry. `lib/openai.ts`
    exposes `call(model, prompt, schema)` and handles exponential
    back-off (max three attempts) and schema parse retries. Write unit
    tests simulating malformed JSON then success.
-7. Add photo add/remove flow using the new queue. POST
+6. Add photo add/remove flow using the new queue. POST
    `/api/cases/[id]/photos` enqueues a job. DELETE `/photos/[photoId]`
    cancels any pending job and updates status. Show per-photo status in
    the UI.
-8. Create an admin dashboard for queue and usage. `/admin/queue` lists
+7. Create an admin dashboard for queue and usage. `/admin/queue` lists
    active, pending and failed jobs with attempts and age. Add retry and
    cancel buttons plus a sidebar showing today's OpenAI cost (mock or
    env based).
-9. Add rate limit and cost guardrails. Middleware checks the daily job
+8. Add rate limit and cost guardrails. Middleware checks the daily job
    count per user (env DAILY_JOB_LIMIT, default 20). Exceeding the limit
    returns 429 and shows a toast. Provide an `/admin/usage` JSON endpoint
    for auditing.
-10. Expand the test suite. Integration test: create a case with three
+9. Expand the test suite. Integration test: create a case with three
     photos, assert queue length, simulate success/failure, verify SSE
     events and final DB statuses. Coverage must be at least 85% for the
     new queue code.
-11. Update Docker entrypoint and graceful shutdown. Modify
+10. Update Docker entrypoint and graceful shutdown. Modify
     `Dockerfile/start.sh` to run the Next.js server and on SIGTERM flush
     the in-memory queue back to the DB, setting jobs to queued. Verify
     with a docker stop script.
-12. Improve documentation and contributor guidelines. Update README.md,
+11. Improve documentation and contributor guidelines. Update README.md,
     Architecture.md and AGENTS.md with a queue design diagram, job
     lifecycle table, env vars (DAILY_JOB_LIMIT, etc.) and coding
     standards. Include a "First PR checklist" for agents.

--- a/test/queue.test.ts
+++ b/test/queue.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let queue: typeof import("@/lib/queue");
+
+beforeEach(async () => {
+  vi.resetModules();
+  queue = await import("@/lib/queue");
+});
+
+describe("queue", () => {
+  it("processes jobs by priority then FIFO", async () => {
+    const order: number[] = [];
+    queue.enqueue(1, 0);
+    queue.enqueue(2, 1);
+    queue.enqueue(3, 1);
+    queue.enqueue(4, 2);
+    queue.registerWorker(async (n: number) => {
+      order.push(n);
+    });
+    await new Promise((resolve) => queue.on("idle", resolve));
+    expect(order).toEqual([4, 2, 3, 1]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `src/lib/queue.ts` providing in-memory FIFO/priority queue with events
- add unit test verifying processing order
- remove first completed item from task list

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_6878488f6af0832b975fad7520b96dbc