### PR TITLE
feat: add in-memory queue module

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5164,8 +5164,8 @@ packages:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
 
-  chromedriver@138.0.2:
-    resolution: {integrity: sha512-mmAtTCK0GHum+zbgcv3PYDX7tqNdTXDsd2t6WWI/Tm/Ts2xCGlc5XUcL3oxw1Dn/kmPJOurwrYJKO7vV4xkisA==}
+  chromedriver@138.0.5:
+    resolution: {integrity: sha512-WE5O09if9TmFfIpvydt5dyhj+TNTUttvnujoRtAShQuDghulSh1HFirBnjNrAWjEoMkXn9VUw+cCYzZ597VPJQ==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -13154,7 +13154,7 @@ snapshots:
     dependencies:
       '@axe-core/webdriverjs': 4.10.2(selenium-webdriver@4.22.0)
       axe-core: 4.10.3
-      chromedriver: 138.0.2
+      chromedriver: 138.0.5
       colors: 1.4.0
       commander: 9.5.0
       dotenv: 16.6.1
@@ -20076,7 +20076,7 @@ snapshots:
 
   chrome-trace-event@1.0.4: {}
 
-  chromedriver@138.0.2:
+  chromedriver@138.0.5:
     dependencies:
       '@testim/chrome-version': 1.1.4
       axios: 1.10.0

--- a/src/lib/__tests__/queue.test.ts
+++ b/src/lib/__tests__/queue.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface TestJob {
+  name: string;
+}
+
+describe("queue", () => {
+  beforeEach(() => {
+    // Reset modules to clear queue state
+    vi.resetModules();
+  });
+
+  it("processes higher priority first and preserves FIFO", async () => {
+    const processed: string[] = [];
+    const { enqueue, registerWorker } = await import("../queue");
+
+    enqueue({ name: "low1" }, 0);
+    enqueue({ name: "high" }, 10);
+    enqueue({ name: "low2" }, 0);
+
+    registerWorker<TestJob>((job) => {
+      processed.push(job.data.name);
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(processed).toEqual(["high", "low1", "low2"]);
+  });
+});

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -1,0 +1,63 @@
+import { EventEmitter } from "node:events";
+
+export interface Job<T = unknown> {
+  id: number;
+  data: T;
+  priority: number;
+}
+
+export type Worker<T = unknown> = (job: Job<T>) => Promise<void> | void;
+
+interface QueueEvents<T> {
+  start: (job: Job<T>) => void;
+  complete: (job: Job<T>) => void;
+  error: (job: Job<T>, err: unknown) => void;
+}
+
+const emitter = new EventEmitter();
+
+const queue: Job[] = [];
+let processing = false;
+let worker: Worker | null = null;
+let nextId = 1;
+
+function sortQueue() {
+  queue.sort((a, b) => b.priority - a.priority);
+}
+
+async function processQueue() {
+  if (processing || !worker) return;
+  const job = queue.shift();
+  if (!job) return;
+  processing = true;
+  emitter.emit("start", job);
+  try {
+    await worker(job);
+    emitter.emit("complete", job);
+  } catch (err) {
+    emitter.emit("error", job, err);
+  } finally {
+    processing = false;
+    processQueue();
+  }
+}
+
+export function enqueue<T>(data: T, priority = 0): number {
+  const job: Job<T> = { id: nextId++, data, priority };
+  queue.push(job);
+  sortQueue();
+  processQueue();
+  return job.id;
+}
+
+export function registerWorker<T>(fn: Worker<T>): void {
+  worker = fn as Worker;
+  processQueue();
+}
+
+export function on<T>(
+  event: keyof QueueEvents<T>,
+  cb: (...args: unknown[]) => void,
+) {
+  emitter.on(event, cb);
+}

--- a/task-list.md
+++ b/task-list.md
@@ -1,50 +1,46 @@
 # Task List
 
-1. Scaffold an in-process job-queue module under `src/lib/queue.ts`.
-   Provide FIFO + priority behavior using an in-memory array. Expose
-   `enqueue()`, `registerWorker()` and `on(event, cb)` functions. Add a
-   Jest unit test proving enqueue/consume order.
-2. Add a persistent jobs table and startup recovery. Create a Drizzle
+1. Add a persistent jobs table and startup recovery. Create a Drizzle
    migration for jobs with columns id, caseId, photoId, type, status,
    payload, attempts, error and timestamps. On server boot, reload jobs
    where status is `queued` or `running` and re-enqueue them.
-3. Refactor analysis into per-photo jobs. Introduce an `analyzePhoto`
+2. Refactor analysis into per-photo jobs. Introduce an `analyzePhoto`
    job type. `analyzeCase` should enqueue each photo job plus a
    `summarizeCase` job that runs after all photos complete. Remove the
    old monolithic logic and keep existing tests passing.
-4. Implement an explicit case and photo state machine. Add a status
+3. Implement an explicit case and photo state machine. Add a status
    column to cases and case_photos with enum values pending → analysing
    → complete/failed/canceled. Guard API mutations with checks and add
    unit tests for transitions.
-5. Emit progress events and an SSE endpoint. The queue should emit
+4. Emit progress events and an SSE endpoint. The queue should emit
    job:start/progress/done/fail events. Add `/api/cases/[id]/events` to
    stream SSE. Create a React hook to listen and update a progress bar.
    Provide a manual demo script.
-6. Build a resilient OpenAI wrapper with Zod retry. `lib/openai.ts`
+5. Build a resilient OpenAI wrapper with Zod retry. `lib/openai.ts`
    exposes `call(model, prompt, schema)` and handles exponential
    back-off (max three attempts) and schema parse retries. Write unit
    tests simulating malformed JSON then success.
-7. Add photo add/remove flow using the new queue. POST
+6. Add photo add/remove flow using the new queue. POST
    `/api/cases/[id]/photos` enqueues a job. DELETE `/photos/[photoId]`
    cancels any pending job and updates status. Show per-photo status in
    the UI.
-8. Create an admin dashboard for queue and usage. `/admin/queue` lists
+7. Create an admin dashboard for queue and usage. `/admin/queue` lists
    active, pending and failed jobs with attempts and age. Add retry and
    cancel buttons plus a sidebar showing today's OpenAI cost (mock or
    env based).
-9. Add rate limit and cost guardrails. Middleware checks the daily job
+8. Add rate limit and cost guardrails. Middleware checks the daily job
    count per user (env DAILY_JOB_LIMIT, default 20). Exceeding the limit
    returns 429 and shows a toast. Provide an `/admin/usage` JSON endpoint
    for auditing.
-10. Expand the test suite. Integration test: create a case with three
+9. Expand the test suite. Integration test: create a case with three
     photos, assert queue length, simulate success/failure, verify SSE
     events and final DB statuses. Coverage must be at least 85% for the
     new queue code.
-11. Update Docker entrypoint and graceful shutdown. Modify
+10. Update Docker entrypoint and graceful shutdown. Modify
     `Dockerfile/start.sh` to run the Next.js server and on SIGTERM flush
     the in-memory queue back to the DB, setting jobs to queued. Verify
     with a docker stop script.
-12. Improve documentation and contributor guidelines. Update README.md,
+11. Improve documentation and contributor guidelines. Update README.md,
     Architecture.md and AGENTS.md with a queue design diagram, job
     lifecycle table, env vars (DAILY_JOB_LIMIT, etc.) and coding
     standards. Include a "First PR checklist" for agents.


### PR DESCRIPTION
## Summary
- implement priority FIFO queue with events
- add unit test verifying order
- update task list

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run e2e:smoke`


------
https://chatgpt.com/codex/tasks/task_e_688a4ba204a0832b8e9ea01c4a9abb39